### PR TITLE
Use bash instead of sh in android upload_sourcemap task. Fix search for instabug token.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,7 +40,7 @@ task upload_sourcemap(type: Exec) {
         project.logger.lifecycle('Automatic Upload of sourcemap files is currently not available on windows, please generate the sourcemapfiles and upload them to the dashboard')
     } else {
         environment "INSTABUG_APP_TOKEN", "YOUR_APP_TOKEN"
-        commandLine 'sh', './upload_sourcemap.sh'
+        commandLine 'bash', './upload_sourcemap.sh'
     }
 }
 

--- a/android/upload_sourcemap.sh
+++ b/android/upload_sourcemap.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd ..
 cd ..
 cd ..
@@ -18,9 +18,7 @@ zip ./android-sourcemap.zip ./android-sourcemap.json
 
 if [ ${INSTABUG_APP_TOKEN} == "YOUR_APP_TOKEN" ]; then
     echo "Instabug: Looking for Token..."
-    if [ ! "${INSTABUG_APP_TOKEN}" ]; then
-        INSTABUG_APP_TOKEN=$(grep -r --exclude-dir={node_modules,ios,android} 'Instabug.startWithToken(\"[0-9a-zA-Z]*\"' ./ -m 1 | grep -o '\"[0-9a-zA-Z]*\"' | cut -d "\"" -f 2)
-    fi
+    INSTABUG_APP_TOKEN=$(grep -r --exclude-dir={node_modules,ios,android} 'Instabug.startWithToken(\"[0-9a-zA-Z]*\"' ./ -m 1 | grep -o '\"[0-9a-zA-Z]*\"' | cut -d "\"" -f 2)
 
     if [ ! "${INSTABUG_APP_TOKEN}" ]; then
         INSTABUG_APP_TOKEN=$(grep -r --exclude-dir={node_modules,ios,android} "Instabug.startWithToken(\'[0-9a-zA-Z]*\'" ./ -m 1 | grep -o "\'[0-9a-zA-Z]*\'" | cut -d "\"" -f 2)

--- a/ios/upload_sourcemap.sh
+++ b/ios/upload_sourcemap.sh
@@ -17,9 +17,7 @@ zip ./ios-sourcemap.zip ./ios-sourcemap.json
 
 if [ ${INSTABUG_APP_TOKEN} == "YOUR_APP_TOKEN" ]; then
     echo "Instabug: Looking for Token..."
-    if [ ! "${INSTABUG_APP_TOKEN}" ]; then
-        INSTABUG_APP_TOKEN=$(grep -r --exclude-dir={node_modules,ios,android} 'Instabug.startWithToken(\"[0-9a-zA-Z]*\"' ./ -m 1 | grep -o '\"[0-9a-zA-Z]*\"' | cut -d "\"" -f 2)
-    fi
+    INSTABUG_APP_TOKEN=$(grep -r --exclude-dir={node_modules,ios,android} 'Instabug.startWithToken(\"[0-9a-zA-Z]*\"' ./ -m 1 | grep -o '\"[0-9a-zA-Z]*\"' | cut -d "\"" -f 2)
 
     if [ ! "${INSTABUG_APP_TOKEN}" ]; then
         INSTABUG_APP_TOKEN=$(grep -r --exclude-dir={node_modules,ios,android} "Instabug.startWithToken(\'[0-9a-zA-Z]*\'" ./ -m 1 | grep -o "\'[0-9a-zA-Z]*\'" | cut -d "\"" -f 2)


### PR DESCRIPTION
I'm not super familiar with shell scripting so feel free to correct if I'm wrong.

[[ is specific to bash so should be ran using bash instead of sh.

If INSTABUG_APP_TOKEN == "YOUR_APP_TOKEN", these next two conditionals would never run and INSTABUG_APP_TOKEN will never be found.