### PR TITLE
[MOB-8620] Fix startExecutionTrace return type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -583,7 +583,7 @@ export namespace APM {
    * Returns a promise, the promise delivers the trace reference if APM is enabled, otherwise it gets rejected
    * @param {string} name 
    */
-  function startExecutionTrace(name: string): Trace;
+  function startExecutionTrace(name: string): Promise<Trace>;
   /**
    * Starts a custom trace
    * @param {string} name 


### PR DESCRIPTION
## Description of the change

- Fix the return type of `APM.startExecutionTrace` to be `Promise<Trace>` instead of `Trace`. 

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
https://github.com/Instabug/Instabug-React-Native/issues/684
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
