### PR TITLE
Fix com.instabug.library:instabug version ref

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,7 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api ('com.instabug.library:instabug:8.3.0.0'){
+    api ('com.instabug.library:instabug:8.3.0'){
         exclude group: 'com.android.support:appcompat-v7'
     }
 }


### PR DESCRIPTION
I have no idea how this issue passed inspection but the following change corrupted the version number to the core Android Instabug library:
https://github.com/Instabug/Instabug-React-Native/commit/5f3b96d8abddc874e6de3e83d91166c12ead78d3#diff-7ae5a9093507568eabbf35c3b0665732

This change fixes that issue.