### PR TITLE
Fix/network logger defensive coding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## master
+
+* Fixes a crash caused by the network logger when the object passed is too large
 
 ## v9.1.9 (2020-10-01)
 

--- a/modules/NetworkLogger.js
+++ b/modules/NetworkLogger.js
@@ -29,10 +29,14 @@ export default {
               network
             );
           } else {
-            if (Platform.OS === 'android') {
-              Instabug.networkLog(JSON.stringify(network));
-            } else {
-              Instabug.networkLog(network);
+            try {
+              if (Platform.OS === 'android') {
+                Instabug.networkLog(JSON.stringify(network));
+              } else {
+                Instabug.networkLog(network);
+              }
+            } catch (e) {
+              console.error(e);
             }
           }
         }


### PR DESCRIPTION
## Description of the change
* Fixes a crash caused by the network logger when the object passed is too large by adding defensive coding
## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
https://instabugteam.slack.com/archives/GHK5TA7AR/p1606306825246300
### Development
- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
