### PR TITLE
fix(ios): update upload_sourcemap to looking for env files

### DIFF
--- a/ios/upload_sourcemap.sh
+++ b/ios/upload_sourcemap.sh
@@ -9,8 +9,8 @@ fi
 export NODE_BINARY=node
 
 if [ ! "${INSTABUG_APP_TOKEN}" ] || [ -z "${INSTABUG_APP_TOKEN}" ]; then
-    echo "Instabug: Looking for Token..."
-    INSTABUG_APP_TOKEN=$(grep -r --exclude-dir={node_modules,ios,android} "Instabug.start[WithToken]*([\"\'][0-9a-zA-Z]*[\"\']" ./ -m 1 | grep -o "[\"\'][0-9a-zA-Z]*[\"\']" | cut -d "\"" -f 2 | cut -d "'" -f 2)
+    echo "Instabug: Looking for Token in env files..."
+    INSTABUG_APP_TOKEN=$(grep -r --exclude-dir={node_modules,ios,android} "INSTABUG_APP_TOKEN=" ./.env* -m 1 |  gcut -d "=" -f2)
 fi
 
 if [ ! "${INSTABUG_APP_TOKEN}" ] || [ -z "${INSTABUG_APP_TOKEN}" ]; then


### PR DESCRIPTION
## Description of the change
> Read INSTABUG_APP_TOKEN value from .env files to not be hardcoded

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> https://github.com/Instabug/Instabug-React-Native/issues/547
## Checklists
### Development
- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
