### PR TITLE
Podspec for CocoaPods

### DIFF
--- a/instabug-reactnative.podspec
+++ b/instabug-reactnative.podspec
@@ -1,0 +1,16 @@
+require 'json'
+version = JSON.parse(File.read('package.json'))["version"]
+
+Pod::Spec.new do |s|
+  s.name         = "instabug-reactnative"
+  s.version      = version
+  s.summary      = "React Native wrapper for Instabug"
+  s.author       = 'Hossam Hassan && Yousef Hamza'
+  s.license      = 'MIT'
+  s.homepage     = 'https://github.com/Instabug/instabug-reactnative#readme'
+  s.source       = { :git => "https://github.com/Instabug/instabug-reactnative.git" }
+  s.source_files = 'ios/RNInstabug/*'
+  s.platform     = :ios, "8.0"
+  s.ios.vendored_frameworks = 'ios/Instabug.framework'
+  s.dependency 'React'
+end


### PR DESCRIPTION
Adds CocoaPods support for this package without forcing existing users to adopt it. 
 
Related to https://github.com/Instabug/instabug-reactnative/pull/31 but instead of relying on the CocoaPods version of Instabug it uses the vendored version in this repo. 