### PR TITLE
🐛 Fix version name uploading on Android [INSD-3904]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v9.1.1 (2020-04-06)
+
+* Fixes an issue with the version name while uploading the sourcemap on Android.
+
 ## v9.1.0 (2020-03-19)
 
 * Bump Native SDKs to v9.1

--- a/android/upload_sourcemap.sh
+++ b/android/upload_sourcemap.sh
@@ -25,7 +25,7 @@ else
             exit 0
         fi
     fi
-    if [ ! "${INSTABUG_APP_VERSION_CODE}" ] || [ -z "${INSTABUG_APP_VERSION_CODE}" ]; then
+    if [ ! "${INSTABUG_APP_VERSION_NAME}" ] || [ -z "${INSTABUG_APP_VERSION_NAME}" ]; then
          INSTABUG_APP_VERSION_NAME=$(grep "versionName" android/app/build.gradle | awk '{print $2}' | tr -d \''"\')
         if [ ! "${INSTABUG_APP_VERSION_NAME}" ] || [ -z "${INSTABUG_APP_VERSION_NAME}" ]; then
         echo "versionName could not be found, please upload the sourcemap files manually"
@@ -34,6 +34,8 @@ else
     fi
     VERSION='{"code":"'"$INSTABUG_APP_VERSION_CODE"'","name":"'"$INSTABUG_APP_VERSION_NAME"'"}'
     echo "Instabug: Token found" "\""${INSTABUG_APP_TOKEN}"\""
+    echo "Instabug: Version Code found" "\""${INSTABUG_APP_VERSION_CODE}"\""
+    echo "Instabug: Version Name found" "\""${INSTABUG_APP_VERSION_NAME}"\""
     echo "Instabug: Generating sourcemap files..."
     IS_HERMES=$(grep "enableHermes:" ./android/app/build.gradle)
     if [[ $IS_HERMES == *"true"* ]]; then

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instabug-reactnative",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "description": "React Native plugin for integrating the Instabug SDK",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
https://instabug.atlassian.net/browse/INSD-3904

Fixes a typo in `upload_sourcemap.sh` that caused the version name not to be uploaded.

<img width="1162" alt="Screenshot" src="https://user-images.githubusercontent.com/10587548/78550349-37d30500-7804-11ea-8c95-71d71c47e9fe.png">
