### PR TITLE
e2e/invocation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,7 @@ jobs:
           command: avdmanager create avd -n Nexus_9_API_27 -k "system-images;android-27;google_apis;x86" -g google_apis -d "Nexus 9"
       - run:
           name: Run Emulator in background
-          command: /usr/local/share/android-sdk/emulator/emulator @Nexus_9_API_27 -noaudio -no-boot-anim -no-window
+          command: /usr/local/share/android-sdk/emulator/emulator @Nexus_9_API_27 -noaudio -no-boot-anim -no-window -memory 1024
           background: true
       - run:
           name: Install Node Packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,7 @@ jobs:
           command: avdmanager create avd -n Nexus_9_API_27 -k "system-images;android-27;google_apis;x86" -g google_apis -d "Nexus 9"
       - run:
           name: Run Emulator in background
-          command: /usr/local/share/android-sdk/emulator/emulator @Nexus_9_API_27 -noaudio -no-boot-anim -no-window -memory 2048
+          command: /usr/local/share/android-sdk/emulator/emulator @Nexus_9_API_27 -noaudio -no-boot-anim -no-window -memory 2048 -logcat *:e
           background: true
       - run:
           name: Install Node Packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,16 +207,16 @@ jobs:
           name: Install Detox CLI
           command: sudo npm install -g detox-cli
       - run:
-          name: Detox - Build Release App
+          name: Detox - Build Debug App
           command: |
             sudo chmod -R 777 /Users/distiller/project/InstabugSample/node_modules/instabug-reactnative
             sudo chmod -R 777 /Users/distiller/project/InstabugSample/node_modules/detox
-            detox build --configuration android.emu.release
+            detox build --configuration android.emu.debug
       - run:
           name: Detox - Run E2E Tests
           command: |
             sudo chmod -R 777 /Users/distiller/Library/Detox
-            detox test --configuration android.emu.release --loglevel trace --debug-synchronization 9000 --take-screenshots failing
+            detox test --configuration android.emu.debug --loglevel trace --debug-synchronization 9000 --take-screenshots failing
       - store_artifacts:
           path: ./artifacts
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,23 +234,23 @@ workflows:
   version: 2
   publish:
     jobs:
-      - danger:
-          context: cross-platform
-      - test_module
-      - test_sample
-      - test_android
-      - test_ios
-      - e2e_ios:
-          context: cross-platform
+      # - danger:
+      #     context: cross-platform
+      # - test_module
+      # - test_sample
+      # - test_android
+      # - test_ios
+      # - e2e_ios:
+      #     context: cross-platform
       - e2e_android:
           context: cross-platform
       - hold:
           requires:
-            - test_module
-            - test_sample
-            - test_android
-            - test_ios
-            - e2e_ios
+            # - test_module
+            # - test_sample
+            # - test_android
+            # - test_ios
+            # - e2e_ios
             - e2e_android
           type: approval
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,6 +117,11 @@ jobs:
       - checkout:
           path: ~/project
       - run:
+          name: Set Application Token
+          command: |
+            echo 'export INSTABUG_APP_TOKEN="$RN_E2E_APP_TOKEN"' >> $BASH_ENV
+            sed -i.bak 's|YOUR_TOKEN|'"$RN_E2E_APP_TOKEN"'|g' App.js
+      - run:
           name: Install React Native CLI
           command: npm install -g react-native-cli
       - run:
@@ -149,13 +154,16 @@ jobs:
       - checkout:
           path: ~/project
       - run:
-          name: Install Android SDK
+          name: Set Application Token
           command: |
-            HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/cask
-            HOMEBREW_NO_AUTO_UPDATE=1 brew cask install android-sdk
+            echo 'export INSTABUG_APP_TOKEN="$RN_E2E_APP_TOKEN"' >> $BASH_ENV
+            sed -i.bak 's|YOUR_TOKEN|'"$RN_E2E_APP_TOKEN"'|g' App.js
+            sed -i.bak 's|YOUR_TOKEN|'"$RN_E2E_APP_TOKEN"'|g' android/app/src/main/java/com/instabugsample/MainApplication.java
       - run:
-          name: Accept Android SDK Licenses
-          command: (yes | sdkmanager --licenses) || true
+          name: Install Java 8
+          command: |
+            HOMEBREW_NO_AUTO_UPDATE=1 brew tap AdoptOpenJDK/openjdk
+            HOMEBREW_NO_AUTO_UPDATE=1 brew cask install adoptopenjdk/openjdk/adoptopenjdk8
       - run:
           name: Setup Android Environment Variables
           command: |
@@ -164,14 +172,22 @@ jobs:
             echo 'export ANDROID_SDK_ROOT=/usr/local/share/android-sdk' >> $BASH_ENV
             echo 'export PATH=$PATH:$ANDROID_HOME/tools:$ANDROID_HOME/platform-tools' >> $BASH_ENV
       - run:
+          name: Install Android SDK
+          command: |
+            HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/cask
+            HOMEBREW_NO_AUTO_UPDATE=1 brew cask install android-sdk
+      - run:
+          name: Accept Android SDK Licenses
+          command: (yes | sdkmanager --licenses) || true
+      - run:
           name: SDK Manager - Download Emulator Image
           command: (yes | sdkmanager "platform-tools" "platforms;android-27" "extras;intel;Hardware_Accelerated_Execution_Manager" "build-tools;27.0.3" "system-images;android-27;google_apis;x86" "emulator" --verbose) || true
       - run:
           name: AVD Manager - Setup Emulator
-          command: avdmanager create avd -n Nexus_6P_API_27 -k "system-images;android-27;google_apis;x86" -g google_apis -d "Nexus 6P"
+          command: avdmanager create avd -n Nexus_9_API_27 -k "system-images;android-27;google_apis;x86" -g google_apis -d "Nexus 9"
       - run:
           name: Run Emulator in background
-          command: /usr/local/share/android-sdk/emulator/emulator @Nexus_6P_API_27 -noaudio -no-boot-anim -no-window
+          command: /usr/local/share/android-sdk/emulator/emulator @Nexus_9_API_27 -noaudio -no-boot-anim -no-window
           background: true
       - run:
           name: Install Node Packages
@@ -192,12 +208,13 @@ jobs:
           name: Detox - Build Release App
           command: |
             sudo chmod -R 777 /Users/distiller/project/InstabugSample/node_modules/instabug-reactnative
+            sudo chmod -R 777 /Users/distiller/project/InstabugSample/node_modules/detox
             detox build --configuration android.emu.release
       - run:
           name: Detox - Run E2E Tests
           command: |
             sudo chmod -R 777 /Users/distiller/Library/Detox
-            detox test --configuration android.emu.release --cleanup
+            detox test --configuration android.emu.release --loglevel verbose
 
 
   publish:
@@ -220,8 +237,10 @@ workflows:
       - test_sample
       - test_android
       - test_ios
-      - e2e_ios
-      # - e2e_android
+      - e2e_ios:
+          context: cross-platform
+      - e2e_android:
+          context: cross-platform
       - hold:
           requires:
             - test_module
@@ -229,7 +248,7 @@ workflows:
             - test_android
             - test_ios
             - e2e_ios
-            # - e2e_android
+            - e2e_android
           type: approval
           filters:
             branches:
@@ -241,4 +260,3 @@ workflows:
           filters:
             branches:
               only: master
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
           command: detox build --configuration ios.sim.release
       - run:
           name: Detox - Run E2E Tests
-          command: detox test --configuration ios.sim.release --loglevel verbose --debug-synchronization 9000 --take-screenshots failing
+          command: detox test --configuration ios.sim.release --loglevel trace --debug-synchronization 9000 --take-screenshots failing
       - store_artifacts:
           path: ./artifacts
 
@@ -186,10 +186,10 @@ jobs:
           command: (yes | sdkmanager "platform-tools" "platforms;android-27" "extras;intel;Hardware_Accelerated_Execution_Manager" "build-tools;27.0.3" "system-images;android-27;google_apis;x86" "emulator" --verbose) || true
       - run:
           name: AVD Manager - Setup Emulator
-          command: avdmanager create avd -n Nexus_9_API_27 -k "system-images;android-27;google_apis;x86" -g google_apis -d "Nexus 9"
+          command: avdmanager create avd -n Pixel_2_XL_API_27 -k "system-images;android-27;google_apis;x86" -g google_apis -d "pixel_xl"
       - run:
           name: Run Emulator in background
-          command: /usr/local/share/android-sdk/emulator/emulator @Nexus_9_API_27 -noaudio -no-boot-anim -no-window -memory 1024
+          command: /usr/local/share/android-sdk/emulator/emulator @Pixel_2_XL_API_27 -noaudio -no-boot-anim -no-window -memory 1024
           background: true
       - run:
           name: Install Node Packages
