### PR TITLE
Fix android build ignoring `instabugUploadEnable` property

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,7 +51,7 @@ task upload_sourcemap(type: Exec) {
 
 tasks.whenTaskAdded { task ->
     if (task.name == 'preReleaseBuild' &&
-        rootProject.hasProperty("instabugUploadEnable") ? rootProject.instabugUploadEnable : true) {
+        (rootProject.hasProperty("instabugUploadEnable") ? rootProject.instabugUploadEnable : true)) {
         task.dependsOn upload_sourcemap 
     }
 }


### PR DESCRIPTION
The previous boolean expression for checking the `instabugUploadEnable` always returned true even if the `instabugUploadEnable` ext property was set to `false`. I must confess that either I'm currently too tired, or I don't know enough to understand why this was happening.

Adding the parentheses fixes it. I manually tested all the cases:

* Not adding the `instabugUploadEnable` property: Source map is **uploaded**
* Adding the `instabugUploadEnable` property with true as value: Source map is **uploaded**
* Adding the `instabugUploadEnable` property with false as value: Source map is **not uploaded**
