### PR TITLE
adding header search paths - expo detached

### DIFF
--- a/ios/RNInstabug.xcodeproj/project.pbxproj
+++ b/ios/RNInstabug.xcodeproj/project.pbxproj
@@ -266,6 +266,7 @@
 					"$(SRCROOT)/../../React/**",
 					"$(SRCROOT)/../../../node_modules/react-native/React/**",
 					"$(SRCROOT)/../react-native/React/**",
+					"$(SRCROOT)/../../../ios/Pods/Headers/Public/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -289,6 +290,7 @@
 					"$(SRCROOT)/../../React/**",
 					"$(SRCROOT)/../../../node_modules/react-native/React/**",
 					"$(SRCROOT)/../react-native/React/**",
+					"$(SRCROOT)/../../../ios/Pods/Headers/Public/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
had to add these header search paths this to get instabug to build properly for a detached expo project. Problem is outlined here: https://docs.expo.io/versions/v28.0.0/expokit/expokit#ios

Tested this with a fresh expo detached build, expo v28 and the build now works. With current package and instructions, this would happen otherwise:
![Build Error](http://cloud.nafets.io/433L1F2d1F3B/Image%202018-06-24%20at%2010.46.56%20PM.png)

Hopefully this helps others, or you can implement a better method for expo detached projects