### PR TITLE
`BugReporting.setViewHierarchyEnabled` Hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v8.7.3 (2019-11-14)
+
+* Fixes `BugReporting.setViewHierarchyEnabled` crashing on iOS.
+
 ## v8.7.2 (2019-11-05)
 
 * Fixes the automatic uploading of the source map files in some cases due to incorrect regex.

--- a/InstabugSample/ios/InstabugSampleTests/InstabugBugReportingTests.m
+++ b/InstabugSample/ios/InstabugSampleTests/InstabugBugReportingTests.m
@@ -173,7 +173,7 @@
 
 - (void) testgivenBoolean$setViewHierarchyEnabled_whenQuery_thenShouldCallNativeApi {
   BOOL enabled = true;
-  [self.instabugBridge setViewHirearchyEnabled:enabled];
+  [self.instabugBridge setViewHierarchyEnabled:enabled];
   XCTAssertTrue(IBGBugReporting.shouldCaptureViewHierarchy);
 }
 

--- a/ios/RNInstabug/InstabugBugReportingBridge.h
+++ b/ios/RNInstabug/InstabugBugReportingBridge.h
@@ -45,6 +45,6 @@
 
 - (void)setAutoScreenRecordingMaxDuration:(CGFloat)duration;
 
-- (void)setViewHirearchyEnabled:(BOOL)viewHirearchyEnabled;
+- (void)setViewHierarchyEnabled:(BOOL)viewHirearchyEnabled;
 
 @end

--- a/ios/RNInstabug/InstabugBugReportingBridge.m
+++ b/ios/RNInstabug/InstabugBugReportingBridge.m
@@ -162,7 +162,7 @@ RCT_EXPORT_METHOD(setEnabledAttachmentTypes:(BOOL)screenShot
     IBGBugReporting.enabledAttachmentTypes = attachmentTypes;
 }
 
-RCT_EXPORT_METHOD(setViewHirearchyEnabled:(BOOL)viewHirearchyEnabled) {
+RCT_EXPORT_METHOD(setViewHierarchyEnabled:(BOOL)viewHirearchyEnabled) {
     IBGBugReporting.shouldCaptureViewHierarchy = viewHirearchyEnabled;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instabug-reactnative",
-  "version": "8.7.2",
+  "version": "8.7.3",
   "description": "React Native plugin for integrating the Instabug SDK",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
* Fixes `BugReporting.setViewHierarchyEnabled` crashing on iOS due to a typo