### PR TITLE
[WIP][Refactor] Network Logging

### DIFF
--- a/utils/NetworkLogManager.js
+++ b/utils/NetworkLogManager.js
@@ -1,0 +1,122 @@
+'use strict';
+
+const INITIAL_LOG_ATTRS = {
+  method: '',
+  url: '',
+  requestHeaders: {},
+};
+
+const COMPLEMENTARY_LOG_ATTRS = {
+  requestBody: '',
+  responseHeaders: {},
+  responseBody: '',
+  responseCode: 0,
+  contentType: '',
+  duration: 0,
+  start: 0
+};
+
+let initialLoggedData = {};
+
+return {
+  resetInitialLoggedData,
+  logRequestMethod,
+  logRequestUrl,
+  logRequestHeader,
+  createNetworkLogInstance,
+};
+
+function resetInitialLoggedData() {
+  initialLoggedData = { ...INITIAL_LOG_ATTRS };
+}
+
+function logRequestMethod({ method }) {
+  initialLoggedData.method = method;
+}
+
+function logRequestUrl({ url }) {
+  initialLoggedData.url = url;
+}
+
+function logRequestHeader({ header, value }) {
+  if (!initialLoggedData.requestHeaders) {
+    initialLoggedData.requestHeaders = {};
+  }
+  initialLoggedData.requestHeaders[header] = value;
+}
+
+function createNetworkLogInstance() {
+  let networkLogInstance = {
+    ...JSON.parse(JSON.stringify(initialLoggedData)),
+    ...COMPLEMENTARY_LOG_ATTRS,
+  };
+
+  return {
+    logRequestBody: _logRequestBody.bind(networkLogInstance),
+    logResponseHeaders: _logResponseHeaders.bind(networkLogInstance),
+    logStartTime: _logStartTime.bind(networkLogInstance),
+    logDuration: _logDuration.bind(networkLogInstance),
+    logResponseCode: _logResponseCode.bind(networkLogInstance),
+    logResponseBody: _logResponseBody.bind(networkLogInstance),
+  };
+}
+
+
+function _logRequestBody(requestBody) {
+  const networkLogInstance = this;
+  networkLogInstance.requestBody = requestBody ? requestBody : '';
+}
+
+function _logResponseHeaders(interceptedRequest) {
+  const networkLogInstance = this;
+  const contentTypeString = interceptedRequest.getResponseHeader('Content-Type');
+
+  if (contentTypeString) {
+    networkLogInstance.contentType = contentTypeString.split(';')[0];
+  }
+    
+  if (interceptedRequest.getAllResponseHeaders()) {
+    const responseHeaders = interceptedRequest.getAllResponseHeaders().split('\r\n');
+    const responseHeadersDictionary = {};
+
+    responseHeaders.forEach(element => {
+      const key = element.split(':')[0];
+      const value = element.split(':')[1];
+      responseHeadersDictionary[key] = value;
+    });
+
+    networkLogInstance.responseHeaders = responseHeadersDictionary;
+  }
+}
+
+function _logStartTime() {
+  const networkLogInstance = this;
+  networkLogInstance.start = Date.now();
+}
+
+function _logDuration() {
+  const networkLogInstance = this;
+  networkLogInstance.duration = (Date.now() - networkLogInstance.start);
+}
+
+function _logResponseCode(interceptedRequest) {
+  const networkLogInstance = this;
+  networkLogInstance.responseCode = interceptedRequest.status ? interceptedRequest.status : 0;
+}
+
+function _logResponseBody (interceptedRequest) {
+  const networkLogInstance = this;
+
+  if (interceptedRequest.response) {
+    if (interceptedRequest.responseType === 'blob') {
+      const responseBody = await (new Response(interceptedRequest.response)).text();
+      networkLogInstance.responseBody = responseBody;
+    } else if (interceptedRequest.responseType === 'text') {
+      networkLogInstance.responseBody = interceptedRequest.response;
+    }
+  }
+
+  if (interceptedRequest._hasError) {
+    networkLogInstance.requestBody = interceptedRequest._response;
+  }
+}

--- a/utils/XhrNetworkInterceptor.js
+++ b/utils/XhrNetworkInterceptor.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import NetworkLogManager from './NetworkLogManager';
+
 const XMLHttpRequest = global.XMLHttpRequest;
 const _xhrDefaultOpen = XMLHttpRequest.prototype.open;
 const _xhrDefaultSend = XMLHttpRequest.prototype.send;
@@ -8,7 +10,6 @@ const _xhrDefaultSetRequestHeader = XMLHttpRequest.prototype.setRequestHeader;
 let onProgressCallback;
 let onDoneCallback;
 let isInterceptorEnabled = false;
