### PR TITLE
[MOB-8642] Map dismissType enum values on Android

### DIFF
--- a/android/src/main/java/com/instabug/reactlibrary/ArgsRegistry.java
+++ b/android/src/main/java/com/instabug/reactlibrary/ArgsRegistry.java
@@ -7,6 +7,8 @@ import java.util.Map;
 import com.instabug.bug.BugReporting;
 import com.instabug.bug.invocation.Option;
 import com.instabug.featuresrequest.ActionType;
+
+import com.instabug.library.OnSdkDismissCallback;
 import com.instabug.library.InstabugColorTheme;
 import com.instabug.library.InstabugCustomTextPlaceHolder;
 import com.instabug.library.extendedbugreport.ExtendedBugReport;
@@ -63,6 +65,7 @@ final class ArgsRegistry {
         registerInstabugExtendedBugReportModeArgs(ARGS);
         registerInstabugVideoRecordingFloatingButtonPositionArgs(ARGS);
         registerInstabugReportTypesArgs(ARGS);
+        registerInstabugDismissTypesArgs(ARGS);
         registerReproStepsModeArgs(ARGS);
         registerWelcomeMessageArgs(ARGS);
         registerInstabugFeatureRequestsActionTypes(ARGS);
@@ -211,6 +214,12 @@ final class ArgsRegistry {
         args.put("bugReportingReportTypeBug", BugReporting.ReportType.BUG);
         args.put("bugReportingReportTypeFeedback", BugReporting.ReportType.FEEDBACK);
         args.put("bugReportingReportTypeQuestion", BugReporting.ReportType.QUESTION);
+    }
+
+    static void registerInstabugDismissTypesArgs(Map<String, Object> args){
+        args.put("dismissTypeAddAttachment", OnSdkDismissCallback.DismissType.ADD_ATTACHMENT);
+        args.put("dismissTypeCancel", OnSdkDismissCallback.DismissType.CANCEL);
+        args.put("dismissTypeSubmit", OnSdkDismissCallback.DismissType.SUBMIT);
     }
 
     static void registerLogLevelArgs(Map<String, Object> args) {

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
@@ -184,6 +184,10 @@ public class RNInstabugReactnativeModule extends ReactContextBaseJavaModule {
     private final String BUG_REPORTING_REPORT_TYPE_FEEDBACK = "bugReportingReportTypeFeedback";
     private final String BUG_REPORTING_REPORT_TYPE_QUESTION = "bugReportingReportTypeQuestion";
 
+    private final String DISMISS_TYPE_ADD_ATTACHMENT = "dismissTypeAddAttachment";
+    private final String DISMISS_TYPE_CANCEL = "dismissTypeCancel";
+    private final String DISMISS_TYPE_SUBMIT = "dismissTypeSubmit";
+
     private final String EMAIL_FIELD_HIDDEN = "emailFieldHidden";
     private final String EMAIL_FIELD_OPTIONAL = "emailFieldOptional";
     private final String COMMENT_FIELD_REQUIRED = "commentFieldRequired";
@@ -2439,6 +2443,10 @@ public class RNInstabugReactnativeModule extends ReactContextBaseJavaModule {
         constants.put(BUG_REPORTING_REPORT_TYPE_BUG, BUG_REPORTING_REPORT_TYPE_BUG);
         constants.put(BUG_REPORTING_REPORT_TYPE_FEEDBACK, BUG_REPORTING_REPORT_TYPE_FEEDBACK);
         constants.put(BUG_REPORTING_REPORT_TYPE_QUESTION, BUG_REPORTING_REPORT_TYPE_QUESTION);
+
+        constants.put(DISMISS_TYPE_ADD_ATTACHMENT, DISMISS_TYPE_ADD_ATTACHMENT);
+        constants.put(DISMISS_TYPE_CANCEL, DISMISS_TYPE_CANCEL);
+        constants.put(DISMISS_TYPE_SUBMIT, DISMISS_TYPE_SUBMIT);
 
         constants.put("localeArabic", LOCALE_ARABIC);
         constants.put("localeAzerbaijani", LOCALE_AZERBAIJANI);


### PR DESCRIPTION
## Description of the change

- Add string keys for the ```dismissType``` enum values on Android

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues

## Checklists
### Development
- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request 
