### PR TITLE
Restore ability to destructure InstabugUtils

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ import {
   processColor
 } from 'react-native';
 let { Instabug } = NativeModules;
-import InstabugUtils from './utils/InstabugUtils';
+import { parseErrorStack, captureJsErrors } from './utils/InstabugUtils';
 import BugReporting from './modules/BugReporting';
 import Surveys from './modules/Surveys';
 import FeatureRequests from './modules/FeatureRequests';
@@ -14,7 +14,7 @@ import Chats from './modules/Chats';
 import Replies from './modules/Replies';
 import CrashReporting from './modules/CrashReporting';
 
-InstabugUtils.captureJsErrors();
+captureJsErrors();
 
 /**
  * Instabug
@@ -609,7 +609,7 @@ const InstabugModule = {
    */
 
   reportJSException: function(errorObject) {
-    let jsStackTrace = InstabugUtils.parseErrorStack(errorObject);
+    let jsStackTrace = parseErrorStack(errorObject);
     var jsonObject = {
       message: errorObject.name + ' - ' + errorObject.message,
       os: Platform.OS,

--- a/modules/CrashReporting.js
+++ b/modules/CrashReporting.js
@@ -1,5 +1,5 @@
 import { NativeModules, Platform } from 'react-native';
-import InstabugUtils from '../utils/InstabugUtils';
+import { parseErrorStack } from '../utils/InstabugUtils';
 let { Instabug } = NativeModules;
 
 /**
@@ -22,7 +22,7 @@ export default {
    * @param errorObject   Error object to be sent to Instabug's servers
    */
   reportJSException: function(errorObject) {
-    let jsStackTrace = InstabugUtils.parseErrorStack(errorObject);
+    let jsStackTrace = parseErrorStack(errorObject);
     var jsonObject = {
       message: errorObject.name + ' - ' + errorObject.message,
       os: Platform.OS,

--- a/utils/InstabugUtils.js
+++ b/utils/InstabugUtils.js
@@ -3,13 +3,13 @@ import {NativeModules, Platform} from 'react-native';
 let {Instabug} = NativeModules;
 import parseErrorStackLib from '../../react-native/Libraries/Core/Devtools/parseErrorStack.js';
 
-let parseErrorStack = (error) => {
+export const parseErrorStack = (error) => {
     return parseErrorStackLib(error);
 };
 
 const originalHandler = global.ErrorUtils.getGlobalHandler();
 
-let init = () => {
+export const captureJsErrors = () => {
     if (__DEV__) {
         return;
     }
@@ -43,6 +43,6 @@ let init = () => {
 };
 
 export default {
-    parseErrorStack: parseErrorStack,
-    captureJsErrors: init
+    parseErrorStack,
+    captureJsErrors
 };


### PR DESCRIPTION
And make use of that ability in the library. Sensible because Utils is
not a meaningful collection.

I broke destructuring in #257 due to an incorrect understanding of how default exports work.
https://github.com/Instabug/Instabug-React-Native/pull/257#issuecomment-475310926