### PR TITLE
Adds instabug.json

### DIFF
--- a/android/upload_sourcemap.sh
+++ b/android/upload_sourcemap.sh
@@ -9,6 +9,16 @@ elif [[ -x "$(command -v brew)" && -s "$(brew --prefix nvm)/nvm.sh" ]]; then
 fi
 export NODE_BINARY=node
 
+INSTABUG_JSON_SOURCEMAP_UPLOADS_ENABLED=$(grep "enableSourcemapUploads" ./instabug.json -m 1 | cut -d ":" -f 2 | grep -o "[a-z]*")
+if [ ! -z "$INSTABUG_JSON_SOURCEMAP_UPLOADS_ENABLED" ]; then
+    if [ "$INSTABUG_JSON_SOURCEMAP_UPLOADS_ENABLED" != "true" ]; then
+        echo "Instabug: sourcemap upload disabled in instabug.json"
+        exit 0
+    fi
+fi
+
+INSTABUG_APP_TOKEN=$(grep "key" ./instabug.json -m 1 | cut -d ":" -f 2 | grep -o "[0-9a-zA-Z]*" -m 1)
+
 if [ ! "${INSTABUG_APP_TOKEN}" ] || [ -z "${INSTABUG_APP_TOKEN}" ]; then
     echo "Instabug: Looking for Token..."
     INSTABUG_APP_TOKEN=$(grep -r --exclude-dir={node_modules,ios,android} --exclude='*.json' "Instabug.start[WithToken]*([\"\'][0-9a-zA-Z]*[\"\']" ./ -m 1 | grep -o "[\"\'][0-9a-zA-Z]*[\"\']" | cut -d "\"" -f 2 | cut -d "'" -f 2)

--- a/ios/upload_sourcemap.sh
+++ b/ios/upload_sourcemap.sh
@@ -8,6 +8,16 @@ elif [ -x "$(command -v brew)" ] && [ -s "$(brew --prefix nvm)/nvm.sh" ]; then
 fi
 export NODE_BINARY=node
 
+INSTABUG_JSON_SOURCEMAP_UPLOADS_ENABLED=$(grep "enableSourcemapUploads" ./instabug.json -m 1 | cut -d ":" -f 2 | grep -o "[a-z]*")
+if [ ! -z "$INSTABUG_JSON_SOURCEMAP_UPLOADS_ENABLED" ]; then
+    if [ "$INSTABUG_JSON_SOURCEMAP_UPLOADS_ENABLED" != "true" ]; then
+        echo "Instabug: sourcemap upload disabled in instabug.json"
+        exit 0
+    fi
+fi
+
+INSTABUG_APP_TOKEN=$(grep "key" ./instabug.json -m 1 | cut -d ":" -f 2 | grep -o "[0-9a-zA-Z]*" -m 1)
+
 if [ ! "$INFOPLIST_FILE" ] || [ -z "$INFOPLIST_FILE" ]; then
     echo "Instabug: INFOPLIST_FILE not found in Xcode build settings, skipping sourcemap upload"
     exit 0


### PR DESCRIPTION
## Description of the change

Adds an alternative "instabug.json" option to handle the app key and upload/disable source maps.
Address #686 and other related issues when the app key is in a variable, for example.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues

#686

## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
