### PR TITLE
📝 8.5.0 bug fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,9 +131,6 @@ jobs:
           name: Install node_modules
           command: cd .. && yarn
       - run:
-          name: Remove instabug.framework
-          command: rm -rf ../node_modules/instabug-reactnative/ios/Instabug.framework
-      - run:
           name: Fetch CocoaPods Specs
           command: curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh  | bash -s cf
       - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Fixes an issue that would cause Instabug.framework to appear twice when using CocoaPods.
 * Fixes a deadlock that would happen when `console.log` is called immediately after `startWithToken`.
-* Fixes an issue in the upload sourcemap script that was preventing it from greping the token automatically
+* Fixes an issue that prevented app token from being detected correctly when uploading source map files.
 * Fixes an issue that caused Android release builds to fail when building on a Windows machine.
 
 ## v8.5.0 (2019-07-11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v8.5.1 (2019-07-22)
+
+* Fixes an issue when causing duplicate framework when using cocoapods
+* Fixes an issue in the upload sourcemap script that was preventing it from greping the token automatically
+* Fixes an issue that caused Android release builds to fail when building on a Windows machine.
+
 ## v8.5.0 (2019-07-11)
 
 **⚠️ If you are using React Native 0.60, please follow our migration guide [here](https://github.com/Instabug/Instabug-React-Native/blob/master/README.md#updating-to-version-85)**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v8.5.1 (2019-07-22)
 
 * Fixes an issue when causing duplicate framework when using cocoapods
+* Fixes an issue that cause a deadlock when calling `concole.log` many times after `Instabug.startWithToken`
 * Fixes an issue in the upload sourcemap script that was preventing it from greping the token automatically
 * Fixes an issue that caused Android release builds to fail when building on a Windows machine.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v8.5.1 (2019-07-22)
 
-* Fixes an issue when causing duplicate framework when using cocoapods
+* Fixes an issue that would cause Instabug.framework to appear twice when using CocoaPods.
 * Fixes an issue that cause a deadlock when calling `concole.log` many times after `Instabug.startWithToken`
 * Fixes an issue in the upload sourcemap script that was preventing it from greping the token automatically
 * Fixes an issue that caused Android release builds to fail when building on a Windows machine.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## v8.5.1 (2019-07-22)
 
 * Fixes an issue that would cause Instabug.framework to appear twice when using CocoaPods.
-* Fixes an issue that cause a deadlock when calling `concole.log` many times after `Instabug.startWithToken`
+* Fixes a deadlock that would happen when `console.log` is called immediately after `startWithToken`.
 * Fixes an issue in the upload sourcemap script that was preventing it from greping the token automatically
 * Fixes an issue that caused Android release builds to fail when building on a Windows machine.
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 import org.apache.tools.ant.taskdefs.condition.Os
 task upload_sourcemap(type: Exec) {
     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+        commandLine 'cmd', '/c', 'echo Automatic Upload of sourcemap files is currently not available on windows, please generate the sourcemapfiles and upload them to the dashboard'
         project.logger.lifecycle('Automatic Upload of sourcemap files is currently not available on windows, please generate the sourcemapfiles and upload them to the dashboard')
     } else {
         environment "INSTABUG_APP_TOKEN", "YOUR_APP_TOKEN"

--- a/android/upload_sourcemap.sh
+++ b/android/upload_sourcemap.sh
@@ -18,6 +18,7 @@ zip ./android-sourcemap.zip ./android-sourcemap.json
 
 if [ ${INSTABUG_APP_TOKEN} == "YOUR_APP_TOKEN" ]; then
     echo "Instabug: Looking for Token..."
+    INSTABUG_APP_TOKEN='';
     if [ ! "${INSTABUG_APP_TOKEN}" ]; then
         INSTABUG_APP_TOKEN=$(grep -r --exclude-dir={node_modules,ios,android} 'Instabug.startWithToken(\"[0-9a-zA-Z]*\"' ./ -m 1 | grep -o '\"[0-9a-zA-Z]*\"' | cut -d "\"" -f 2)
     fi

--- a/autolink.rb
+++ b/autolink.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
-require 'fileutils'
+# require 'fileutils'
 
-FileUtils.rm_rf('node_modules/instabug-reactnative/ios/Instabug.framework')
+# FileUtils.rm_rf('node_modules/instabug-reactnative/ios/Instabug.framework')
 
 begin
 	require 'xcodeproj'

--- a/instabug-reactnative.podspec
+++ b/instabug-reactnative.podspec
@@ -15,5 +15,4 @@ Pod::Spec.new do |s|
   s.static_framework = true
   s.ios.vendored_frameworks = 'ios/Instabug.framework'
   s.dependency 'React'
-  s.dependency 'Instabug', '8.5.2'
 end

--- a/ios/RNInstabug/InstabugReactBridge.m
+++ b/ios/RNInstabug/InstabugReactBridge.m
@@ -50,9 +50,7 @@ RCT_EXPORT_METHOD(startWithToken:(NSString *)token invocationEvents:(NSArray*)in
     for (NSNumber *boxedValue in invocationEventsArray) {
         invocationEvents |= [boxedValue intValue];
     }
-    [[NSRunLoop mainRunLoop] performBlock:^{
-         [Instabug startWithToken:token invocationEvents:invocationEvents];
-    }];
+    [Instabug startWithToken:token invocationEvents:invocationEvents];
 
     RCTAddLogFunction(InstabugReactLogFunction);
     RCTSetLogThreshold(RCTLogLevelInfo);

--- a/ios/upload_sourcemap.sh
+++ b/ios/upload_sourcemap.sh
@@ -17,6 +17,7 @@ zip ./ios-sourcemap.zip ./ios-sourcemap.json
 
 if [ ${INSTABUG_APP_TOKEN} == "YOUR_APP_TOKEN" ]; then
     echo "Instabug: Looking for Token..."
+    INSTABUG_APP_TOKEN='';
     if [ ! "${INSTABUG_APP_TOKEN}" ]; then
         INSTABUG_APP_TOKEN=$(grep -r --exclude-dir={node_modules,ios,android} 'Instabug.startWithToken(\"[0-9a-zA-Z]*\"' ./ -m 1 | grep -o '\"[0-9a-zA-Z]*\"' | cut -d "\"" -f 2)
     fi


### PR DESCRIPTION
* Fixes an issue when causing duplicate framework when using cocoapods
* Fixes an issue that cause a deadlock when calling `concole.log` many times after `Instabug.startWithToken`
* Fixes an issue in the upload sourcemap script that was preventing it from greping the token automatically
* Fixes an issue that caused Android release builds to fail when building on a Windows machine.