-let loggedNetworkData;
 
 const enableInterception = () => {
   isInterceptorEnabled = true;
@@ -37,22 +38,22 @@ const setOnProgressCallback = (callback) => {
 };
 
 function _xhrInterceptorOpen(method, url) {
-  _resetLoggedNetworkData();
-  _logRequestMethod(loggedNetworkData, { method });
-  _logRequestUrl(loggedNetworkData, { url });
+  NetworkLogManager.resetLoggedNetworkData();
+  NetworkLogManager.logRequestMethod({ method });
+  NetworkLogManager.logRequestUrl({ url });
 
   _xhrDefaultOpen.apply(this, arguments);
 }
 
 function _xhrInterceptorSetRequestHeader(header, value) {
-  _logRequestHeader(loggedNetworkData, { header, value });
+  NetworkLogManager.logRequestHeader({ header, value });
 
   _xhrDefaultSetRequestHeader.apply(this, arguments);
 }
 
 function _xhrInterceptorSend(data) {
-  const loggedNetworkDataClone = JSON.parse(JSON.stringify(loggedNetworkData));
-  _logRequestBody(loggedNetworkDataClone, data);
+  const networkLogInstance = NetworkLogManager.createNetworkLogInstance();
+  console.log('intercepted request', this);
   
   if (this.addEventListener) {
     this.addEventListener(
@@ -63,11 +64,11 @@ function _xhrInterceptorSend(data) {
         }
 
         if (this.readyState === this.HEADERS_RECEIVED) {
-          _logResponseHeaders(loggedNetworkDataClone, this);
+          networkLogInstance.logResponseHeaders(this);
         } else if (this.readyState === this.DONE) {
-          _logDuration(loggedNetworkDataClone);
-          _logResponseCode(loggedNetworkDataClone, this);
-          _logResponseBody(loggedNetworkDataClone, this);
+          networkLogInstance.logDuration();
+          networkLogInstance.logResponseCode(this);
+          networkLogInstance.logResponseBody(this);
 
           if (onDoneCallback) {
             onDoneCallback(loggedNetworkDataClone);
@@ -87,92 +88,15 @@ function _xhrInterceptorSend(data) {
         onProgressCallback(totalBytesSent, totalBytesExpectedToSend);
       }
     };
+
     this.addEventListener('progress', downloadUploadProgressCallback);
     this.upload.addEventListener('progress', downloadUploadProgressCallback);
   }
 
-  _logStartTime(loggedNetworkDataClone);
+  networkLogInstance.logRequestBody(data);
+  networkLogInstance.logStartTime();
 
   _xhrDefaultSend.apply(this, arguments);
-}
-
-function _logRequestMethod(loggedNetworkData, { method }) {
-  loggedNetworkData.method = method;
-}
-
-function _logRequestUrl(loggedNetworkData, { url }) {
-  loggedNetworkData.url = url;
-}
-
-function _logRequestHeader(loggedNetworkData, { header, value }) {
-  if (loggedNetworkData.requestHeaders === '') {
-    loggedNetworkData.requestHeaders = {};
-  }
-  loggedNetworkData.requestHeaders[header] = value;
-}
-
-function _logRequestBody(loggedNetworkDataClone, data) {
-  loggedNetworkDataClone.requestBody = data ? data : '';
-}
-
-function _logResponseHeaders(loggedNetworkDataClone, interceptedRequest) {
-  const contentTypeString = interceptedRequest.getResponseHeader('Content-Type');
-  if (contentTypeString) {
-    loggedNetworkDataClone.contentType = contentTypeString.split(';')[0];
-  }
-    
-  if (interceptedRequest.getAllResponseHeaders()) {
-    const responseHeaders = interceptedRequest.getAllResponseHeaders().split('\r\n');
-    const responseHeadersDictionary = {};
-    responseHeaders.forEach(element => {
-      const key = element.split(':')[0];
-      const value = element.split(':')[1];
-      responseHeadersDictionary[key] = value;
-    });
-    loggedNetworkDataClone.responseHeaders = responseHeadersDictionary;
-  }
-}
-
-function _logStartTime(loggedNetworkDataClone) {
-  loggedNetworkDataClone.start = Date.now();
-}
-
-function _logDuration(loggedNetworkDataClone) {
-  loggedNetworkDataClone.duration = (Date.now() - loggedNetworkDataClone.start);
-}
-
-function _logResponseCode(loggedNetworkDataClone, interceptedRequest) {
-  loggedNetworkDataClone.responseCode = interceptedRequest.status ? interceptedRequest.status : 0;
-}
-
-function _logResponseBody (loggedNetworkDataClone, interceptedRequest) {
-  if (interceptedRequest.response) {
-    if (interceptedRequest.responseType === 'blob') {
-      const responseBody = await (new Response(interceptedRequest.response)).text();
-      loggedNetworkDataClone.responseBody = responseBody;
-    } else if (interceptedRequest.responseType === 'text') {
-      loggedNetworkDataClone.responseBody = interceptedRequest.response;
-    }
-  }
-
-  if (interceptedRequest._hasError) {
-    loggedNetworkDataClone.requestBody = interceptedRequest._response;
-  }
-}
-
-function _resetLoggedNetworkData() {
-  loggedNetworkData = {
-    method: '',
-    url: '',
-    requestHeaders: {},
-    requestBody: '',
-    responseHeaders: {},
-    responseBody: '',
-    responseCode: 0,
-    contentType: '',
-    duration: 0,
-    start: 0
-  };
 }
 
 module.exports = {


### PR DESCRIPTION
## Why Refactor?
- To break down and organize the network logging logic flow into functional modules.
- To address a racing issue concern -- asynchronous calls to [open](https://github.com/Instabug/Instabug-React-Native/blob/master/utils/XhrNetworkInterceptor.js#L36)/[setRequestHeader](https://github.com/Instabug/Instabug-React-Native/blob/master/utils/XhrNetworkInterceptor.js#L43) could manipulate the global [network object](https://github.com/Instabug/Instabug-React-Native/blob/master/utils/XhrNetworkInterceptor.js#L11) resulting in inaccurate logs.
- To replace the evil [`eval`](https://github.com/Instabug/Instabug-React-Native/blob/master/modules/NetworkLogger.js#L25) with a safer approach.

## What's Done?
- Added NetworkLogManager -- responsible for the logged data object manipulation.
- Started logging network responses that have `ResponseType`: `""` (Already included as a separate [PR](https://github.com/Instabug/Instabug-React-Native/pull/485))

### ResponseType References:
https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseType
https://mathiasbynens.be/notes/xhr-responsetype-json
https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Sending_and_Receiving_Binary_Data

### Racing Issue Helper References:
https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/onreadystatechange

### General References:
https://www.w3.org/TR/XMLHttpRequest/