### PR TITLE
Fix isRunningLive always returning true on device

### DIFF
--- a/ios/RNInstabug/InstabugReactBridge.m
+++ b/ios/RNInstabug/InstabugReactBridge.m
@@ -583,8 +583,9 @@ RCT_EXPORT_METHOD(isRunningLive:(RCTResponseSenderBlock)callback) {
     if (isRunningTestFlightBeta || hasEmbeddedMobileProvision)
     {
         result = NO;
+    } else {
+        result = YES;
     }
-    result = YES;
 #endif
     callback(@[[NSNumber numberWithBool:result]]);
 }


### PR DESCRIPTION
Recommend merging this quickly. The isRunningLive feature is effectively broken for the RN -> iOS integration. It will always return true.