@@ -216,7 +216,7 @@ jobs:
           name: Detox - Run E2E Tests
           command: |
             sudo chmod -R 777 /Users/distiller/Library/Detox
-            detox test --configuration android.emu.release --loglevel verbose --debug-synchronization 9000 --take-screenshots failing
+            detox test --configuration android.emu.release --loglevel trace --debug-synchronization 9000 --take-screenshots failing
       - store_artifacts:
           path: ./artifacts
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
           command: detox build --configuration ios.sim.release
       - run:
           name: Detox - Run E2E Tests
-          command: detox test --configuration ios.sim.release --cleanup
+          command: detox test --configuration ios.sim.release --loglevel verbose --debug-synchronization 9000 --take-screenshots failing
 
   e2e_android:
     macos:
@@ -214,7 +214,7 @@ jobs:
           name: Detox - Run E2E Tests
           command: |
             sudo chmod -R 777 /Users/distiller/Library/Detox
-            detox test --configuration android.emu.release --loglevel verbose
+            detox test --configuration android.emu.release --loglevel verbose --debug-synchronization 9000 --take-screenshots failing
 
 
   publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,10 +186,10 @@ jobs:
           command: (yes | sdkmanager "platform-tools" "platforms;android-27" "extras;intel;Hardware_Accelerated_Execution_Manager" "build-tools;27.0.3" "system-images;android-27;google_apis;x86" "emulator" --verbose) || true
       - run:
           name: AVD Manager - Setup Emulator
-          command: avdmanager create avd -n Nexus_9_API_27 -k "system-images;android-27;google_apis;x86" -g google_apis -d "Nexus 9"
+          command: avdmanager create avd -n Pixel_API_27 -k "system-images;android-27;google_apis;x86" -g google_apis -d "pixel_xl"
       - run:
           name: Run Emulator in background
-          command: /usr/local/share/android-sdk/emulator/emulator @Nexus_9_API_27 -noaudio -no-boot-anim -no-window -memory 2048 -logcat *:e
+          command: /usr/local/share/android-sdk/emulator/emulator @Pixel_API_27 -no-snapshot -noaudio -no-boot-anim -no-window -memory 2048 -logcat '*:e'
           background: true
       - run:
           name: Install Node Packages
@@ -207,6 +207,14 @@ jobs:
           name: Install Detox CLI
           command: sudo npm install -g detox-cli
       - run:
+          name: Wait for Emulator
+          command: adb wait-for-device shell 'while [[ -z $(getprop dev.bootcomplete) ]]; do sleep 1; done;'
+      - run: 
+          name: Emulator Post Booting Screenshot
+          command: mkdir -p ./early-artifacts && adb shell screencap -p > ./early-artifacts/before-running-detox.png
+      - store_artifacts:
+          path: ./early-artifacts
+      - run:
           name: Detox - Build Release App
           command: |
             sudo chmod -R 777 /Users/distiller/project/InstabugSample/node_modules/instabug-reactnative
@@ -220,15 +228,405 @@ jobs:
       - store_artifacts:
           path: ./artifacts
 
-  publish:
+  e2e_android2:
     macos:
-      xcode: "10.1.0"
+      xcode: "10.2.0"
+    working_directory: ~/project/InstabugSample
     steps:
