### PR TITLE
Fix relative path for ios/upload_sourcemap.sh

### DIFF
--- a/ios/upload_sourcemap.sh
+++ b/ios/upload_sourcemap.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 cd ..
-cd ..
-cd ..
 if [[ -s "$HOME/.nvm/nvm.sh" ]]; then
 . "$HOME/.nvm/nvm.sh"
 elif [[ -x "$(command -v brew)" && -s "$(brew --prefix nvm)/nvm.sh" ]]; then


### PR DESCRIPTION
Currently, the Upload Sourcemap phase fails silently on iOS react native