### PR TITLE
🔨 refactor js code

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -156,6 +156,7 @@ describe('Instabug Module', () => {
 
   it('should call the native method didSelectPromptOptionHandler with a function', () => {
 
+    Platform.OS = 'ios';
     const callback = jest.fn()
     Instabug.setDidSelectPromptOptionHandler(callback);
 
@@ -165,6 +166,7 @@ describe('Instabug Module', () => {
 
   it('should invoke callback on emitting the event IBGDidSelectPromptOptionHandler', (done) => {
 
+    Platform.OS = 'ios';
     const payload = { promptOption: Instabug.promptOption.bug };
     const callback = (promptOption) => {
       expect(promptOption).toBe(payload.promptOption);
@@ -174,6 +176,17 @@ describe('Instabug Module', () => {
     IBGEventEmitter.emit(IBGConstants.DID_SELECT_PROMPT_OPTION_HANDLER, payload);
 
     expect(IBGEventEmitter.getListeners(IBGConstants.DID_SELECT_PROMPT_OPTION_HANDLER).length).toEqual(1);
+  });
+
+  it('should return on calling setDidSelectPromptOptionHandler when Platform is android', () => {
+
+    Platform.OS = 'android';
+
+    Instabug.setDidSelectPromptOptionHandler(jest.fn());
+    IBGEventEmitter.emit(IBGConstants.DID_SELECT_PROMPT_OPTION_HANDLER, {});
+
+    expect(didSelectPromptOptionHandler.notCalled).toBe(true);
+    expect(IBGEventEmitter.getListeners(IBGConstants.DID_SELECT_PROMPT_OPTION_HANDLER).length).toEqual(0);
   });
 
   it('should call the native method setSessionProfilerEnabled', () => {

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,9 +12,9 @@ export namespace BugReporting {
     invocationMode: invocationMode,
     invocationOptions: invocationOptions[]
     ): void;
-  function onInvokeHandler(preInvocationHandler: () => void): void;
+  function onInvokeHandler(handler: () => void): void;
   function onReportSubmitHandler(preSendingHandler: () => void): void;
-  function onSDKDismissedHandler(postInvocationHandler: (dismiss: dismissType, report: reportType) => void): void;
+  function onSDKDismissedHandler(handler: (dismiss: dismissType, report: reportType) => void): void;
   function setPromptOptionsEnabled(
     chat: boolean,
     bug: boolean,

--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 import {
   NativeModules,
-  NativeAppEventEmitter,
-  DeviceEventEmitter,
   Platform,
   findNodeHandle,
   processColor
@@ -129,23 +127,10 @@ const InstabugModule = {
    *                  gets executed when a prompt option is selected.
    */
   setDidSelectPromptOptionHandler: function(didSelectPromptOptionHandler) {
-    if (Platform.OS === 'ios') {
-      Instabug.addListener('IBGDidSelectPromptOptionHandler');
-      NativeAppEventEmitter.addListener(
-        'IBGDidSelectPromptOptionHandler',
-        function(payload) {
-          didSelectPromptOptionHandler(payload['promptOption']);
-        }
-      );
-    } else {
-      DeviceEventEmitter.addListener(
-        'IBGDidSelectPromptOptionHandler',
-        function(payload) {
-          didSelectPromptOptionHandler(payload.promptOption);
-        }
-      );
-    }
-
+    if (Platform.OS === 'android') return;
+    IBGEventEmitter.addListener(InstabugConstants.DID_SELECT_PROMPT_OPTION_HANDLER, (payload) => {
+      didSelectPromptOptionHandler(payload.promptOption);
+    });
     Instabug.didSelectPromptOptionHandler(didSelectPromptOptionHandler);
   },
 
@@ -562,20 +547,7 @@ const InstabugModule = {
    * executed when a new message is received.
    */
   setOnNewMessageHandler: function(onNewMessageHandler) {
-    if (Platform.OS === 'ios') {
-      Instabug.addListener('IBGonNewMessageHandler');
-      NativeAppEventEmitter.addListener(
-        'IBGonNewMessageHandler',
-        onNewMessageHandler
-      );
-    } else {
-      DeviceEventEmitter.addListener(
-        'IBGonNewMessageHandler',
-        onNewMessageHandler
-      );
-    }
-
-    Instabug.setOnNewMessageHandler(onNewMessageHandler);
+    Replies.setOnNewReplyReceivedHandler(onNewMessageHandler);
   },
 
   /**

--- a/modules/BugReporting.js
+++ b/modules/BugReporting.js
@@ -1,11 +1,11 @@
 import {
   NativeModules,
-  NativeAppEventEmitter,
-  DeviceEventEmitter,
   Platform
 } from 'react-native';
 let { Instabug } = NativeModules;
 import InstabugModule from '../index';
+import IBGEventEmitter from '../utils/IBGEventEmitter';
+import InstabugConstants from '../utils/InstabugConstants';
 
 /**
  * BugReporting
@@ -76,23 +76,11 @@ export default {
    * Sets a block of code to be executed just before the SDK's UI is presented.
    * This block is executed on the UI thread. Could be used for performing any
    * UI changes before the SDK's UI is shown.
-   * @param {function} preInvocationHandler - A callback that gets executed before invoking the SDK
+   * @param {function} handler - A callback that gets executed before invoking the SDK
    */
-  onInvokeHandler: function(preInvocationHandler) {
-    if (Platform.OS === 'ios') {
-      Instabug.addListener('IBGpreInvocationHandler');
-      NativeAppEventEmitter.addListener(
-        'IBGpreInvocationHandler',
-        preInvocationHandler
-      );
-    } else {
-      DeviceEventEmitter.addListener(
-        'IBGpreInvocationHandler',
-        preInvocationHandler
-      );
-    }
-
-    Instabug.setPreInvocationHandler(preInvocationHandler);
+  onInvokeHandler: function(handler) {
+    IBGEventEmitter.addListener(InstabugConstants.ON_INVOKE_HANDLER, handler);
+    Instabug.setPreInvocationHandler(handler);
   },
 
   /**
@@ -111,26 +99,14 @@ export default {
    * Sets a block of code to be executed right after the SDK's UI is dismissed.
    * This block is executed on the UI thread. Could be used for performing any
    * UI changes after the SDK's UI is dismissed.
-   * @param {function} postInvocationHandler - A callback to get executed after
+   * @param {function} handler - A callback to get executed after
    * dismissing the SDK.
    */
-  onSDKDismissedHandler: function(postInvocationHandler) {
-    if (Platform.OS === 'ios') {
-      Instabug.addListener('IBGpostInvocationHandler');
-      NativeAppEventEmitter.addListener('IBGpostInvocationHandler', function(
-        payload
-      ) {
-        postInvocationHandler(payload['dismissType'], payload['reportType']);
-      });
-    } else {
-      DeviceEventEmitter.addListener('IBGpostInvocationHandler', function(
-        payload
-      ) {
-        postInvocationHandler(payload.dismissType, payload.reportType);
-      });
-    }
-
-    Instabug.setPostInvocationHandler(postInvocationHandler);
+  onSDKDismissedHandler: function(handler) {
+    IBGEventEmitter.addListener(InstabugConstants.ON_SDK_DISMISSED_HANDLER, (payload) => {
+      handler(payload.dismissType, payload.reportType);
+    });
+    Instabug.setPostInvocationHandler(handler);
   },
 
   /**

--- a/modules/Surveys.js
+++ b/modules/Surveys.js
@@ -1,9 +1,8 @@
 import {
   NativeModules,
-  NativeAppEventEmitter,
-  DeviceEventEmitter,
-  Platform
 } from 'react-native';
+import IBGEventEmitter from '../utils/IBGEventEmitter';
+import InstabugConstants from '../utils/InstabugConstants';
 let { Instabug } = NativeModules;
 
 /**
@@ -92,19 +91,7 @@ export default {
    * presenting the survey's UI.
    */
   setOnShowHandler: function(onShowHandler) {
-    if (Platform.OS === 'ios') {
-      Instabug.addListener('IBGWillShowSurvey');
-      NativeAppEventEmitter.addListener(
-        'IBGWillShowSurvey',
-        onShowHandler
-      );
-    } else {
-      DeviceEventEmitter.addListener(
-        'IBGWillShowSurvey',
-        onShowHandler
-      );
-    }
-
+    IBGEventEmitter.addListener(InstabugConstants.WILL_SHOW_SURVEY_HANDLER, onShowHandler);
     Instabug.setWillShowSurveyHandler(onShowHandler);
   },
 
@@ -128,19 +115,7 @@ export default {
    * the survey's UI is dismissed.
    */
   setOnDismissHandler: function(onDismissHandler) {
-    if (Platform.OS === 'ios') {
-      Instabug.addListener('IBGDidDismissSurvey');
-      NativeAppEventEmitter.addListener(
-        'IBGDidDismissSurvey',
-        onDismissHandler
-      );
-    } else {
-      DeviceEventEmitter.addListener(
-        'IBGDidDismissSurvey',
-        onDismissHandler
-      );
-    }
-
+    IBGEventEmitter.addListener(InstabugConstants.DID_DISMISS_SURVEY_HANDLER, onDismissHandler);
     Instabug.setDidDismissSurveyHandler(onDismissHandler);
   },
 


### PR DESCRIPTION
- Move constants to a single shared file
- Use the class `IBGEventEmitter` to handle all JS events.