### PR TITLE
[MOB-8633] Fix typo in dismissType enum in iOS bridge

### DIFF
--- a/ios/RNInstabug/InstabugReactBridge.m
+++ b/ios/RNInstabug/InstabugReactBridge.m
@@ -463,7 +463,7 @@ RCT_EXPORT_METHOD(clearAllExperiments) {
               
               @"dismissTypeSubmit": @(IBGDismissTypeSubmit),
               @"dismissTypeCancel": @(IBGDismissTypeCancel),
-              @"dismissTypeAddAtttachment": @(IBGDismissTypeAddAttachment),
+              @"dismissTypeAddAttachment": @(IBGDismissTypeAddAttachment),
               
               @"reproStepsEnabled": @(IBGUserStepsModeEnable),
               @"reproStepsDisabled": @(IBGUserStepsModeDisable),

--- a/ios/RNInstabug/RCTConvert+InstabugEnums.m
+++ b/ios/RNInstabug/RCTConvert+InstabugEnums.m
@@ -38,7 +38,7 @@ RCT_ENUM_CONVERTER(IBGBugReportingInvocationOption, (@{
 RCT_ENUM_CONVERTER(IBGDismissType, (@{
                                       @"dismissTypeSubmit": @(IBGDismissTypeSubmit),
                                       @"dismissTypeCancel": @(IBGDismissTypeCancel),
-                                      @"dismissTypeAddAtttachment": @(IBGDismissTypeAddAttachment)
+                                      @"dismissTypeAddAttachment": @(IBGDismissTypeAddAttachment)
                                       }), IBGDismissTypeSubmit, integerValue)
 
 RCT_ENUM_CONVERTER(IBGUserStepsMode, (@{


### PR DESCRIPTION
## Description of the change

- Fix a typo in the ```dismissTypeAddAttachment``` enum constant in iOS bridge

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues

## Checklists
### Development
- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request 
