### PR TITLE
Fix network response header value logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## master
+
+* Fixes an issue with network header value formatting.
+
 ## v10.8.1 (2021-08-25)
 
 * Fixes a crash that occurs with network requests on slow network connectivity in v10.8

--- a/utils/XhrNetworkInterceptor.js
+++ b/utils/XhrNetworkInterceptor.js
@@ -83,8 +83,8 @@ const XHRInterceptor = {
                 const responseHeaders = this.getAllResponseHeaders().split('\r\n');
                 const responseHeadersDictionary = {};
                 responseHeaders.forEach(element => {
-                  const key = element.split(':')[0];
-                  const value = element.split(':')[1];
+                  const key = element.split(/:(.+)/)[0];
+                  const value = element.split(/:(.+)/)[1];
                   responseHeadersDictionary[key] = value;
                 });
                 cloneNetwork.responseHeaders = responseHeadersDictionary;


### PR DESCRIPTION
## Description of the change
> Fixed response headers being logged incorrectly if their value contains the ":" separator
## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
