### PR TITLE
Fix/string mappings in iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Master
 
 * Fixes hang/crash issues on iOS 9 devices
+* Fixes string mappings for addVideoMessage and conversationsHeaderTitle in iOS.
 
 ## v8.5.2 (2019-08-04)
 

--- a/android/src/main/java/com/instabug/reactlibrary/ArgsRegistry.java
+++ b/android/src/main/java/com/instabug/reactlibrary/ArgsRegistry.java
@@ -183,7 +183,7 @@ final class ArgsRegistry {
         args.put("voiceMessageReleaseToAttach", InstabugCustomTextPlaceHolder.Key.VOICE_MESSAGE_RELEASE_TO_ATTACH);
         args.put("reportSuccessfullySent", InstabugCustomTextPlaceHolder.Key.REPORT_SUCCESSFULLY_SENT);
         args.put("successDialogHeader", InstabugCustomTextPlaceHolder.Key.SUCCESS_DIALOG_HEADER);
-        args.put("addVideo", InstabugCustomTextPlaceHolder.Key.ADD_VIDEO);
+        args.put("addVideoMessage", InstabugCustomTextPlaceHolder.Key.ADD_VIDEO);
         args.put("betaWelcomeMessageWelcomeStepTitle", InstabugCustomTextPlaceHolder.Key.BETA_WELCOME_MESSAGE_WELCOME_STEP_TITLE);
         args.put("betaWelcomeMessageWelcomeStepContent", InstabugCustomTextPlaceHolder.Key.BETA_WELCOME_MESSAGE_WELCOME_STEP_CONTENT);
         args.put("betaWelcomeMessageHowToReportStepTitle", InstabugCustomTextPlaceHolder.Key.BETA_WELCOME_MESSAGE_HOW_TO_REPORT_STEP_TITLE);

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
@@ -181,7 +181,7 @@ public class RNInstabugReactnativeModule extends ReactContextBaseJavaModule {
     private final String ADD_VOICE_MESSAGE = "addVoiceMessage";
     private final String ADD_IMAGE_FROM_GALLERY = "addImageFromGallery";
     private final String ADD_EXTRA_SCREENSHOT = "addExtraScreenshot";
-    private final String ADD_VIDEO = "addVideo";
+    private final String ADD_VIDEO = "addVideoMessage";
 
     private final String AUDIO_RECORDING_PERMISSION_DENIED = "audioRecordingPermissionDenied";
 

--- a/index.js
+++ b/index.js
@@ -987,6 +987,9 @@ const InstabugModule = {
     audio: Instabug.audio,
     video: Instabug.video,
     image: Instabug.image,
+    /**
+     * @deprecated use {@link Instabug.strings.conversationsHeaderTitle}
+     */
     chatsHeaderTitle: Instabug.chatsHeaderTitle,
     team: Instabug.team,
     messagesNotification: Instabug.messagesNotification,

--- a/ios/RNInstabug/InstabugReactBridge.m
+++ b/ios/RNInstabug/InstabugReactBridge.m
@@ -832,7 +832,7 @@ RCT_EXPORT_METHOD(setOnNewReplyReceivedCallback:(RCTResponseSenderBlock) callbac
               @"emailFieldHint": kIBGEmailFieldPlaceholderStringName,
               @"commentFieldHintForBugReport": kIBGCommentFieldPlaceholderForBugReportStringName,
               @"commentFieldHintForFeedback": kIBGCommentFieldPlaceholderForFeedbackStringName,
-              @"addScreenRecordingMessage": kIBGAddScreenRecordingMessageStringName,
+              @"addVideoMessage": kIBGAddScreenRecordingMessageStringName,
               @"addVoiceMessage": kIBGAddVoiceMessageStringName,
               @"addImageFromGallery": kIBGAddImageFromGalleryStringName,
               @"addExtraScreenshot": kIBGAddExtraScreenshotStringName,

--- a/ios/RNInstabug/InstabugReactBridge.m
+++ b/ios/RNInstabug/InstabugReactBridge.m
@@ -839,6 +839,7 @@ RCT_EXPORT_METHOD(setOnNewReplyReceivedCallback:(RCTResponseSenderBlock) callbac
               @"audioRecordingPermissionDeniedTitle": kIBGAudioRecordingPermissionDeniedTitleStringName,
               @"audioRecordingPermissionDeniedMessage": kIBGAudioRecordingPermissionDeniedMessageStringName,
               @"microphonePermissionAlertSettingsButtonTitle": kIBGMicrophonePermissionAlertSettingsButtonTitleStringName,
+              @"conversationsHeaderTitle": kIBGChatsTitleStringName,
               @"chatsHeaderTitle": kIBGChatsTitleStringName,
               @"team": kIBGTeamStringName,
               @"recordingMessageToHoldText": kIBGRecordingMessageToHoldTextStringName,


### PR DESCRIPTION
#### What's done:
- Fixed string mapping for addVideoMessage in iOS in accordance with the
existing Android key.
- Fixed string mapping for conversationsHeaderTitle.