-      - checkout
-      - run: git clone https://InstabugCI:$RELEASE_GITHUB_TOKEN@github.com/Instabug/Escape.git
-      - run: cd Escape; swift build -c release -Xswiftc -static-stdlib
-      - run: cd Escape/.build/release; cp -f Escape /usr/local/bin/escape
-      - run: Escape react-native publish
+      - checkout:
+          path: ~/project
+      - run:
+          name: Set Application Token
+          command: |
+            echo 'export INSTABUG_APP_TOKEN="$RN_E2E_APP_TOKEN"' >> $BASH_ENV
+            sed -i.bak 's|YOUR_TOKEN|'"$RN_E2E_APP_TOKEN"'|g' App.js
+            sed -i.bak 's|YOUR_TOKEN|'"$RN_E2E_APP_TOKEN"'|g' android/app/src/main/java/com/instabugsample/MainApplication.java
+      - run:
+          name: Install Java 8
+          command: |
+            HOMEBREW_NO_AUTO_UPDATE=1 brew tap AdoptOpenJDK/openjdk
+            HOMEBREW_NO_AUTO_UPDATE=1 brew cask install adoptopenjdk/openjdk/adoptopenjdk8
+      - run:
+          name: Setup Android Environment Variables
+          command: |
+            echo 'export JAVA_HOME=`/usr/libexec/java_home -v 1.8`' >> $BASH_ENV
+            echo 'export ANDROID_HOME=/usr/local/share/android-sdk' >> $BASH_ENV
+            echo 'export ANDROID_SDK_ROOT=/usr/local/share/android-sdk' >> $BASH_ENV
+            echo 'export PATH=$PATH:$ANDROID_HOME/tools:$ANDROID_HOME/platform-tools' >> $BASH_ENV
+      - run:
+          name: Install Android SDK
+          command: |
+            HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/cask
+            HOMEBREW_NO_AUTO_UPDATE=1 brew cask install android-sdk
+      - run:
+          name: Accept Android SDK Licenses
+          command: (yes | sdkmanager --licenses) || true
+      - run:
+          name: SDK Manager - Download Emulator Image
+          command: (yes | sdkmanager "platform-tools" "platforms;android-27" "extras;intel;Hardware_Accelerated_Execution_Manager" "build-tools;27.0.3" "system-images;android-27;google_apis;x86" "emulator" --verbose) || true
+      - run:
+          name: AVD Manager - Setup Emulator
+          command: avdmanager create avd -n Pixel_API_27 -k "system-images;android-27;google_apis;x86" -g google_apis -d "pixel_xl"
+      - run:
+          name: Run Emulator in background
+          command: /usr/local/share/android-sdk/emulator/emulator @Pixel_API_27 -no-snapshot -noaudio -no-boot-anim -no-window -memory 2048 -logcat '*:e'
+          background: true
+      - run:
+          name: Install Node Packages
+          command: sudo yarn
+      - run:
+          name: Generate Android Keystore
+          command: cd android/app && keytool -genkey -v -keystore debug.keystore -storepass android -alias androiddebugkey -keypass android -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=AA, OU=AA, O=AA, L=AA, S=AA, C=EG"
+      - run:
+          name: Make gradlew Executable
+          command: cd android && chmod +x ./gradlew
+      - run:
+          name: Download Android Dependencies
+          command: cd android && ./gradlew androidDependencies
+      - run:
+          name: Install Detox CLI
+          command: sudo npm install -g detox-cli
+      - run:
+          name: Wait for Emulator
+          command: adb wait-for-device shell 'while [[ -z $(getprop dev.bootcomplete) ]]; do sleep 1; done;'
+      - run: 
+          name: Emulator Post Booting Screenshot
+          command: mkdir -p ./early-artifacts && adb shell screencap -p > ./early-artifacts/before-running-detox.png
+      - store_artifacts:
+          path: ./early-artifacts
+      - run:
+          name: Detox - Build Release App
+          command: |
+            sudo chmod -R 777 /Users/distiller/project/InstabugSample/node_modules/instabug-reactnative
+            sudo chmod -R 777 /Users/distiller/project/InstabugSample/node_modules/detox
+            detox build --configuration android.emu.release
+      - run:
+          name: Detox - Run E2E Tests
+          command: |
+            sudo chmod -R 777 /Users/distiller/Library/Detox
+            detox test --configuration android.emu.release --loglevel trace --debug-synchronization 9000 --take-screenshots failing
+      - store_artifacts:
+          path: ./artifacts
+
+  e2e_android3:
+    macos:
+      xcode: "10.2.0"
+    working_directory: ~/project/InstabugSample
+    steps:
+      - checkout:
+          path: ~/project
+      - run:
+          name: Set Application Token
+          command: |
+            echo 'export INSTABUG_APP_TOKEN="$RN_E2E_APP_TOKEN"' >> $BASH_ENV
+            sed -i.bak 's|YOUR_TOKEN|'"$RN_E2E_APP_TOKEN"'|g' App.js
+            sed -i.bak 's|YOUR_TOKEN|'"$RN_E2E_APP_TOKEN"'|g' android/app/src/main/java/com/instabugsample/MainApplication.java
+      - run:
+          name: Install Java 8
+          command: |
+            HOMEBREW_NO_AUTO_UPDATE=1 brew tap AdoptOpenJDK/openjdk
+            HOMEBREW_NO_AUTO_UPDATE=1 brew cask install adoptopenjdk/openjdk/adoptopenjdk8
+      - run:
+          name: Setup Android Environment Variables
+          command: |
+            echo 'export JAVA_HOME=`/usr/libexec/java_home -v 1.8`' >> $BASH_ENV
+            echo 'export ANDROID_HOME=/usr/local/share/android-sdk' >> $BASH_ENV
+            echo 'export ANDROID_SDK_ROOT=/usr/local/share/android-sdk' >> $BASH_ENV
+            echo 'export PATH=$PATH:$ANDROID_HOME/tools:$ANDROID_HOME/platform-tools' >> $BASH_ENV
+      - run:
+          name: Install Android SDK
+          command: |
+            HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/cask
+            HOMEBREW_NO_AUTO_UPDATE=1 brew cask install android-sdk
+      - run:
+          name: Accept Android SDK Licenses
+          command: (yes | sdkmanager --licenses) || true
+      - run:
+          name: SDK Manager - Download Emulator Image
+          command: (yes | sdkmanager "platform-tools" "platforms;android-27" "extras;intel;Hardware_Accelerated_Execution_Manager" "build-tools;27.0.3" "system-images;android-27;google_apis;x86" "emulator" --verbose) || true
+      - run:
+          name: AVD Manager - Setup Emulator
+          command: avdmanager create avd -n Pixel_API_27 -k "system-images;android-27;google_apis;x86" -g google_apis -d "pixel_xl"
+      - run:
+          name: Run Emulator in background
+          command: /usr/local/share/android-sdk/emulator/emulator @Pixel_API_27 -no-snapshot -noaudio -no-boot-anim -no-window -memory 2048 -logcat '*:e'
+          background: true
+      - run:
+          name: Install Node Packages
+          command: sudo yarn
+      - run:
+          name: Generate Android Keystore
+          command: cd android/app && keytool -genkey -v -keystore debug.keystore -storepass android -alias androiddebugkey -keypass android -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=AA, OU=AA, O=AA, L=AA, S=AA, C=EG"
+      - run:
+          name: Make gradlew Executable
+          command: cd android && chmod +x ./gradlew
+      - run:
+          name: Download Android Dependencies
+          command: cd android && ./gradlew androidDependencies
+      - run:
+          name: Install Detox CLI
+          command: sudo npm install -g detox-cli
+      - run:
+          name: Wait for Emulator
+          command: adb wait-for-device shell 'while [[ -z $(getprop dev.bootcomplete) ]]; do sleep 1; done;'
+      - run: 
+          name: Emulator Post Booting Screenshot
+          command: mkdir -p ./early-artifacts && adb shell screencap -p > ./early-artifacts/before-running-detox.png
+      - store_artifacts:
+          path: ./early-artifacts
+      - run:
+          name: Detox - Build Release App
+          command: |
+            sudo chmod -R 777 /Users/distiller/project/InstabugSample/node_modules/instabug-reactnative
+            sudo chmod -R 777 /Users/distiller/project/InstabugSample/node_modules/detox
+            detox build --configuration android.emu.release
+      - run:
+          name: Detox - Run E2E Tests
+          command: |
+            sudo chmod -R 777 /Users/distiller/Library/Detox
+            detox test --configuration android.emu.release --loglevel trace --debug-synchronization 9000 --take-screenshots failing
+      - store_artifacts:
+          path: ./artifacts
+
+  e2e_android4:
+    macos:
+      xcode: "10.2.0"
+    working_directory: ~/project/InstabugSample
+    steps:
+      - checkout:
+          path: ~/project
+      - run:
+          name: Set Application Token
+          command: |
+            echo 'export INSTABUG_APP_TOKEN="$RN_E2E_APP_TOKEN"' >> $BASH_ENV
+            sed -i.bak 's|YOUR_TOKEN|'"$RN_E2E_APP_TOKEN"'|g' App.js
+            sed -i.bak 's|YOUR_TOKEN|'"$RN_E2E_APP_TOKEN"'|g' android/app/src/main/java/com/instabugsample/MainApplication.java
+      - run:
+          name: Install Java 8
+          command: |
+            HOMEBREW_NO_AUTO_UPDATE=1 brew tap AdoptOpenJDK/openjdk
+            HOMEBREW_NO_AUTO_UPDATE=1 brew cask install adoptopenjdk/openjdk/adoptopenjdk8
+      - run:
+          name: Setup Android Environment Variables
+          command: |
+            echo 'export JAVA_HOME=`/usr/libexec/java_home -v 1.8`' >> $BASH_ENV
+            echo 'export ANDROID_HOME=/usr/local/share/android-sdk' >> $BASH_ENV
+            echo 'export ANDROID_SDK_ROOT=/usr/local/share/android-sdk' >> $BASH_ENV
+            echo 'export PATH=$PATH:$ANDROID_HOME/tools:$ANDROID_HOME/platform-tools' >> $BASH_ENV
+      - run:
+          name: Install Android SDK
+          command: |
+            HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/cask
+            HOMEBREW_NO_AUTO_UPDATE=1 brew cask install android-sdk
+      - run:
+          name: Accept Android SDK Licenses
+          command: (yes | sdkmanager --licenses) || true
+      - run:
+          name: SDK Manager - Download Emulator Image
+          command: (yes | sdkmanager "platform-tools" "platforms;android-27" "extras;intel;Hardware_Accelerated_Execution_Manager" "build-tools;27.0.3" "system-images;android-27;google_apis;x86" "emulator" --verbose) || true
+      - run:
+          name: AVD Manager - Setup Emulator
+          command: avdmanager create avd -n Pixel_API_27 -k "system-images;android-27;google_apis;x86" -g google_apis -d "pixel_xl"
+      - run:
+          name: Run Emulator in background
+          command: /usr/local/share/android-sdk/emulator/emulator @Pixel_API_27 -no-snapshot -noaudio -no-boot-anim -no-window -memory 2048 -logcat '*:e'
+          background: true
+      - run:
+          name: Install Node Packages
+          command: sudo yarn
+      - run:
+          name: Generate Android Keystore
+          command: cd android/app && keytool -genkey -v -keystore debug.keystore -storepass android -alias androiddebugkey -keypass android -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=AA, OU=AA, O=AA, L=AA, S=AA, C=EG"
+      - run:
+          name: Make gradlew Executable
+          command: cd android && chmod +x ./gradlew
+      - run:
+          name: Download Android Dependencies
+          command: cd android && ./gradlew androidDependencies
+      - run:
+          name: Install Detox CLI
+          command: sudo npm install -g detox-cli
+      - run:
+          name: Wait for Emulator
+          command: adb wait-for-device shell 'while [[ -z $(getprop dev.bootcomplete) ]]; do sleep 1; done;'
+      - run: 
+          name: Emulator Post Booting Screenshot
+          command: mkdir -p ./early-artifacts && adb shell screencap -p > ./early-artifacts/before-running-detox.png
+      - store_artifacts:
+          path: ./early-artifacts
+      - run:
+          name: Detox - Build Release App
+          command: |
+            sudo chmod -R 777 /Users/distiller/project/InstabugSample/node_modules/instabug-reactnative
+            sudo chmod -R 777 /Users/distiller/project/InstabugSample/node_modules/detox
+            detox build --configuration android.emu.release
+      - run:
+          name: Detox - Run E2E Tests
+          command: |
+            sudo chmod -R 777 /Users/distiller/Library/Detox
+            detox test --configuration android.emu.release --loglevel trace --debug-synchronization 9000 --take-screenshots failing
+      - store_artifacts:
+          path: ./artifacts
+
+  e2e_android5:
+    macos:
+      xcode: "10.2.0"
+    working_directory: ~/project/InstabugSample
+    steps:
+      - checkout:
+          path: ~/project
+      - run:
+          name: Set Application Token
+          command: |
+            echo 'export INSTABUG_APP_TOKEN="$RN_E2E_APP_TOKEN"' >> $BASH_ENV
+            sed -i.bak 's|YOUR_TOKEN|'"$RN_E2E_APP_TOKEN"'|g' App.js
+            sed -i.bak 's|YOUR_TOKEN|'"$RN_E2E_APP_TOKEN"'|g' android/app/src/main/java/com/instabugsample/MainApplication.java
+      - run:
+          name: Install Java 8
+          command: |
+            HOMEBREW_NO_AUTO_UPDATE=1 brew tap AdoptOpenJDK/openjdk
+            HOMEBREW_NO_AUTO_UPDATE=1 brew cask install adoptopenjdk/openjdk/adoptopenjdk8
+      - run:
+          name: Setup Android Environment Variables
+          command: |
+            echo 'export JAVA_HOME=`/usr/libexec/java_home -v 1.8`' >> $BASH_ENV
+            echo 'export ANDROID_HOME=/usr/local/share/android-sdk' >> $BASH_ENV
+            echo 'export ANDROID_SDK_ROOT=/usr/local/share/android-sdk' >> $BASH_ENV
+            echo 'export PATH=$PATH:$ANDROID_HOME/tools:$ANDROID_HOME/platform-tools' >> $BASH_ENV
+      - run:
+          name: Install Android SDK
+          command: |
+            HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/cask
+            HOMEBREW_NO_AUTO_UPDATE=1 brew cask install android-sdk
+      - run:
+          name: Accept Android SDK Licenses
+          command: (yes | sdkmanager --licenses) || true
+      - run:
+          name: SDK Manager - Download Emulator Image
+          command: (yes | sdkmanager "platform-tools" "platforms;android-27" "extras;intel;Hardware_Accelerated_Execution_Manager" "build-tools;27.0.3" "system-images;android-27;google_apis;x86" "emulator" --verbose) || true
+      - run:
+          name: AVD Manager - Setup Emulator
+          command: avdmanager create avd -n Pixel_API_27 -k "system-images;android-27;google_apis;x86" -g google_apis -d "pixel_xl"
+      - run:
+          name: Run Emulator in background
+          command: /usr/local/share/android-sdk/emulator/emulator @Pixel_API_27 -no-snapshot -noaudio -no-boot-anim -no-window -memory 2048 -logcat '*:e'
+          background: true
+      - run:
+          name: Install Node Packages
+          command: sudo yarn
+      - run:
+          name: Generate Android Keystore
+          command: cd android/app && keytool -genkey -v -keystore debug.keystore -storepass android -alias androiddebugkey -keypass android -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=AA, OU=AA, O=AA, L=AA, S=AA, C=EG"
+      - run:
+          name: Make gradlew Executable
+          command: cd android && chmod +x ./gradlew
+      - run:
+          name: Download Android Dependencies
+          command: cd android && ./gradlew androidDependencies
+      - run:
+          name: Install Detox CLI
+          command: sudo npm install -g detox-cli
+      - run:
+          name: Wait for Emulator
+          command: adb wait-for-device shell 'while [[ -z $(getprop dev.bootcomplete) ]]; do sleep 1; done;'
+      - run: 
+          name: Emulator Post Booting Screenshot
+          command: mkdir -p ./early-artifacts && adb shell screencap -p > ./early-artifacts/before-running-detox.png
+      - store_artifacts:
+          path: ./early-artifacts
+      - run:
+          name: Detox - Build Release App
+          command: |
+            sudo chmod -R 777 /Users/distiller/project/InstabugSample/node_modules/instabug-reactnative
+            sudo chmod -R 777 /Users/distiller/project/InstabugSample/node_modules/detox
+            detox build --configuration android.emu.release
+      - run:
+          name: Detox - Run E2E Tests
+          command: |
+            sudo chmod -R 777 /Users/distiller/Library/Detox
+            detox test --configuration android.emu.release --loglevel trace --debug-synchronization 9000 --take-screenshots failing
+      - store_artifacts:
+          path: ./artifacts
+
+  e2e_android6:
+    macos:
+      xcode: "10.2.0"
+    working_directory: ~/project/InstabugSample
+    steps:
+      - checkout:
+          path: ~/project
+      - run:
+          name: Set Application Token
+          command: |
+            echo 'export INSTABUG_APP_TOKEN="$RN_E2E_APP_TOKEN"' >> $BASH_ENV
+            sed -i.bak 's|YOUR_TOKEN|'"$RN_E2E_APP_TOKEN"'|g' App.js
+            sed -i.bak 's|YOUR_TOKEN|'"$RN_E2E_APP_TOKEN"'|g' android/app/src/main/java/com/instabugsample/MainApplication.java
+      - run:
+          name: Install Java 8
+          command: |
+            HOMEBREW_NO_AUTO_UPDATE=1 brew tap AdoptOpenJDK/openjdk
+            HOMEBREW_NO_AUTO_UPDATE=1 brew cask install adoptopenjdk/openjdk/adoptopenjdk8
+      - run:
+          name: Setup Android Environment Variables
+          command: |
+            echo 'export JAVA_HOME=`/usr/libexec/java_home -v 1.8`' >> $BASH_ENV
+            echo 'export ANDROID_HOME=/usr/local/share/android-sdk' >> $BASH_ENV
+            echo 'export ANDROID_SDK_ROOT=/usr/local/share/android-sdk' >> $BASH_ENV
+            echo 'export PATH=$PATH:$ANDROID_HOME/tools:$ANDROID_HOME/platform-tools' >> $BASH_ENV
+      - run:
+          name: Install Android SDK
+          command: |
+            HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/cask
+            HOMEBREW_NO_AUTO_UPDATE=1 brew cask install android-sdk
+      - run:
+          name: Accept Android SDK Licenses
+          command: (yes | sdkmanager --licenses) || true
+      - run:
+          name: SDK Manager - Download Emulator Image
+          command: (yes | sdkmanager "platform-tools" "platforms;android-27" "extras;intel;Hardware_Accelerated_Execution_Manager" "build-tools;27.0.3" "system-images;android-27;google_apis;x86" "emulator" --verbose) || true
+      - run:
+          name: AVD Manager - Setup Emulator
+          command: avdmanager create avd -n Pixel_API_27 -k "system-images;android-27;google_apis;x86" -g google_apis -d "pixel_xl"
+      - run:
+          name: Run Emulator in background
+          command: /usr/local/share/android-sdk/emulator/emulator @Pixel_API_27 -no-snapshot -noaudio -no-boot-anim -no-window -memory 2048 -logcat '*:e'
+          background: true
+      - run:
+          name: Install Node Packages
+          command: sudo yarn
+      - run:
+          name: Generate Android Keystore
+          command: cd android/app && keytool -genkey -v -keystore debug.keystore -storepass android -alias androiddebugkey -keypass android -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=AA, OU=AA, O=AA, L=AA, S=AA, C=EG"
+      - run:
+          name: Make gradlew Executable
+          command: cd android && chmod +x ./gradlew
+      - run:
+          name: Download Android Dependencies
+          command: cd android && ./gradlew androidDependencies
+      - run:
+          name: Install Detox CLI
+          command: sudo npm install -g detox-cli
+      - run:
+          name: Wait for Emulator
+          command: adb wait-for-device shell 'while [[ -z $(getprop dev.bootcomplete) ]]; do sleep 1; done;'
+      - run: 
+          name: Emulator Post Booting Screenshot
+          command: mkdir -p ./early-artifacts && adb shell screencap -p > ./early-artifacts/before-running-detox.png
+      - store_artifacts:
+          path: ./early-artifacts
+      - run:
+          name: Detox - Build Release App
+          command: |
+            sudo chmod -R 777 /Users/distiller/project/InstabugSample/node_modules/instabug-reactnative
+            sudo chmod -R 777 /Users/distiller/project/InstabugSample/node_modules/detox
+            detox build --configuration android.emu.release
+      - run:
+          name: Detox - Run E2E Tests
+          command: |
+            sudo chmod -R 777 /Users/distiller/Library/Detox
+            detox test --configuration android.emu.release --loglevel trace --debug-synchronization 9000 --take-screenshots failing
+      - store_artifacts:
+          path: ./artifacts
 
 workflows:
   version: 2
