### PR TITLE
Allow to skip uploading sourcemaps with env variable INSTABUG_SKIP_UPLOAD

### DIFF
--- a/ios/upload_sourcemap.sh
+++ b/ios/upload_sourcemap.sh
@@ -30,6 +30,11 @@ if [ ! "${INSTABUG_APP_TOKEN}" ] || [ -z "${INSTABUG_APP_TOKEN}" ]; then
     echo "Instabug: INSTABUG_APP_TOKEN not found. Make sure you've added the SDK initialization line Instabug.start Or added the environment variable INSTABUG_APP_TOKEN"
     exit 0
 else
+    if [[ $INSTABUG_SKIP_UPLOAD == "true" ]]; then
+        echo "Instabug: INSTABUG_SKIP_UPLOAD is true, skipping upload"
+        exit 0
+    fi
+
     if [ ! "${INSTABUG_APP_VERSION_CODE}" ] || [ -z "${INSTABUG_APP_VERSION_CODE}" ]; then
         INSTABUG_APP_VERSION_CODE=$(/usr/libexec/PlistBuddy -c 'print CFBundleVersion' ${PLIST_ABS_PATH} )
         if [ ! "${INSTABUG_APP_VERSION_CODE}" ] || [ -z "${INSTABUG_APP_VERSION_CODE}" ]; then

--- a/ios/upload_sourcemap.sh
+++ b/ios/upload_sourcemap.sh
@@ -30,7 +30,7 @@ if [ ! "${INSTABUG_APP_TOKEN}" ] || [ -z "${INSTABUG_APP_TOKEN}" ]; then
     echo "Instabug: INSTABUG_APP_TOKEN not found. Make sure you've added the SDK initialization line Instabug.start Or added the environment variable INSTABUG_APP_TOKEN"
     exit 0
 else
-    if [[ $INSTABUG_SKIP_UPLOAD == "true" ]]; then
+    if [[ "${INSTABUG_SKIP_UPLOAD}" == "true" ]]; then
         echo "Instabug: INSTABUG_SKIP_UPLOAD is true, skipping upload"
         exit 0
     fi


### PR DESCRIPTION
## Description of the change

For faster tests builds where we don't need to send source maps, this variable `INSTABUG_SKIP_UPLOAD` allows us to skip this part

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
