### PR TITLE
[MOB-9131] Symlink the SDK in the sample app

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - checkout:
           path: ~/project
-
+      - run: yarn
       - run: cd InstabugSample && yarn install
 
       - run:

--- a/InstabugSample/metro.config.js
+++ b/InstabugSample/metro.config.js
@@ -5,7 +5,15 @@
  * @format
  */
 
+const path = require('path');
+const escape = require('escape-string-regexp');
+const exclusionList = require('metro-config/src/defaults/exclusionList');
+
+const root = path.resolve(__dirname, '..');
+const modules = ['react', 'react-native'];
+
 module.exports = {
+  watchFolders: [root],
   transformer: {
     getTransformOptions: async () => ({
       transform: {
@@ -14,5 +22,13 @@ module.exports = {
       },
     }),
   },
-  maxWorkers: 2,
+  resolver: {
+    blacklistRE: exclusionList(
+      modules.map(m => new RegExp(`^${escape(path.join(root, 'node_modules', m))}\\/.*$`)),
+    ),
+    extraNodeModules: modules.reduce((acc, name) => {
+      acc[name] = path.join(__dirname, 'node_modules', name);
+      return acc;
+    }, {}),
+  },
 };

--- a/InstabugSample/metro.config.js
+++ b/InstabugSample/metro.config.js
@@ -8,9 +8,11 @@
 const path = require('path');
 const escape = require('escape-string-regexp');
 const exclusionList = require('metro-config/src/defaults/exclusionList');
+const pkg = require('../package.json');
 
 const root = path.resolve(__dirname, '..');
-const modules = ['react', 'react-native', '@babel/runtime'];
+const peerDependencies = Object.keys(pkg.peerDependencies);
+const modules = [...peerDependencies, '@babel/runtime'];
 
 module.exports = {
   watchFolders: [root],

--- a/InstabugSample/metro.config.js
+++ b/InstabugSample/metro.config.js
@@ -10,7 +10,7 @@ const escape = require('escape-string-regexp');
 const exclusionList = require('metro-config/src/defaults/exclusionList');
 
 const root = path.resolve(__dirname, '..');
-const modules = ['react', 'react-native'];
+const modules = ['react', 'react-native', '@babel/runtime'];
 
 module.exports = {
   watchFolders: [root],

--- a/InstabugSample/package.json
+++ b/InstabugSample/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@react-navigation/bottom-tabs": "^6.0.9",
     "@react-navigation/native": "^6.0.6",
-    "instabug-reactnative": "../",
+    "instabug-reactnative": "link:../",
     "react": "17.0.2",
     "react-native": "0.66.0",
     "react-native-safe-area-context": "^3.3.2",

--- a/InstabugSample/yarn.lock
+++ b/InstabugSample/yarn.lock
@@ -3557,8 +3557,9 @@ ini@^1.3.4:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
-instabug-reactnative@../:
-  version "10.13.0"
+"instabug-reactnative@link:../":
+  version "0.0.0"
+  uid ""
 
 internal-slot@^1.0.3:
   version "1.0.3"

--- a/InstabugSample/yarn.lock
+++ b/InstabugSample/yarn.lock
@@ -3557,7 +3557,7 @@ ini@^1.3.4:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
-"instabug-reactnative@link:../":
+"instabug-reactnative@link:..":
   version "0.0.0"
   uid ""
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,10 @@
     "esprima": "^4.0.1",
     "typescript": "^4.0.3"
   },
+  "peerDependencies": {
+    "react": "*",
+    "react-native": "*"
+  },
   "jest": {
     "preset": "react-native",
     "modulePathIgnorePatterns": [


### PR DESCRIPTION
## Description of the change

Symlinks the Instabug SDK in the sample app's `node_modules` instead of copying the whole Instabug-React-Native repo files again in the `node_modules` folder.

## Benefits

- Update SDK files on the fly (no need to `yarn install` every time you do a change) with hot reload when running the sample app.
- Update native SDK code in the sample app's Android and iOS projects — This makes autosuggestions in Android Studio and Xcode much better.
- More efficient storage usage — No need to copy the whole repo each time you install, it also prevents recursive file copying when doing multiple installs.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
