### PR TITLE
Fix setSdkDebugLogsLevel crashing on Android

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,23 +14,7 @@ jobs:
       - checkout:
           path: ~/project
 
-      - restore_cache:
-          key: yarn-v1-{{ checksum "yarn.lock" }}-{{ arch }}
-
-      - restore_cache:
-          key: node-v1-{{ checksum "package.json" }}-{{ arch }}
-
       - run: yarn
-
-      - save_cache:
-          key: yarn-v1-{{ checksum "yarn.lock" }}-{{ arch }}
-          paths:
-            - ~/.cache/yarn
-
-      - save_cache:
-          key: node-v1-{{ checksum "package.json" }}-{{ arch }}
-          paths:
-            - node_modules
 
       - run:
           name: jest tests

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -367,11 +367,22 @@ describe('Instabug Module', () => {
 
   });
 
-  it('should call the native method setSdkDebugLogsLevel', () => {
+  it('should call the native method setSdkDebugLogsLevel on iOS', () => {
     const debugLevel = Instabug.sdkDebugLogsLevel.sdkDebugLogsLevelVerbose;
+    
+    Platform.OS = 'ios';
     Instabug.setSdkDebugLogsLevel(debugLevel);
 
     expect(setSdkDebugLogsLevel.calledOnceWithExactly(debugLevel)).toBe(true);
+  });
+
+  it('should not call the native method setSdkDebugLogsLevel on Android', () => {
+    const debugLevel = Instabug.sdkDebugLogsLevel.sdkDebugLogsLevelVerbose;
+    
+    Platform.OS = 'android';
+    Instabug.setSdkDebugLogsLevel(debugLevel);
+
+    expect(setSdkDebugLogsLevel.notCalled).toBe(true);
   });
 
   it('should call the native method setUserAttribute', () => {

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -74,6 +74,7 @@ describe('Instabug Module', () => {
     setIBGLogPrintsToConsole.resetHistory();
     setPushNotificationsEnabled.resetHistory();
     log.resetHistory();
+    setSdkDebugLogsLevel.resetHistory();
     setDebugEnabled.resetHistory();
     enable.resetHistory();
     disable.resetHistory();

--- a/index.js
+++ b/index.js
@@ -165,7 +165,9 @@ const InstabugModule = {
    *
    */
   setSdkDebugLogsLevel(sdkDebugLogsLevel) {
-    Instabug.setSdkDebugLogsLevel(sdkDebugLogsLevel);
+    if (Platform.OS === 'ios') {
+      Instabug.setSdkDebugLogsLevel(sdkDebugLogsLevel);
+    }
   },
 
   /* istanbul ignore next */


### PR DESCRIPTION
## Description of the change
- `setSdkDebugLogsLevel` API is targeted for iOS only, calling it on Android would crash the app. I've added a platform check to avoid that.
- Disable node_modules cache on test_module job.
## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [X] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [X] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