@@ -240,9 +638,19 @@ workflows:
       # - test_sample
       # - test_android
       # - test_ios
-      # - e2e_ios:
-      #     context: cross-platform
+      - e2e_ios:
+          context: cross-platform
       - e2e_android:
+          context: cross-platform
+      - e2e_android2:
+          context: cross-platform
+      - e2e_android3:
+          context: cross-platform
+      - e2e_android4:
+          context: cross-platform
+      - e2e_android5:
+          context: cross-platform
+      - e2e_android6:
           context: cross-platform
       - hold:
           requires:
@@ -250,7 +658,7 @@ workflows:
             # - test_sample
             # - test_android
             # - test_ios
-            # - e2e_ios
+            - e2e_ios
             - e2e_android
           type: approval
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,8 @@ jobs:
       - run:
           name: Detox - Run E2E Tests
           command: detox test --configuration ios.sim.release --loglevel verbose --debug-synchronization 9000 --take-screenshots failing
+      - store_artifacts:
+          path: ./artifacts
 
   e2e_android:
     macos:
@@ -215,7 +217,8 @@ jobs:
           command: |
             sudo chmod -R 777 /Users/distiller/Library/Detox
             detox test --configuration android.emu.release --loglevel verbose --debug-synchronization 9000 --take-screenshots failing
