### PR TITLE
Fix Android initialization with no invocation events

### DIFF
--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativePackage.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativePackage.java
@@ -73,21 +73,22 @@ public class RNInstabugReactnativePackage implements ReactPackage {
     }
 
     private void parseInvocationEvent(String[] invocationEventValues) {
+        if (invocationEventValues != null) {
+            for (int i = 0; i < invocationEventValues.length; i++) {
+                if (invocationEventValues[i].equals("button")) {
+                    this.invocationEvents.add(InstabugInvocationEvent.FLOATING_BUTTON);
+                } else if (invocationEventValues[i].equals("swipe")) {
+                    this.invocationEvents.add(InstabugInvocationEvent.TWO_FINGER_SWIPE_LEFT);
 
-        for (int i = 0; i < invocationEventValues.length; i++) {
-            if (invocationEventValues[i].equals("button")) {
-                this.invocationEvents.add(InstabugInvocationEvent.FLOATING_BUTTON);
-            } else if (invocationEventValues[i].equals("swipe")) {
-                this.invocationEvents.add(InstabugInvocationEvent.TWO_FINGER_SWIPE_LEFT);
+                } else if (invocationEventValues[i].equals("shake")) {
+                    this.invocationEvents.add(InstabugInvocationEvent.SHAKE);
 
-            } else if (invocationEventValues[i].equals("shake")) {
-                this.invocationEvents.add(InstabugInvocationEvent.SHAKE);
+                } else if (invocationEventValues[i].equals("screenshot")) {
+                    this.invocationEvents.add(InstabugInvocationEvent.SCREENSHOT);
 
-            } else if (invocationEventValues[i].equals("screenshot")) {
-                this.invocationEvents.add(InstabugInvocationEvent.SCREENSHOT);
-
-            } else if (invocationEventValues[i].equals("none")) {
-                this.invocationEvents.add(InstabugInvocationEvent.NONE);
+                } else if (invocationEventValues[i].equals("none")) {
+                    this.invocationEvents.add(InstabugInvocationEvent.NONE);
+                }
             }
         }
 


### PR DESCRIPTION
Null check the array before accessing it.