### PR TITLE
Don't mix import and module.exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -957,4 +957,4 @@ InstabugModule.Chats = Chats;
 InstabugModule.Replies = Replies;
 InstabugModule.CrashReporting = CrashReporting;
 
-module.exports = InstabugModule;
+export default InstabugModule;

--- a/modules/BugReporting.js
+++ b/modules/BugReporting.js
@@ -10,7 +10,7 @@ let { Instabug } = NativeModules;
  * BugReporting
  * @exports BugReporting
  */
-module.exports = {
+export default {
   /**
    * Enables and disables manual invocation and prompt options for bug and feedback.
    * @param {boolean} isEnabled

--- a/modules/Chats.js
+++ b/modules/Chats.js
@@ -7,7 +7,7 @@ import {
  * Chats
  * @exports Chats
  */
-module.exports = {
+export default {
     /**
      * Enables and disables everything related to creating new chats.
      * @param {boolean} isEnabled 

--- a/modules/CrashReporting.js
+++ b/modules/CrashReporting.js
@@ -6,7 +6,7 @@ let { Instabug } = NativeModules;
  * CrashReporting
  * @exports CrashReporting
  */
-module.exports = {
+export default {
   /**
    * Enables and disables everything related to crash reporting including intercepting
    * errors in the global error handler. It is enabled by default.

--- a/modules/FeatureRequests.js
+++ b/modules/FeatureRequests.js
@@ -5,7 +5,7 @@ let {Instabug} = NativeModules;
  * FeatureRequests
  * @exports FeatureRequests
  */
-module.exports = {
+export default {
 
    /**
      * Sets whether users are required to enter an email address or not when

--- a/modules/Replies.js
+++ b/modules/Replies.js
@@ -6,7 +6,7 @@ let { Instabug } = NativeModules;
  * Replies
  * @exports Replies
  */
-module.exports = {
+export default {
   /**
    * Enables and disables everything related to receiving replies.
    * @param {boolean} isEnabled

--- a/modules/Surveys.js
+++ b/modules/Surveys.js
@@ -10,7 +10,7 @@ let { Instabug } = NativeModules;
  * Surveys
  * @exports Surveys
  */
-module.exports = {
+export default {
   /**
    * @summary Sets whether surveys are enabled or not.
    * If you disable surveys on the SDK but still have active surveys on your Instabug dashboard,

--- a/utils/InstabugUtils.js
+++ b/utils/InstabugUtils.js
@@ -42,7 +42,7 @@ let init = () => {
     global.ErrorUtils.setGlobalHandler(errorHandler);
 };
 
-module.exports = {
+export default {
     parseErrorStack: parseErrorStack,
     captureJsErrors: init
 };


### PR DESCRIPTION
Webpack disallows accessing `module.exports` from within es6 files, e.g.
where `import` is used. This assignment results in:
"Attempted to assign to readonly property"
https://github.com/webpack/webpack/issues/3491