-
+      - store_artifacts:
+          path: ./artifacts
 
   publish:
     macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,7 @@ jobs:
           command: avdmanager create avd -n Nexus_9_API_27 -k "system-images;android-27;google_apis;x86" -g google_apis -d "Nexus 9"
       - run:
           name: Run Emulator in background
-          command: /usr/local/share/android-sdk/emulator/emulator @Nexus_9_API_27 -noaudio -no-boot-anim -no-window -memory 1024
+          command: /usr/local/share/android-sdk/emulator/emulator @Nexus_9_API_27 -noaudio -no-boot-anim -no-window -memory 2048
           background: true
       - run:
           name: Install Node Packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,10 +186,10 @@ jobs:
           command: (yes | sdkmanager "platform-tools" "platforms;android-27" "extras;intel;Hardware_Accelerated_Execution_Manager" "build-tools;27.0.3" "system-images;android-27;google_apis;x86" "emulator" --verbose) || true
       - run:
           name: AVD Manager - Setup Emulator
-          command: avdmanager create avd -n Pixel_2_XL_API_27 -k "system-images;android-27;google_apis;x86" -g google_apis -d "pixel_xl"
+          command: avdmanager create avd -n Nexus_9_API_27 -k "system-images;android-27;google_apis;x86" -g google_apis -d "Nexus 9"
       - run:
           name: Run Emulator in background
-          command: /usr/local/share/android-sdk/emulator/emulator @Pixel_2_XL_API_27 -noaudio -no-boot-anim -no-window -memory 1024
+          command: /usr/local/share/android-sdk/emulator/emulator @Nexus_9_API_27 -noaudio -no-boot-anim -no-window -memory 1024
           background: true
       - run:
           name: Install Node Packages
@@ -207,16 +207,16 @@ jobs:
           name: Install Detox CLI
           command: sudo npm install -g detox-cli
       - run:
-          name: Detox - Build Debug App
+          name: Detox - Build Release App
           command: |
             sudo chmod -R 777 /Users/distiller/project/InstabugSample/node_modules/instabug-reactnative
             sudo chmod -R 777 /Users/distiller/project/InstabugSample/node_modules/detox
-            detox build --configuration android.emu.debug
+            detox build --configuration android.emu.release
       - run:
           name: Detox - Run E2E Tests
           command: |
             sudo chmod -R 777 /Users/distiller/Library/Detox
-            detox test --configuration android.emu.debug --loglevel trace --debug-synchronization 9000 --take-screenshots failing
+            detox test --configuration android.emu.release --loglevel trace --debug-synchronization 9000 --take-screenshots failing
       - store_artifacts:
           path: ./artifacts
 

--- a/InstabugSample/.gitignore
+++ b/InstabugSample/.gitignore
@@ -58,3 +58,6 @@ buck-out/
 
 # CocoaPods
 /ios/Pods/
+
+# e2e screenshots
+artifacts/

--- a/InstabugSample/App.js
+++ b/InstabugSample/App.js
@@ -38,21 +38,22 @@ export default class App extends Component<{}> {
       colorTheme: 'Light',
     };
 
