### PR TITLE
Restore ability to destructure the library on import

### DIFF
--- a/index.js
+++ b/index.js
@@ -950,6 +950,15 @@ const InstabugModule = {
   }
 };
 
+export {
+  BugReporting,
+  Surveys,
+  FeatureRequests,
+  Chats,
+  Replies,
+  CrashReporting
+};
+
 InstabugModule.BugReporting = BugReporting;
 InstabugModule.Surveys = Surveys;
 InstabugModule.FeatureRequests = FeatureRequests;


### PR DESCRIPTION
Note only BugReporting, Surveys, FeatureRequests, Chats, Replies,
and CrashReporting are destructurable.

I broke destructuring in #257 due to an incorrect understanding of how default exports work.
https://github.com/Instabug/Instabug-React-Native/pull/257#issuecomment-475310926