### PR TITLE
📝 fix network log request headers crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v8.4.4 (2019-07-08)
+
+* Fixes an issue that causes the sdk to crash when a network request has no headers.
+
 ## v8.4.3 (2019-07-03)
 
 * Fixes an issue that caused Android release builds to fail when building on a Windows machine.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Instabug for React Native
 
+[![CircleCI](https://circleci.com/gh/Instabug/Instabug-React-Native.svg?style=svg)](https://circleci.com/gh/Instabug/Instabug-React-Native)
 [![npm](https://img.shields.io/npm/v/instabug-reactnative.svg)](https://www.npmjs.com/package/instabug-reactnative)
 [![npm](https://img.shields.io/npm/dt/instabug-reactnative.svg)](https://www.npmjs.com/package/instabug-reactnative)
 [![npm](https://img.shields.io/npm/l/instabug-reactnative.svg)](https://github.com/Instabug/instabug-reactnative/blob/master/LICENSE)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instabug-reactnative",
-  "version": "8.4.3", 
+  "version": "8.4.4", 
   "description": "React Native plugin for integrating the Instabug SDK",
   "main": "index.js",
   "types": "index.d.ts",

--- a/utils/XhrNetworkInterceptor.js
+++ b/utils/XhrNetworkInterceptor.js
@@ -52,6 +52,10 @@ const XHRInterceptor = {
       var cloneNetwork = JSON.parse(JSON.stringify(network));
       cloneNetwork.requestBody = data ? data : '';
 
+      if (cloneNetwork.requestHeaders === '') {
+        cloneNetwork.requestHeaders = {};
+      }
+      
       if (this.addEventListener) {
         this.addEventListener(
           'readystatechange',


### PR DESCRIPTION
* Fixes an issue that causes the sdk to crash when a network request has no headers.
