### PR TITLE
🐛 Add IBGpreSendingHandler to the supported events

### DIFF
--- a/ios/RNInstabug/InstabugReactBridge.m
+++ b/ios/RNInstabug/InstabugReactBridge.m
@@ -24,6 +24,7 @@
 
 - (NSArray<NSString *> *)supportedEvents {
     return @[
+             @"IBGpreSendingHandler",
              @"IBGSendHandledJSCrash",
              @"IBGSendUnhandledJSCrash",
              @"IBGSetNetworkDataObfuscationHandler",


### PR DESCRIPTION
### Problem: https://github.com/Instabug/Instabug-React-Native/issues/365

### Root Cause:
`IBGpreSendingHandler` event was accidentally removed while refactoring modules.

### Solution
Added `IBGpreSendingHandler` to the supported events of `InstabugReactBridge`.