### PR TITLE
Correction for Instabug dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api ('com.instabug.library:instabug:8.2.0'){
+    api ('com.instabug.library:instabug:8.2.2'){
         exclude group: 'com.android.support:appcompat-v7'
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api ('com.instabug.library:instabug:8.2.2.0'){
+    api ('com.instabug.library:instabug:8.2.0'){
         exclude group: 'com.android.support:appcompat-v7'
     }
 }


### PR DESCRIPTION
Instabug dependency in build.gradle listed as 8.2.2.0. This doesn't exist in Maven so update to 8.2.2