### PR TITLE
[INSD-5139] Fix handling network request body that is not a string

### DIFF
--- a/__tests__/xhrNetworkInterceptor.spec.js
+++ b/__tests__/xhrNetworkInterceptor.spec.js
@@ -60,7 +60,10 @@ describe('Network Interceptor', () => {
 
     it('should set requestBody in network object', (done) => {
 
-        const requestBody = { data: [{ item: 'first' }, { item: 'second' }] };
+        let requestBody = { data: [{ item: 'first' }, { item: 'second' }] };
+        if(typeof requestBody !== 'string') {
+            requestBody = JSON.stringify(requestBody);
+        }
         Interceptor.enableInterception();
         Interceptor.setOnDoneCallback((network) => {
             expect(network.requestBody).toEqual(requestBody);

--- a/modules/NetworkLogger.js
+++ b/modules/NetworkLogger.js
@@ -33,9 +33,6 @@ export default {
               if (Platform.OS === 'android') {
                 Instabug.networkLog(JSON.stringify(network));
               } else {
-                if (typeof network.requestBody !== "string") {
-                  network.requestBody = JSON.stringify(network.requestBody);
-                }
                 Instabug.networkLog(network);
               }
             } catch (e) {

--- a/modules/NetworkLogger.js
+++ b/modules/NetworkLogger.js
@@ -33,6 +33,9 @@ export default {
               if (Platform.OS === 'android') {
                 Instabug.networkLog(JSON.stringify(network));
               } else {
+                if (typeof network.requestBody !== "string") {
+                  network.requestBody = JSON.stringify(network.requestBody);
+                }
                 Instabug.networkLog(network);
               }
             } catch (e) {

--- a/utils/XhrNetworkInterceptor.js
+++ b/utils/XhrNetworkInterceptor.js
@@ -56,6 +56,10 @@ const XHRInterceptor = {
       var cloneNetwork = JSON.parse(JSON.stringify(network));
       cloneNetwork.requestBody = data ? data : '';
       
+      if (typeof cloneNetwork.requestBody !== "string") {
+        cloneNetwork.requestBody = JSON.stringify(cloneNetwork.requestBody);
+      }
+      
       if (this.addEventListener) {
         this.addEventListener(
           'readystatechange',


### PR DESCRIPTION
## Description of the change
- Added a type check on the request body of a network log in the `NetworkLogger.js` module
- Stringified the request body in case it's not a string before passing it to the native layer.
- Changes done for iOS only
## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
