### PR TITLE
[MOB-5219] Fix CI publish script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,14 +206,14 @@ jobs:
 
   publish:
     macos:
-      xcode: "10.2.0"
-    working_directory: ~
+      xcode: "10.1.0"
+    working_directory: "~"
     steps:
       - checkout:
           path: ~/project
       - run: git clone https://InstabugCI:$RELEASE_GITHUB_TOKEN@github.com/Instabug/Escape.git
-      - run: cd Escape; swift build -c release -Xswiftc -static-stdlib
-      - run: cd Escape/.build/release; cp -f Escape /usr/local/bin/escape
+      - run: cd Escape && swift build -c release -Xswiftc -static-stdlib
+      - run: cd Escape/.build/release && cp -f Escape /usr/local/bin/escape
       - run: cd project && Escape react-native publish
 
 workflows:


### PR DESCRIPTION
## Description of the change
- Fix `working_directory` invalid value.
- Rollback Xcode version for compatibility with _Escape_ build process.
## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
## Checklists
### Code review 
- [X] This pull request has a descriptive title and information useful to a reviewer
- [X] Issue from task tracker has a link to this pull request 
