### PR TITLE
🐛 Allow empty string to be passed to setUserAttribute value

### DIFF
--- a/index.js
+++ b/index.js
@@ -475,7 +475,7 @@ const InstabugModule = {
    * @param value the value
    */
   setUserAttribute(key, value) {
-    if (!key || !value || typeof key !== 'string' || typeof value !== 'string')
+    if (!key || typeof key !== 'string' || typeof value !== 'string')
       throw new TypeError('Invalid param, Expected String');
     Instabug.setUserAttribute(key, value);
   },


### PR DESCRIPTION
### Problem: https://github.com/Instabug/Instabug-React-Native/issues/362

### Root Cause:
We reject empty string values to be passed to the second argument.

### Solution:
- Discard the responsible validation statement.
- Although the discarded statement also checks for `null` and `undefined` values besides empty string values, we don't need to add a replacement because the subsequent validation statement i.e. `typeof value !== 'string'` already invalidates these values.