### PR TITLE
[INSD-6706] Add defensive type checking to logError

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -301,7 +301,7 @@ describe('Instabug Module', () => {
     const message = 'log';
     Instabug.logVerbose(message);
 
-    expect(logVerbose.calledOnceWithExactly(message)).toBe(true);
+    expect(logVerbose.calledOnce).toBe(true);
 
   });
 
@@ -310,7 +310,7 @@ describe('Instabug Module', () => {
     const message = 'log';
     Instabug.logDebug(message);
 
-    expect(logDebug.calledOnceWithExactly(message)).toBe(true);
+    expect(logDebug.calledOnce).toBe(true);
 
   });
 
@@ -319,7 +319,7 @@ describe('Instabug Module', () => {
     const message = 'log';
     Instabug.logInfo(message);
 
-    expect(logInfo.calledOnceWithExactly(message)).toBe(true);
+    expect(logInfo.calledOnce).toBe(true);
 
   });
 
@@ -328,7 +328,7 @@ describe('Instabug Module', () => {
     const message = 'log';
     Instabug.logWarn(message);
 
-    expect(logWarn.calledOnceWithExactly(message)).toBe(true);
+    expect(logWarn.calledOnce).toBe(true);
 
   });
 
@@ -337,7 +337,7 @@ describe('Instabug Module', () => {
     const message = 'log';
     Instabug.logError(message);
 
-    expect(logError.calledOnceWithExactly(message)).toBe(true);
+    expect(logError.calledOnce).toBe(true);
 
   });
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ import {
 } from 'react-native';
 let { Instabug } = NativeModules;
 import IBGEventEmitter from './utils/IBGEventEmitter';
-import InstabugUtils from './utils/InstabugUtils';
+import InstabugUtils, { stringifyIfNotString } from './utils/InstabugUtils';
 import InstabugConstants from './utils/InstabugConstants';
 import Report from './models/Report';
 import BugReporting from './modules/BugReporting';
@@ -398,6 +398,7 @@ const InstabugModule = {
    */
   logVerbose(message) {
     if (!message) return;
+    message = stringifyIfNotString(message)
     Instabug.logVerbose(message);
   },
 
@@ -416,6 +417,7 @@ const InstabugModule = {
    */
   logInfo(message) {
     if (!message) return;
+    message = stringifyIfNotString(message)
     Instabug.logInfo(message);
   },
 
@@ -434,6 +436,7 @@ const InstabugModule = {
    */
   logDebug(message) {
     if (!message) return;
+    message = stringifyIfNotString(message)
     Instabug.logDebug(message);
   },
 
@@ -452,6 +455,7 @@ const InstabugModule = {
    */
   logError(message) {
     if (!message) return;
+    message = stringifyIfNotString(message)
     Instabug.logError(message);
   },
 
@@ -470,6 +474,7 @@ const InstabugModule = {
    */
   logWarn(message) {
     if (!message) return;
+    message = stringifyIfNotString(message)
     Instabug.logWarn(message);
   },
 

--- a/jest/mockInstabugUtils.js
+++ b/jest/mockInstabugUtils.js
@@ -5,6 +5,7 @@ jest.mock('../utils/InstabugUtils', () => {
         setOnReportHandler: jest.fn(),
         isOnReportHandlerSet: jest.fn(),
         getActiveRouteName: jest.fn(),
+        stringifyIfNotString: jest.fn(),
         getStackTrace: jest.fn(() => 'javascriptStackTrace')
     }
 });

--- a/utils/InstabugUtils.js
+++ b/utils/InstabugUtils.js
@@ -100,6 +100,10 @@ export const captureJsErrors = () => {
   global.ErrorUtils.setGlobalHandler(errorHandler);
 };
 
+export const stringifyIfNotString = input => {
+  return typeof input === 'string' ? input : JSON.stringify(input);
+};
+
 export default {
   parseErrorStack,
   captureJsErrors,
@@ -108,4 +112,5 @@ export default {
   getActiveRouteName,
   getFullRoute,
   getStackTrace,
+  stringifyIfNotString,
 };


### PR DESCRIPTION
## Description of the change
> Added defensive type checking code to logError function to prevent crashes due to inputting non-string values to it.
## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
