### PR TITLE
[MOB-7935] Favor namespaced import of React/RCTConvert.h

### DIFF
--- a/ios/RNInstabug/RCTConvert+InstabugEnums.h
+++ b/ios/RNInstabug/RCTConvert+InstabugEnums.h
@@ -5,11 +5,10 @@
 //  Created by Yousef Hamza on 9/29/16.
 //  Copyright © 2016 Facebook. All rights reserved.
 //
-
-#if __has_include("RCTConvert.h")
-  #import "RCTConvert.h"
-#else
+#if __has_include("React/RCTConvert.h")
   #import <React/RCTConvert.h>
+#else
+  #import "RCTConvert.h"
 #endif
 
 @interface RCTConvert (InstabugEnums)


### PR DESCRIPTION
## Description of the change
Could not upgrade to expo 44 because iOS build was failing.

As explained here: expo/expo#15622 (comment)

Old style imports are not supported anymore from expo 44.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
## Checklists
### Development
- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
