### PR TITLE
Fix/get available surveys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v8.4.1 (2019-06-17)
+
+* Fixes Surveys.getAvailableSurveys API not returning the list of surveys on iOS.
+* Fixes typescript definition for the API Surveys.getAvailableSurveys.
+
 ## v8.4.0 (2019-06-11)
 
 * Updates native iOS and Android SDKs to version 8.4.

--- a/index.d.ts
+++ b/index.d.ts
@@ -105,7 +105,7 @@ export namespace Surveys {
     sessionCount: number,
     daysCount: number
     ): void;
-  function getAvailableSurveys(availableSurveysCallback: () => void): void;
+  function getAvailableSurveys(availableSurveysCallback: (surveys: Survey[]) => void): void;
   function setAutoShowingEnabled(autoShowingSurveysEnabled: boolean): void;
   function onShowCallback(willShowSurveyHandler: () => void): void;
   function setOnShowHandler(onShowHandler: () => void): void;
@@ -374,4 +374,8 @@ export enum strings {
   setUserAttribute(key: string, value: string);
   addFileAttachmentWithUrl(url: string, filename: string);
   addFileAttachmentWithData(data: string, filename: string);
+}
+
+interface Survey {
+  title: string
 }

--- a/ios/RNInstabug/InstabugReactBridge.m
+++ b/ios/RNInstabug/InstabugReactBridge.m
@@ -473,7 +473,12 @@ RCT_EXPORT_METHOD(setViewHierarchyEnabled:(BOOL)viewHierarchyEnabled) {
 }
 
 RCT_EXPORT_METHOD(getAvailableSurveys:(RCTResponseSenderBlock)callback) {
-    callback(@[[IBGSurveys availableSurveys]]);
+    NSArray<IBGSurvey* >* availableSurveys = [IBGSurveys availableSurveys];
+    NSMutableArray<NSDictionary*>* mappedSurveys = [[NSMutableArray alloc] init];
+    for (IBGSurvey* survey in availableSurveys) {
+        [mappedSurveys addObject:@{@"title": survey.title }];
+    }
+    callback(@[mappedSurveys]);
 }
 
 RCT_EXPORT_METHOD(logUserEventWithName:(NSString *)name) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instabug-reactnative",
-  "version": "8.4.0", 
+  "version": "8.4.1", 
   "description": "React Native plugin for integrating the Instabug SDK",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
- Fixes `Surveys.getAvailableSurveys` API not returning the list of surveys on iOS.
- Fixes wrong typescript definition for the API `Surveys.getAvailableSurveys`.