### PR TITLE
[INSD-5139] Fix iOS network logger crash due to header value type

### DIFF
--- a/utils/XhrNetworkInterceptor.js
+++ b/utils/XhrNetworkInterceptor.js
@@ -48,7 +48,7 @@ const XHRInterceptor = {
       if (network.requestHeaders === '') {
         network.requestHeaders = {};
       }
-      network.requestHeaders[header] = value;
+      network.requestHeaders[header] = typeof value === 'string' ? value : JSON.stringify(value);
       originalXHRSetRequestHeader.apply(this, arguments);
     };
 


### PR DESCRIPTION
## Description of the change
Fix iOS network logger crash due to header value type
## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
