### PR TITLE
[MOB-8367] Stop publishing useless files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,6 @@
+.github/
+.circleci/
+
 *.iml
 .idea/
 .DS_Store
@@ -7,6 +10,9 @@ android/android.iml
 android/gradlew
 android/gradlew.bat
 android/local.properties
+android/.project
+android/.settings
+*Test.java
 
 ios/.DS_Store
 
@@ -14,3 +20,10 @@ build/
 InstabugSample/
 node_modules/
 coverage/
+__tests__/
+
+Dangerfile
+babel.config.js
+codecov.yml
+typescript_validator.js
+.prettierrc.js


### PR DESCRIPTION

## Description of the change

Open to see what was bundled: https://unpkg.com/browse/instabug-reactnative@10.11.0/

**To test:**
```sh
npm pack --dry-run
```

![image](https://user-images.githubusercontent.com/95620376/148767482-bac600da-8620-495d-b76b-c2f8c18a5524.png)


## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues
> Issue links go here

## Checklists

### Development
- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
