### PR TITLE
Release/8.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v8.5.5 (2019-08-17)
+
+* Fixes an issue with the email validation when reporting a bug on Android.
+* Fixes an issue with the crash reporting which prevented the report from being submitted on Android.
+
 ## v8.5.4 (2019-08-10)
 
 * Hot Fixes an issue with `Instabug.setFloatingButtonEdge` and `Instabug.setEnabledAttachmentTypes` causing the app to crash.

--- a/InstabugSample/__tests__/instabugUtils.spec.js
+++ b/InstabugSample/__tests__/instabugUtils.spec.js
@@ -61,7 +61,7 @@ describe('Test global error handler', () => {
         Platform.OS = 'android';
         Instabug._isOnReportHandlerSet = jest.fn(() => true);
         const handler = global.ErrorUtils.getGlobalHandler();
-        IBGEventEmitter.addListener(IBGConstants.SEND_UNHANDLED_CRASH, (actual) => {
+        IBGEventEmitter.addListener(Instabug, IBGConstants.SEND_UNHANDLED_CRASH, (actual) => {
             const expected = {
                 message: 'TypeError - This is a type error.',
                 os: 'android',

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,7 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api('com.instabug.library:instabug:8.5.0.11') {
+    api('com.instabug.library:instabug:8.5.0.17') {
         exclude group: 'com.android.support:appcompat-v7'
     }
     testImplementation 'org.mockito:mockito-core:1.10.19'

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
@@ -455,7 +455,7 @@ public class RNInstabugReactnativeModule extends ReactContextBaseJavaModule {
     public void sendJSCrash(String exceptionObject) {
         try {
             JSONObject jsonObject = new JSONObject(exceptionObject);
-            sendJSCrashByReflection(jsonObject, false, null);
+            sendJSCrashByReflection(jsonObject, false);
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -470,7 +470,7 @@ public class RNInstabugReactnativeModule extends ReactContextBaseJavaModule {
     public void sendHandledJSCrash(String exceptionObject) {
         try {
             JSONObject jsonObject = new JSONObject(exceptionObject);
-            sendJSCrashByReflection(jsonObject, true, null);
+            sendJSCrashByReflection(jsonObject, true);
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -494,11 +494,11 @@ public class RNInstabugReactnativeModule extends ReactContextBaseJavaModule {
         }
     }
 
- private void sendJSCrashByReflection(JSONObject exceptionObject, boolean isHandled, Report report) {
+ private void sendJSCrashByReflection(JSONObject exceptionObject, boolean isHandled) {
         try {
-            Method method = getMethod(Class.forName("com.instabug.crash.CrashReporting"), "reportException", JSONObject.class, boolean.class, Report.class);
+            Method method = getMethod(Class.forName("com.instabug.crash.CrashReporting"), "reportException", JSONObject.class, boolean.class);
             if (method != null) {
-                method.invoke(null, exceptionObject, isHandled, currentReport);
+                method.invoke(null, exceptionObject, isHandled);
                 currentReport = null;
             }
         } catch (ClassNotFoundException e) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instabug-reactnative",
-  "version": "8.5.4", 
+  "version": "8.5.5", 
   "description": "React Native plugin for integrating the Instabug SDK",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
### Fixes:
- Updates the native Android SDK from 8.5.0.11 to 8.5.0.17.
  - It contains v8.5.0.11 + email validation fix (https://github.com/Instabug/android/compare/master...validation?expand=1)
- Fixes API mapping for the crash reporting method `reportException`
  - Removes the unnecessary third parameter of type `Report` because it had no method signature equivalent in the native side.