### PR TITLE
Replace deprecated API in Sample App [MOB-4792]

### DIFF
--- a/InstabugSample/App.js
+++ b/InstabugSample/App.js
@@ -38,7 +38,7 @@ export default class App extends Component<{}> {
       colorTheme: 'Light',
     };
 
-    Instabug.startWithToken('068ba9a8c3615035e163dc5f829c73be', [
+    Instabug.start('068ba9a8c3615035e163dc5f829c73be', [
       Instabug.invocationEvent.floatingButton,
     ]);
   }

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ import Instabug from 'instabug-reactnative';
      Initialize it in the `constructor` or `componentWillMount`. This line will let the Instabug SDK work with the default behavior. The SDK will be invoked when the device is shaken. You can customize this behavior through the APIs.
 
     ```javascript
-    Instabug.startWithToken('IOS_APP_TOKEN', [Instabug.invocationEvent.shake]);
+    Instabug.start('IOS_APP_TOKEN', [Instabug.invocationEvent.shake]);
     ```
  * ### Android
 1. Open `android/app/src/main/java/[...]/MainApplication.java`


### PR DESCRIPTION
## Description of the change
Replaces the usage of the deprecated API `Instabug.startWithToken` with the newer API `Instabug.start`.

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
### Development
- [X] Lint rules pass locally
- [X] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [X] This pull request has a descriptive title and information useful to a reviewer
- [X] Issue from task tracker has a link to this pull request 
