### PR TITLE
Fix/main views title locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 * Fixes the automatic uploading of the source map files in some cases due to incorrect regex.
+* Add a new string reportQuestion to replace the deprecated string startChats.
 
 ## v8.7.1 (2019-10-02)
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,7 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api('com.instabug.library:instabug:8.7.0.0') {
+    api('com.instabug.library:instabug:8.7.0.3') {
         exclude group: 'com.android.support:appcompat-v7'
     }
     testImplementation 'org.mockito:mockito-core:1.10.19'

--- a/android/src/main/java/com/instabug/reactlibrary/ArgsRegistry.java
+++ b/android/src/main/java/com/instabug/reactlibrary/ArgsRegistry.java
@@ -171,6 +171,7 @@ final class ArgsRegistry {
         args.put("invalidCommentMessage", InstabugCustomTextPlaceHolder.Key.INVALID_COMMENT_MESSAGE);
         args.put("invocationHeader", InstabugCustomTextPlaceHolder.Key.INVOCATION_HEADER);
         args.put("startChats", InstabugCustomTextPlaceHolder.Key.START_CHATS);
+        args.put("reportQuestion", InstabugCustomTextPlaceHolder.Key.REPORT_QUESTION);
         args.put("reportBug", InstabugCustomTextPlaceHolder.Key.REPORT_BUG);
         args.put("reportFeedback", InstabugCustomTextPlaceHolder.Key.REPORT_FEEDBACK);
         args.put("emailFieldHint", InstabugCustomTextPlaceHolder.Key.EMAIL_FIELD_HINT);
@@ -183,8 +184,6 @@ final class ArgsRegistry {
         args.put("conversationsListTitle", InstabugCustomTextPlaceHolder.Key.CONVERSATIONS_LIST_TITLE);
         args.put("audioRecordingPermissionDenied", InstabugCustomTextPlaceHolder.Key.AUDIO_RECORDING_PERMISSION_DENIED);
         args.put("conversationTextFieldHint", InstabugCustomTextPlaceHolder.Key.CONVERSATION_TEXT_FIELD_HINT);
-//        args.put("bugReportHeader", InstabugCustomTextPlaceHolder.Key.BUG_REPORT_HEADER);
-//        args.put("feedbackReportHeader", InstabugCustomTextPlaceHolder.Key.FEEDBACK_REPORT_HEADER);
         args.put("voiceMessagePressAndHoldToRecord", InstabugCustomTextPlaceHolder.Key.VOICE_MESSAGE_PRESS_AND_HOLD_TO_RECORD);
         args.put("voiceMessageReleaseToAttach", InstabugCustomTextPlaceHolder.Key.VOICE_MESSAGE_RELEASE_TO_ATTACH);
         args.put("reportSuccessfullySent", InstabugCustomTextPlaceHolder.Key.REPORT_SUCCESSFULLY_SENT);

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
@@ -158,6 +158,7 @@ public class RNInstabugReactnativeModule extends ReactContextBaseJavaModule {
 
     private final String INVOCATION_HEADER = "invocationHeader";
     private final String START_CHATS = "startChats";
+    private final String REPORT_QUESTION = "reportQuestion";
     private final String REPORT_BUG = "reportBug";
     private final String REPORT_FEEDBACK = "reportFeedback";
 
@@ -2264,6 +2265,8 @@ public class RNInstabugReactnativeModule extends ReactContextBaseJavaModule {
                 return InstabugCustomTextPlaceHolder.Key.INVOCATION_HEADER;
             case START_CHATS:
                 return InstabugCustomTextPlaceHolder.Key.START_CHATS;
+            case REPORT_QUESTION:
+                return InstabugCustomTextPlaceHolder.Key.REPORT_QUESTION;
             case REPORT_BUG:
                 return InstabugCustomTextPlaceHolder.Key.REPORT_BUG;
             case REPORT_FEEDBACK:
@@ -2454,6 +2457,7 @@ public class RNInstabugReactnativeModule extends ReactContextBaseJavaModule {
         constants.put("commentFieldHintForQuestion", COMMENT_FIELD_HINT_FOR_QUESTION);
         constants.put("invocationHeader", INVOCATION_HEADER);
         constants.put("startChats", START_CHATS);
+        constants.put("reportQuestion", REPORT_QUESTION);
         constants.put("reportBug", REPORT_BUG);
         constants.put("reportFeedback", REPORT_FEEDBACK);
         constants.put("conversationsHeaderTitle", CONVERSATIONS_LIST_TITLE);

--- a/index.d.ts
+++ b/index.d.ts
@@ -293,6 +293,7 @@ export enum strings {
   invalidCommentTitle,
   invocationHeader,
   talkToUs,
+  reportQuestion,
   reportBug,
   reportFeedback,
   emailFieldHint,

--- a/index.js
+++ b/index.js
@@ -919,6 +919,7 @@ const InstabugModule = {
     invalidCommentTitle: Instabug.invalidCommentTitle,
     invocationHeader: Instabug.invocationHeader,
     startChats: Instabug.startChats,
+    reportQuestion: Instabug.reportQuestion,
     reportBug: Instabug.reportBug,
     reportFeedback: Instabug.reportFeedback,
     emailFieldHint: Instabug.emailFieldHint,

--- a/ios/RNInstabug/InstabugReactBridge.m
+++ b/ios/RNInstabug/InstabugReactBridge.m
@@ -476,6 +476,7 @@ RCT_EXPORT_METHOD(show) {
               @"invocationHeader": kIBGInvocationTitleStringName,
               //@"talkToUs": kIBGTalkToUsStringName,
               @"startChats": kIBGAskAQuestionStringName,
+              @"reportQuestion": kIBGAskAQuestionStringName,
               @"reportBug": kIBGReportBugStringName,
               @"reportFeedback": kIBGReportFeedbackStringName,
               @"emailFieldHint": kIBGEmailFieldPlaceholderStringName,


### PR DESCRIPTION
- Adds a new string `reportQuestion` to replace `startChats` which is now deprecated on Android.
- Adds a fix for locales from the Android side.