### PR TITLE
[IBGCRASH-9968] Split CR exception message parameter

### DIFF
--- a/InstabugSample/__tests__/instabugUtils.spec.js
+++ b/InstabugSample/__tests__/instabugUtils.spec.js
@@ -33,6 +33,8 @@ describe('Test global error handler', () => {
     handler({name: 'TypeError', message: 'This is a type error.'}, false);
     const expected = {
       message: 'TypeError - This is a type error.',
+      e_message: 'This is a type error.',
+      e_name: 'TypeError',
       os: 'ios',
       platform: 'react_native',
       exception: [],
@@ -48,6 +50,8 @@ describe('Test global error handler', () => {
     handler({name: 'TypeError', message: 'This is a type error.'}, false);
     const expected = {
       message: 'TypeError - This is a type error.',
+      e_message: 'This is a type error.',
+      e_name: 'TypeError',
       os: 'android',
       platform: 'react_native',
       exception: [],

--- a/__tests__/crashReporting.spec.js
+++ b/__tests__/crashReporting.spec.js
@@ -49,6 +49,8 @@ describe('CrashReporting Module', () => {
 
         const expectedObject = {
             message: 'TypeError - Invalid type',
+            e_message: 'Invalid type',
+            e_name: 'TypeError',
             os: 'ios',
             platform: 'react_native',
             exception: 'javascriptStackTrace'
@@ -66,6 +68,8 @@ describe('CrashReporting Module', () => {
 
         const expectedObject = {
             message: 'TypeError - Invalid type',
+            e_message: 'Invalid type',
+            e_name: 'TypeError',
             os: 'android',
             platform: 'react_native',
             exception: 'javascriptStackTrace'
@@ -84,6 +88,8 @@ describe('CrashReporting Module', () => {
         const errorObject = { name: 'TypeError', message: 'Invalid type' };
         const expectedObject = {
             message: 'TypeError - Invalid type',
+            e_message: 'Invalid type',
+            e_name: 'TypeError',
             os: 'android',
             platform: 'react_native',
             exception: 'javascriptStackTrace'

--- a/modules/CrashReporting.js
+++ b/modules/CrashReporting.js
@@ -28,6 +28,8 @@ export default {
     
     var jsonObject = {
       message: errorObject.name + ' - ' + errorObject.message,
+      e_message: errorObject.message,
+      e_name: errorObject.name,
       os: Platform.OS,
       platform: 'react_native',
       exception: jsStackTrace

--- a/utils/InstabugUtils.js
+++ b/utils/InstabugUtils.js
@@ -72,6 +72,8 @@ export const captureJsErrors = () => {
     //JSON object to be sent to the native SDK
     var jsonObject = {
       message: e.name + " - " + e.message,
+      e_message: e.message,
+      e_name: e.name,
       os: Platform.OS,
       platform: 'react_native',
       exception: jsStackTrace


### PR DESCRIPTION
## Description of the change
> In a Crash Report, the exception JSON object has a parameter `message` that was a combination between `name` and `message` of the exception. This PR splits this parameter into `e_name` and `e_message` .
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