-    Instabug.start('068ba9a8c3615035e163dc5f829c73be', [
+    Instabug.start('YOUR_TOKEN', [
+      Instabug.invocationEvent.shake,
       Instabug.invocationEvent.floatingButton,
     ]);
   }
 
   render() {
     return (
-      <View testID="welcome" style={styles.container}>
+      <View testID="appMainView" style={styles.container}>
         <ScrollView contentContainerStyle={styles.contentContainer}>
           <Text style={styles.details}>
             Hello {"Instabug's"} awesome user! The purpose of this application is to show you the
             different options for customizing the SDK and how easy it is to integrate it to your
             existing app
           </Text>
-          <TouchableOpacity style={styles.button} onPress={() => this.invoke()}>
+          <TouchableOpacity testID="invokeBtn" style={styles.button} onPress={() => this.invoke()}>
             <Text style={styles.text}> INVOKE </Text>
           </TouchableOpacity>
           <TouchableOpacity style={styles.button} onPress={() => this.sendBugReport()}>
@@ -132,6 +133,7 @@ export default class App extends Component<{}> {
             <Text style={styles.textInvoke}> TWO FINGERS SWIPE LEFT</Text>
           </TouchableOpacity>
           <TouchableOpacity
+            testID="enableFloatingBtnVisibilityBtn"
             style={styles.buttonColor}
             onPress={() => this.changeInvocationEvent('Button')}
           >
@@ -225,7 +227,7 @@ export default class App extends Component<{}> {
     });
   }
 }
-buttonColor = function(myColor) {
+buttonColor = function (myColor) {
   return {
     marginTop: 10,
     padding: 20,

--- a/InstabugSample/__e2e__/bug-reporting/native-actions.js
+++ b/InstabugSample/__e2e__/bug-reporting/native-actions.js
@@ -1,4 +1,5 @@
 import { getId } from '../utilities/native-utility';
+import { DEFAULT_TIMEOUT } from '../utilities/settings';
 import TestData from './test-data';
 
 export const NativeIds = {
@@ -24,12 +25,15 @@ export const NativeTexts = {
 
 export const NativeActions = {
   async fillOnBugPromptOption() {
-    var emailField = element(by.nativeId(getId(NativeIds.EMAIL_FIELD)));
+    const emailField = element(by.nativeId(getId(NativeIds.EMAIL_FIELD)));
+    await waitFor(emailField).toBeVisible().withTimeout(DEFAULT_TIMEOUT);
     await emailField.tap();
     await emailField.clearText();
     await emailField.typeText(TestData.email);
   },
   async tapOnSendBugReportBtn() {
-    await element(by.nativeId(getId(NativeIds.SEND_BUG_BTN))).tap();
+    const sendBugBtn = element(by.nativeId(getId(NativeIds.SEND_BUG_BTN)));
+    await waitFor(sendBugBtn).toBeVisible().withTimeout(DEFAULT_TIMEOUT);
+    await sendBugBtn.tap();
   },
 };

--- a/InstabugSample/__e2e__/bug-reporting/native-actions.js
+++ b/InstabugSample/__e2e__/bug-reporting/native-actions.js
@@ -1,0 +1,35 @@
+import { getId } from '../utilities/native-utility';
+import TestData from './test-data';
+
+export const NativeIds = {
+  EMAIL_FIELD: {
+    IOS: 'IBGBugInputViewEmailFieldAccessibilityIdentifier',
+    ANDROID: 'instabug_edit_text_email',
+  },
+  SEND_BUG_BTN: {
+    IOS: 'IBGBugVCNextButtonAccessibilityIdentifier',
+    ANDROID: 'instabug_bugreporting_send',
+  },
+  SUCCESS_POPUP_MSG: {
+    ANDROID: 'instabug_txt_success_note',
+  },
+};
+
+export const NativeTexts = {
+  SUCCESS_POPUP_HEADER: {
+    IOS: 'Thank you',
+    ANDROID: 'Thank you!',
+  },
+};
+
+export const NativeActions = {
+  async fillOnBugPromptOption() {
+    var emailField = element(by.nativeId(getId(NativeIds.EMAIL_FIELD)));
+    await emailField.tap();
+    await emailField.clearText();
+    await emailField.typeText(TestData.email);
+  },
+  async tapOnSendBugReportBtn() {
+    await element(by.nativeId(getId(NativeIds.SEND_BUG_BTN))).tap();
+  },
+};

--- a/InstabugSample/__e2e__/bug-reporting/report-bug.spec.js
+++ b/InstabugSample/__e2e__/bug-reporting/report-bug.spec.js
@@ -24,8 +24,10 @@ describe('Bug Reporting', () => {
     // Expect a "Thank you" popup
     if (device.getPlatform() === 'ios') {
       await waitFor(element(by.text('Thank you'))).toBeVisible().withTimeout(DEFAULT_TIMEOUT);
+      await expect(element(by.text('Thank you'))).toBeVisible();
     } else {
       await waitFor(element(by.nativeId(getId(BugReportingNativeIds.SUCCESS_POPUP_MSG)))).toBeVisible().withTimeout(DEFAULT_TIMEOUT);
+      await expect(element(by.nativeId(getId(BugReportingNativeIds.SUCCESS_POPUP_MSG)))).toBeVisible();
     }
   });
 });

--- a/InstabugSample/__e2e__/bug-reporting/report-bug.spec.js
+++ b/InstabugSample/__e2e__/bug-reporting/report-bug.spec.js
@@ -1,0 +1,31 @@
+import { NativeActions as InstabugNativeActions } from '../instabug/native-actions';
+import { NativeActions as BugReportingNativeActions, NativeIds as BugReportingNativeIds } from './native-actions';
+import { ReactNativeActions } from '../utilities/rn-utility';
+import { DEFAULT_TIMEOUT } from '../utilities/settings';
+import { getId } from '../utilities/native-utility';
+
+describe('Bug Reporting', () => {
+  it('should report a bug', async () => {
+    // RN App Sanity
+    await ReactNativeActions.checkRnSanity();
+
+    // Invoke Prompt Options
+    await ReactNativeActions.tapOnInvokeBtn();
+
+    // Tap on Report a Bug option
+    await InstabugNativeActions.tapOnBugPromptOption();
+    
+    // Fill the Email field
+    await BugReportingNativeActions.fillOnBugPromptOption();
+    
+    // Tap on Send Bug Report button
+    await BugReportingNativeActions.tapOnSendBugReportBtn();
+
+    // Expect a "Thank you" popup
+    if (device.getPlatform() === 'ios') {
+      await waitFor(element(by.text('Thank you'))).toBeVisible().withTimeout(DEFAULT_TIMEOUT);
+    } else {
+      await waitFor(element(by.nativeId(getId(BugReportingNativeIds.SUCCESS_POPUP_MSG)))).toBeVisible().withTimeout(DEFAULT_TIMEOUT);
+    }
+  });
+});

--- a/InstabugSample/__e2e__/bug-reporting/report-bug.spec.js
+++ b/InstabugSample/__e2e__/bug-reporting/report-bug.spec.js
@@ -10,7 +10,7 @@ describe('Bug Reporting', () => {
     await ReactNativeActions.checkRnSanity();
 
     // Invoke Prompt Options
-    await ReactNativeActions.tapOnInvokeBtn();
+    await InstabugNativeActions.tapOnFloatingBtn();
 
     // Tap on Report a Bug option
     await InstabugNativeActions.tapOnBugPromptOption();

--- a/InstabugSample/__e2e__/bug-reporting/test-data.js
+++ b/InstabugSample/__e2e__/bug-reporting/test-data.js
@@ -1,0 +1,3 @@
+export default {
+  email: 'rn_e2e@instabug.com',
+};

--- a/InstabugSample/__e2e__/firstTest.spec.js
+++ b/InstabugSample/__e2e__/firstTest.spec.js
@@ -1,9 +1,0 @@
-describe('Example', () => {
-  beforeEach(async () => {
-    await device.reloadReactNative();
-  });
-
-  it('should have welcome screen', async () => {
-    await expect(element(by.id('welcome'))).toBeVisible();
-  });
-});

--- a/InstabugSample/__e2e__/init.js
+++ b/InstabugSample/__e2e__/init.js
@@ -16,6 +16,10 @@ beforeAll(async () => {
 });
 
 beforeEach(async () => {
+  if (device === undefined) {
+    await detox.init(config);
+  }
+  await device.launchApp({newInstance: true});
   await adapter.beforeEach();
 });
 

--- a/InstabugSample/__e2e__/init.js
+++ b/InstabugSample/__e2e__/init.js
@@ -16,7 +16,7 @@ beforeAll(async () => {
 });
 
 beforeEach(async () => {
-  if (device === undefined) {
+  if (typeof(device) == 'undefined') {
     await detox.init(config);
   }
   await device.launchApp({newInstance: true});

--- a/InstabugSample/__e2e__/instabug/invoke-prompt-options.spec.js
+++ b/InstabugSample/__e2e__/instabug/invoke-prompt-options.spec.js
@@ -10,15 +10,20 @@ describe('Invoking Prompt Options', () => {
   });
   
   it('should show instabug prompt options when calling Instabug.show()', async () => {
+    let promptOption;
+
     // Action
     await ReactNativeActions.tapOnInvokeBtn();
     
     // Expectation
-    await waitFor(element(by.nativeId(getId(InstabugNativeIds.PROMPT_TITLE)))).toBeVisible().withTimeout(DEFAULT_TIMEOUT);
-    await expect(element(by.nativeId(getId(InstabugNativeIds.PROMPT_TITLE)))).toBeVisible();
+    promptOption = element(by.nativeId(getId(InstabugNativeIds.PROMPT_TITLE)));
+    await waitFor(promptOption).toBeVisible().withTimeout(DEFAULT_TIMEOUT);
+    await expect(promptOption).toBeVisible();
   });
 
   it('should show instabug prompt options when tapping the floating button', async () => {
+    let promptOption;
+
     // Prepare
     await ReactNativeActions.tapOnEnableFloatingBtn();
 
@@ -26,18 +31,22 @@ describe('Invoking Prompt Options', () => {
     await InstabugNativeActions.tapOnFloatingBtn();
     
     // Expectation
-    await waitFor(element(by.nativeId(getId(InstabugNativeIds.PROMPT_TITLE)))).toBeVisible().withTimeout(DEFAULT_TIMEOUT);
-    await expect(element(by.nativeId(getId(InstabugNativeIds.PROMPT_TITLE)))).toBeVisible();
+    promptOption = element(by.nativeId(getId(InstabugNativeIds.PROMPT_TITLE)));
+    await waitFor(promptOption).toBeVisible().withTimeout(DEFAULT_TIMEOUT);
+    await expect(promptOption).toBeVisible();
   });
 
   it('[iOS_Only] should show instabug prompt options when shaking the device', async () => {
+    let promptOption;
+
     if (device.getPlatform() === 'ios') {
       // Action
       await device.shake();
 
       // Expectation
-      await waitFor(element(by.nativeId(getId(InstabugNativeIds.PROMPT_TITLE)))).toBeVisible().withTimeout(DEFAULT_TIMEOUT);
-      await expect(element(by.nativeId(getId(InstabugNativeIds.PROMPT_TITLE)))).toBeVisible();
+      promptOption = element(by.nativeId(getId(InstabugNativeIds.PROMPT_TITLE)));
+      await waitFor(promptOption).toBeVisible().withTimeout(DEFAULT_TIMEOUT);
+      await expect(promptOption).toBeVisible();
     }
   });
 });

--- a/InstabugSample/__e2e__/instabug/invoke-prompt-options.spec.js
+++ b/InstabugSample/__e2e__/instabug/invoke-prompt-options.spec.js
@@ -1,0 +1,40 @@
+import { getId } from '../utilities/native-utility';
+import { NativeActions as InstabugNativeActions, NativeIds as InstabugNativeIds } from './native-actions';
+import { ReactNativeActions } from '../utilities/rn-utility';
+import { DEFAULT_TIMEOUT } from '../utilities/settings';
+
+describe('Invoking Prompt Options', () => {
+  it('should show the app main view', async () => {
+    // RN Sanity
+    await ReactNativeActions.checkRnSanity();
+  });
+  
+  it('should show instabug prompt options when calling Instabug.show()', async () => {
+    // Action
+    await ReactNativeActions.tapOnInvokeBtn();
+    
+    // Expectation
+    await waitFor(element(by.nativeId(getId(InstabugNativeIds.PROMPT_TITLE)))).toBeVisible().withTimeout(DEFAULT_TIMEOUT);
+  });
+
+  it('should show instabug prompt options when tapping the floating button', async () => {
+    // Prepare
+    await ReactNativeActions.tapOnEnableFloatingBtn();
+
+    // Action
+    await InstabugNativeActions.tapOnFloatingBtn();
+    
+    // Expectation
+    await waitFor(element(by.nativeId(getId(InstabugNativeIds.PROMPT_TITLE)))).toBeVisible().withTimeout(DEFAULT_TIMEOUT);
+  });
+
+  it('[iOS_Only] should show instabug prompt options when shaking the device', async () => {
+    if (device.getPlatform() === 'ios') {
+      // Action
+      await device.shake();
+
+      // Expectation
+      await waitFor(element(by.nativeId(getId(InstabugNativeIds.PROMPT_TITLE)))).toBeVisible().withTimeout(DEFAULT_TIMEOUT);
+    }
+  });
+});

--- a/InstabugSample/__e2e__/instabug/invoke-prompt-options.spec.js
+++ b/InstabugSample/__e2e__/instabug/invoke-prompt-options.spec.js
@@ -15,6 +15,7 @@ describe('Invoking Prompt Options', () => {
     
     // Expectation
     await waitFor(element(by.nativeId(getId(InstabugNativeIds.PROMPT_TITLE)))).toBeVisible().withTimeout(DEFAULT_TIMEOUT);
+    await expect(element(by.nativeId(getId(InstabugNativeIds.PROMPT_TITLE)))).toBeVisible();
   });
 
   it('should show instabug prompt options when tapping the floating button', async () => {
@@ -26,6 +27,7 @@ describe('Invoking Prompt Options', () => {
     
     // Expectation
     await waitFor(element(by.nativeId(getId(InstabugNativeIds.PROMPT_TITLE)))).toBeVisible().withTimeout(DEFAULT_TIMEOUT);
+    await expect(element(by.nativeId(getId(InstabugNativeIds.PROMPT_TITLE)))).toBeVisible();
   });
 
   it('[iOS_Only] should show instabug prompt options when shaking the device', async () => {
@@ -35,6 +37,7 @@ describe('Invoking Prompt Options', () => {
 
       // Expectation
       await waitFor(element(by.nativeId(getId(InstabugNativeIds.PROMPT_TITLE)))).toBeVisible().withTimeout(DEFAULT_TIMEOUT);
+      await expect(element(by.nativeId(getId(InstabugNativeIds.PROMPT_TITLE)))).toBeVisible();
     }
   });
 });

--- a/InstabugSample/__e2e__/instabug/native-actions.js
+++ b/InstabugSample/__e2e__/instabug/native-actions.js
@@ -1,4 +1,5 @@
 import { getId } from '../utilities/native-utility';
+import { DEFAULT_TIMEOUT } from '../utilities/settings';
 
 export const NativeIds = {
   PROMPT_TITLE: {
@@ -17,10 +18,12 @@ export const NativeIds = {
 
 export const NativeActions = {
   async tapOnFloatingBtn() {
-    await element(by.nativeId(getId(NativeIds.FLOATING_BUTTON))).tap();
+    const floatingBtn = element(by.nativeId(getId(NativeIds.FLOATING_BUTTON)));
+    await waitFor(floatingBtn).toBeVisible().withTimeout(DEFAULT_TIMEOUT);
+    await floatingBtn.tap();
   },
   async tapOnBugPromptOption() {
-    var promptOption;
+    let promptOption;
 
     if (device.getPlatform() === 'ios') {
       // iOS has a unique id for each prompt option.
@@ -31,6 +34,7 @@ export const NativeActions = {
       promptOption = element(by.nativeId(getId(NativeIds.PROMPT_OPTION_BUG)).and(by.text('Report a bug')));
     }
 
+    await waitFor(promptOption).toBeVisible().withTimeout(DEFAULT_TIMEOUT);
     await promptOption.tap();
   },
 };

--- a/InstabugSample/__e2e__/instabug/native-actions.js
+++ b/InstabugSample/__e2e__/instabug/native-actions.js
@@ -1,0 +1,36 @@
+import { getId } from '../utilities/native-utility';
+
+export const NativeIds = {
+  PROMPT_TITLE: {
+    IOS: 'IBGPromptVCHeaderAccessibilityIdentifier',
+    ANDROID: 'instabug_fragment_title',
+  },
+  FLOATING_BUTTON: {
+    IOS: 'IBGFloatingButtonAccessibilityIdentifier',
+    ANDROID: 'instabug_floating_button',
+  },
+  PROMPT_OPTION_BUG: {
+    IOS: 'IBGReportBugPromptOptionAccessibilityIdentifier',
+    ANDROID: 'instabug_prompt_option_title',
+  },
+};
+
+export const NativeActions = {
+  async tapOnFloatingBtn() {
+    await element(by.nativeId(getId(NativeIds.FLOATING_BUTTON))).tap();
+  },
+  async tapOnBugPromptOption() {
+    var promptOption;
+
+    if (device.getPlatform() === 'ios') {
+      // iOS has a unique id for each prompt option.
+      promptOption = element(by.nativeId(getId(NativeIds.PROMPT_OPTION_BUG)));
+    } else {
+      // Android has a list with identical IDs for all prompt options,
+      // so we're matching with text as a second factor for the sake of targetting the correct item.
+      promptOption = element(by.nativeId(getId(NativeIds.PROMPT_OPTION_BUG)).and(by.text('Report a bug')));
+    }
+
+    await promptOption.tap();
+  },
+};

--- a/InstabugSample/__e2e__/utilities/native-utility.js
+++ b/InstabugSample/__e2e__/utilities/native-utility.js
@@ -1,0 +1,10 @@
+export function getId(idObj) {
+  if (device.getPlatform() === 'ios') {
+    return idObj.IOS;
+  }
+  return idObj.ANDROID;
+}
+
+export default {
+  getId,
+};

--- a/InstabugSample/__e2e__/utilities/rn-utility.js
+++ b/InstabugSample/__e2e__/utilities/rn-utility.js
@@ -1,0 +1,17 @@
+export const ReactNativeIds = {
+  APP_MAIN_VIEW: 'appMainView',
+  INVOKE_BTN: 'invokeBtn',
+  ENABLE_FLOATING_BTN: 'enableFloatingBtnVisibilityBtn',
+};
+
+export const ReactNativeActions = {
+  async checkRnSanity() {
+    await expect(element(by.id(ReactNativeIds.APP_MAIN_VIEW))).toBeVisible();
+  },
+  async tapOnInvokeBtn() {
+    await element(by.id(ReactNativeIds.INVOKE_BTN)).tap();
+  },
+  async tapOnEnableFloatingBtn() {
+    await element(by.id(ReactNativeIds.ENABLE_FLOATING_BTN)).tap();
+  },
+};

--- a/InstabugSample/__e2e__/utilities/rn-utility.js
+++ b/InstabugSample/__e2e__/utilities/rn-utility.js
@@ -1,3 +1,5 @@
+import { DEFAULT_TIMEOUT } from './settings';
+
 export const ReactNativeIds = {
   APP_MAIN_VIEW: 'appMainView',
   INVOKE_BTN: 'invokeBtn',
@@ -6,12 +8,21 @@ export const ReactNativeIds = {
 
 export const ReactNativeActions = {
   async checkRnSanity() {
-    await expect(element(by.id(ReactNativeIds.APP_MAIN_VIEW))).toBeVisible();
+    const appMainView = element(by.id(ReactNativeIds.APP_MAIN_VIEW));
+
+    await waitFor(appMainView).toBeVisible().withTimeout(DEFAULT_TIMEOUT);
+    await expect(appMainView).toBeVisible();
   },
   async tapOnInvokeBtn() {
-    await element(by.id(ReactNativeIds.INVOKE_BTN)).tap();
+    const invokeBtn = element(by.id(ReactNativeIds.INVOKE_BTN));
+
+    await waitFor(invokeBtn).toBeVisible().withTimeout(DEFAULT_TIMEOUT);
+    await invokeBtn.tap();
   },
   async tapOnEnableFloatingBtn() {
-    await element(by.id(ReactNativeIds.ENABLE_FLOATING_BTN)).tap();
+    const enableFloatingBtn = element(by.id(ReactNativeIds.ENABLE_FLOATING_BTN));
+
+    await waitFor(enableFloatingBtn).toBeVisible().withTimeout(DEFAULT_TIMEOUT);
+    await enableFloatingBtn.tap();
   },
 };

--- a/InstabugSample/__e2e__/utilities/settings.js
+++ b/InstabugSample/__e2e__/utilities/settings.js
@@ -1,0 +1,5 @@
+export const DEFAULT_TIMEOUT = 10000;
+
+export default {
+  DEFAULT_TIMEOUT,
+};

--- a/InstabugSample/__e2e__/utilities/settings.js
+++ b/InstabugSample/__e2e__/utilities/settings.js
@@ -1,4 +1,4 @@
-export const DEFAULT_TIMEOUT = 10000;
+export const DEFAULT_TIMEOUT = 20000;
 
 export default {
   DEFAULT_TIMEOUT,

--- a/InstabugSample/android/app/build.gradle
+++ b/InstabugSample/android/app/build.gradle
@@ -180,7 +180,7 @@ dependencies {
 
     // Detox
     implementation "androidx.annotation:annotation:1.1.0"
-    androidTestImplementation('com.wix:detox:+') { transitive = true }
+    androidTestImplementation(project(path: ":detox"))
     androidTestImplementation 'junit:junit:4.12'
 }
 

--- a/InstabugSample/android/app/src/main/java/com/instabugsample/MainApplication.java
+++ b/InstabugSample/android/app/src/main/java/com/instabugsample/MainApplication.java
@@ -1,18 +1,24 @@
 package com.instabugsample;
 
 import android.app.Application;
+import android.content.Context;
+
+import androidx.multidex.MultiDex;
+import androidx.multidex.MultiDexApplication;
 
 import com.facebook.react.PackageList;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.soloader.SoLoader;
+import com.instabug.library.Instabug;
+import com.instabug.library.ui.onboarding.WelcomeMessage;
 import com.instabug.reactlibrary.RNInstabugReactnativePackage;
 
 
 import java.util.List;
 
-public class MainApplication extends Application implements ReactApplication {
+public class MainApplication extends MultiDexApplication implements ReactApplication {
 
   private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
     @Override
@@ -49,6 +55,13 @@ public class MainApplication extends Application implements ReactApplication {
             .setFloatingEdge("left")
             .setFloatingButtonOffsetFromTop(250)
             .build();
+    Instabug.setWelcomeMessageState(WelcomeMessage.State.DISABLED);
     SoLoader.init(this, /* native exopackage */ false);
   }
+//
+//  @Override
+//  protected void attachBaseContext(Context base) {
+//    super.attachBaseContext(base);
+//    MultiDex.install(this);
+//  }
 }

--- a/InstabugSample/android/build.gradle
+++ b/InstabugSample/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         compileSdkVersion = 29
         targetSdkVersion = 28
         supportLibVersion = "28.0.0"
-        kotlinVersion = '1.3.10'
+        kotlinVersion = '1.3.61'
     }
     repositories {
         google()

--- a/InstabugSample/android/gradle/wrapper/gradle-wrapper.properties
+++ b/InstabugSample/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,3 +1,4 @@
+#Mon Oct 28 14:10:59 EET 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/InstabugSample/android/settings.gradle
+++ b/InstabugSample/android/settings.gradle
@@ -1,3 +1,5 @@
 rootProject.name = 'InstabugSample'
 apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
 include ':app'
+include ':detox'
+project(':detox').projectDir = new File(rootProject.projectDir, '../node_modules/detox/android/detox')

--- a/InstabugSample/package.json
+++ b/InstabugSample/package.json
@@ -16,10 +16,11 @@
     "@babel/core": "^7.5.4",
     "@babel/runtime": "^7.5.4",
     "@react-native-community/eslint-config": "^0.0.5",
-    "babel-jest": "^24.8.0",
-    "detox": "^13.2.0",
+    "babel-jest": "^24.9.0",
+    "detox": "Instabug/Detox#build/13.3.3-native-id",
     "eslint": "^6.0.1",
-    "jest": "^24.8.0",
+    "jest": "^24.9.0",
+    "jetifier": "^1.6.4",
     "metro-react-native-babel-preset": "^0.55.0",
     "react-test-renderer": "16.8.6"
   },
@@ -37,27 +38,25 @@
         "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/InstabugSample.app",
         "build": "xcodebuild -workspace ios/InstabugSample.xcworkspace -scheme InstabugSample -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build",
         "type": "ios.simulator",
-        "name": "iPhone X"
+        "name": "iPhone Xʀ"
       },
       "ios.sim.release": {
         "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/InstabugSample.app",
         "build": "xcodebuild -workspace ios/InstabugSample.xcworkspace -scheme InstabugSample -configuration Release -sdk iphonesimulator -derivedDataPath ios/build",
         "type": "ios.simulator",
-        "name": "iPhone X"
+        "name": "iPhone Xʀ"
       },
       "android.emu.debug": {
         "binaryPath": "android/app/build/outputs/apk/debug/app-debug.apk",
-        "build":
-        "cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug && cd ..",
+        "build": "cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug && cd ..",
         "type": "android.emulator",
-        "name": "Pixel_3_API_28"
+        "name": "Nexus_9_API_27"
       },
       "android.emu.release": {
         "binaryPath": "android/app/build/outputs/apk/release/app-release.apk",
-        "build":
-        "cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release && cd ..",
+        "build": "cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release && cd ..",
         "type": "android.emulator",
-        "name": "Nexus_6P_API_27"
+        "name": "Nexus_9_API_27"
       }
     }
   }

--- a/InstabugSample/package.json
+++ b/InstabugSample/package.json
@@ -50,13 +50,13 @@
         "binaryPath": "android/app/build/outputs/apk/debug/app-debug.apk",
         "build": "cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug && cd ..",
         "type": "android.emulator",
-        "name": "Pixel_2_XL_API_27"
+        "name": "Nexus_9_API_27"
       },
       "android.emu.release": {
         "binaryPath": "android/app/build/outputs/apk/release/app-release.apk",
         "build": "cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release && cd ..",
         "type": "android.emulator",
-        "name": "Pixel_2_XL_API_27"
+        "name": "Nexus_9_API_27"
       }
     }
   }

--- a/InstabugSample/package.json
+++ b/InstabugSample/package.json
@@ -50,13 +50,13 @@
         "binaryPath": "android/app/build/outputs/apk/debug/app-debug.apk",
         "build": "cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug && cd ..",
         "type": "android.emulator",
-        "name": "Nexus_9_API_27"
+        "name": "Pixel_2_XL_API_27"
       },
       "android.emu.release": {
         "binaryPath": "android/app/build/outputs/apk/release/app-release.apk",
         "build": "cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release && cd ..",
         "type": "android.emulator",
-        "name": "Nexus_9_API_27"
+        "name": "Pixel_2_XL_API_27"
       }
     }
   }

--- a/InstabugSample/package.json
+++ b/InstabugSample/package.json
@@ -50,13 +50,13 @@
         "binaryPath": "android/app/build/outputs/apk/debug/app-debug.apk",
         "build": "cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug && cd ..",
         "type": "android.emulator",
-        "name": "Nexus_9_API_27"
+        "name": "Pixel_API_27"
       },
       "android.emu.release": {
         "binaryPath": "android/app/build/outputs/apk/release/app-release.apk",
         "build": "cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release && cd ..",
         "type": "android.emulator",
-        "name": "Nexus_9_API_27"
+        "name": "Pixel_API_27"
       }
     }
   }

--- a/InstabugSample/yarn.lock
+++ b/InstabugSample/yarn.lock
@@ -1188,7 +1188,7 @@ babel-eslint@10.0.1:
     eslint-scope "3.7.1"
     eslint-visitor-keys "^1.0.0"
 
-babel-jest@^24.8.0, babel-jest@^24.9.0:
+babel-jest@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-24.9.0.tgz#3fc327cb8467b89d14d7bc70e315104a783ccd54"
   dependencies:
@@ -1813,9 +1813,9 @@ detect-newline@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
 
-detox@^13.2.0:
+detox@Instabug/Detox#build/13.3.3-native-id:
   version "13.3.3"
-  resolved "https://registry.yarnpkg.com/detox/-/detox-13.3.3.tgz#caef4e14f9a5021207f88f4960d092afd9703a1e"
+  resolved "https://codeload.github.com/Instabug/Detox/tar.gz/dcef7a07890e23ec47558fa96cc60d8e193de816"
   dependencies:
     "@babel/core" "^7.4.5"
     bunyan "^1.8.12"
@@ -3309,14 +3309,14 @@ jest-worker@^24.6.0, jest-worker@^24.9.0:
     merge-stream "^2.0.0"
     supports-color "^6.1.0"
 
-jest@^24.8.0:
+jest@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest/-/jest-24.9.0.tgz#987d290c05a08b52c56188c1002e368edb007171"
   dependencies:
     import-local "^2.0.0"
     jest-cli "^24.9.0"
 
-jetifier@^1.6.2:
+jetifier@^1.6.2, jetifier@^1.6.4:
   version "1.6.4"
   resolved "https://registry.yarnpkg.com/jetifier/-/jetifier-1.6.4.tgz#6159db8e275d97980d26162897a0648b6d4a3222"
 


### PR DESCRIPTION
### What's done?
- Updated CI config for e2e automation on Android.
- Added UI tests for Instabug invocation and for submitting a bug report.

### Devices and SDKs:
- Runs on Nexus 9 with Android SDK 27.
- Runs on iPhone XR with iOS 12.2.

### Use Artifacts for failed tests:
<img width="1373" alt="Screen Shot 2019-11-04 at 15 58 16" src="https://user-images.githubusercontent.com/10587548/68126342-3da68080-ff1c-11e9-8dd5-57ba95e37a22.png">

### Known Issues:
- **Error while running `detox test ..` command:** `ReferenceError: device is not defined` happens randomly. **Solution:** restart the test.
- **Error while running `yarn` command:** `Error: Command failed: /Users/distiller/project/InstabugSample/node_modules/detox/scripts/build_framework.ios.sh` happens randomly on iOS. **Solution:** restart the test.
- System UI is not responding on Android.