### PR TITLE
[INSD-5139] Fix handling a network request body that is not a string

### DIFF
--- a/__tests__/xhrNetworkInterceptor.spec.js
+++ b/__tests__/xhrNetworkInterceptor.spec.js
@@ -60,10 +60,10 @@ describe('Network Interceptor', () => {
 
     it('should set requestBody in network object', (done) => {
 
-        const requestBody = { data: [{ item: 'first' }, { item: 'second' }] };
+        let requestBody = { data: [{ item: 'first' }, { item: 'second' }] };
         Interceptor.enableInterception();
         Interceptor.setOnDoneCallback((network) => {
-            expect(network.requestBody).toEqual(requestBody);
+            expect(network.requestBody).toEqual(JSON.stringify(requestBody));
             done();
         })
         FakeRequest.open(method, url);

--- a/__tests__/xhrNetworkInterceptor.spec.js
+++ b/__tests__/xhrNetworkInterceptor.spec.js
@@ -60,7 +60,7 @@ describe('Network Interceptor', () => {
 
     it('should set requestBody in network object', (done) => {
 
-        let requestBody = { data: [{ item: 'first' }, { item: 'second' }] };
+        const requestBody = { data: [{ item: 'first' }, { item: 'second' }] };
         Interceptor.enableInterception();
         Interceptor.setOnDoneCallback((network) => {
             expect(network.requestBody).toEqual(JSON.stringify(requestBody));

--- a/utils/XhrNetworkInterceptor.js
+++ b/utils/XhrNetworkInterceptor.js
@@ -56,6 +56,10 @@ const XHRInterceptor = {
       var cloneNetwork = JSON.parse(JSON.stringify(network));
       cloneNetwork.requestBody = data ? data : '';
       
+      if (typeof cloneNetwork.requestBody !== "string") {
+        cloneNetwork.requestBody = JSON.stringify(cloneNetwork.requestBody);
+      }
+      
       if (this.addEventListener) {
         this.addEventListener(
           'readystatechange',

--- a/utils/XhrNetworkInterceptor.js
+++ b/utils/XhrNetworkInterceptor.js
@@ -48,7 +48,7 @@ const XHRInterceptor = {
       if (network.requestHeaders === '') {
         network.requestHeaders = {};
       }
-      network.requestHeaders[header] = value;
+      network.requestHeaders[header] = typeof value === 'string' ? value : JSON.stringify(value);
       originalXHRSetRequestHeader.apply(this, arguments);
     };
 


### PR DESCRIPTION
## Description of the change
- Added a type check on the request body of a network log in the `NetworkLogger.js` module.
- Stringified the request body in case it's not a string before passing it to the native layer.
- Adjusted unit tests accordingly.
## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
## Checklists
### Development
- [x] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
