### PR TITLE
[Hotfix] Network Logging - Include XHR Response when responseType is `""`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## master
+
+* Fixes an issue that caused XHR Response not to be logged.
+
 ## v9.1.1 (2020-04-06)
 
 * Fixes an issue with the version name while uploading the sourcemap on Android.

--- a/utils/XhrNetworkInterceptor.js
+++ b/utils/XhrNetworkInterceptor.js
@@ -88,7 +88,7 @@ const XHRInterceptor = {
                 if (this.responseType === 'blob') {
                   var responseText = await (new Response(this.response)).text();
                   cloneNetwork.responseBody = responseText;
-                } else if (this.responseType === 'text') {
+                } else if (this.responseType === 'text' || this.responseType === '') {
                   cloneNetwork.responseBody = this.response;
                 }
               }


### PR DESCRIPTION
Fixes an issue where XHR Response is not being logged.