### PR TITLE
Android crashes when calling setInvocationEvent() from Javascript

### DIFF
--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
@@ -807,12 +807,17 @@ public class RNInstabugReactnativeModule extends ReactContextBaseJavaModule {
      * @see InstabugInvocationEvent
      */
     @ReactMethod
-    public void setInvocationEvent(String invocationEventValue) {
-        try {
-            BugReporting.setInvocationEvents(getInvocationEventById(invocationEventValue));
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+    public void setInvocationEvent(final String invocationEventValue) {
+        new Handler(Looper.getMainLooper()).post(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    BugReporting.setInvocationEvents(getInvocationEventById(invocationEventValue));
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
When calling `setInvocationEvent()` in javascript, this message gets sent across the bridge on a non-ui thread. The native instabug internal Android code eventually touches the UI view hierarchy, which cannot be touched by a non-UI thread... 

This PR simply executes this internal method on the UI thread. 