### PR TITLE
[MOB-8866] Start SDK from JS only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fixes an issue with setRequestFilterExpression API not working with Hermes
 * Fixes an issue with swipe invocation event not working on Android
 * Breaking: Removes the deprecated APIs. For the full list, check PR #703
+* Supports starting SDK from JS only.
 
 ## 10.13.0 (2022-03-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 ## master
 
+* Breaking: Adds the ability to initialize the Android SDK from JavaScript. Check the migration guide referenced in our README
+* Breaking: Removes the deprecated APIs. Check the migration guide referenced in our README
 * Adds the ability to opt out of iOS source maps auto upload through the INSTABUG_SOURCEMAPS_UPLOAD_DISABLE env variable
 * Adds dynamic entry file support through the INSTABUG_ENTRY_FILE env variable
 * Fixes an issue with setRequestFilterExpression API not working with Hermes
 * Fixes an issue with swipe invocation event not working on Android
-* Breaking: Removes the deprecated APIs. For the full list, check PR #703
-* Supports starting SDK from JS only.
 
 ## 10.13.0 (2022-03-17)
 

--- a/InstabugSample/android/app/src/main/java/com/instabugsample/MainApplication.java
+++ b/InstabugSample/android/app/src/main/java/com/instabugsample/MainApplication.java
@@ -9,7 +9,6 @@ import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.soloader.SoLoader;
 import java.lang.reflect.InvocationTargetException;
-import com.instabug.reactlibrary.RNInstabugReactnativePackage;
 
 import java.util.List;
 
@@ -45,12 +44,6 @@ public class MainApplication extends Application implements ReactApplication {
   @Override
   public void onCreate() {
     super.onCreate();
-     new RNInstabugReactnativePackage.Builder("2c63627b9923e10eee2c8abf92e6925f", MainApplication.this)
-            .setInvocationEvent("button")
-            .setPrimaryColor("#1D82DC")
-            .setFloatingEdge("left")
-            .setFloatingButtonOffsetFromTop(250)
-            .build();
     SoLoader.init(this, /* native exopackage */ false);
     initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
   }

--- a/README.md
+++ b/README.md
@@ -44,56 +44,26 @@ Updating to a new version? Check the [Update Guide](#update-guide) before bumpin
 
 ## Initializing Instabug
 
- To start using Instabug, import it as follows.
+To start using Instabug, import it as follows, then initialize it in the `constructor` or `componentWillMount`. This line will let the SDK work with the default behavior. The SDK will be invoked when the device is shaken. You can customize this behavior through the APIs.
 
 ```javascript
 import Instabug from 'instabug-reactnative';
+
+Instabug.start('APP_TOKEN', [Instabug.invocationEvent.shake]);
 ```
-### iOS
-- Initialize it in the `constructor` or `componentWillMount`. This line will let the Instabug SDK work with the default behavior. The SDK will be invoked when the device is shaken. You can customize this behavior through the APIs.
 
-    ```javascript
-    Instabug.start('IOS_APP_TOKEN', [Instabug.invocationEvent.shake]);
-    ```
-### Android
-- Open `android/app/src/main/java/[...]/MainApplication.java`
-    * Make sure to import the package class:  
-    `import com.instabug.reactlibrary.RNInstabugReactnativePackage;`
-    * **For React Native >= 0.60**   
-   Add the integration code to the `onCreate()` method like the below snippet. 
+**For React Native < 0.60 on Android**  
+You should find the `getPackages()` method looks like the below snippet. You just need to add your Android app token. 
 
-       ```java
-        @Override
-        public void onCreate() {
-            super.onCreate();
-            new RNInstabugReactnativePackage
-                .Builder("APP_TOKEN", MainApplication.this)
-                .setInvocationEvent("shake")
-                .setPrimaryColor("#1D82DC")
-                .setFloatingEdge("left")
-                .setFloatingButtonOffsetFromTop(250)
-                .build();
-        }
-      ```
-    * **For React Native < 0.60**  
-   You should find the `getPackages()` method looks like the below snippet. You just need to add your Android app token. 
-
-        ```javascript
-        @Override
-        protected List<ReactPackage> getPackages() {
-            return Arrays.<ReactPackage>asList(
-                new MainReactPackage(),
-                new RNInstabugReactnativePackage.Builder("YOUR_APP_TOKEN", MainApplication.this)
-                .setInvocationEvent("shake")
-                .setPrimaryColor("#1D82DC")
-                .setFloatingEdge("left")
-                .setFloatingButtonOffsetFromTop(250)
-                .build()
-            );
-        }
-        ```
-    * You can change the invocation event from here, simply by replacing the `"shake"` with any of the following `"button"`, `"none"`, `"screenshot"`, or `"swipe"`. You can change the primary color by replacing the `"#1D82DC"` with any color of your choice.
-   In the case that you are using the floating button as an invocation event, you can change the floating button edge and the floating button offset using the last two methods, by replacing `"left"` to `"right"`, and by changing the offset number. 
+```java
+@Override
+protected List<ReactPackage> getPackages() {
+    return Arrays.<ReactPackage>asList(
+        new MainReactPackage(),
+        new RNInstabugReactnativePackage()
+    );
+}
+```
    
 _You can find your app token by selecting the SDK tab from your [**Instabug dashboard**](https://dashboard.instabug.com)._
 

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -101,8 +101,6 @@ describe('Instabug Module', () => {
   });
 
   it('should call the native method start', () => {
-
-    Platform.OS = 'ios';
     const token = 'some-token';
     const invocationEvents = [Instabug.invocationEvent.floatingButton, Instabug.invocationEvent.shake];
     Instabug.start(token, invocationEvents);
@@ -110,17 +108,6 @@ describe('Instabug Module', () => {
     expect(start.calledOnceWithExactly(token, invocationEvents)).toBe(true);
 
   });
-
-  // it('should not call the native method start when platform is android', () => {
-
-  //   Platform.OS = 'android';
-  //   const token = 'some-token';
-  //   const invocationEvents = [Instabug.invocationEvent.floatingButton, Instabug.invocationEvent.shake];
-  //   Instabug.start(token, invocationEvents);
-
-  //   expect(start.calledOnceWithExactly(token, invocationEvents)).toBe(true);
-
-  // });
 
   it('should call the native method setUserData', () => {
 

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativePackage.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativePackage.java
@@ -1,29 +1,12 @@
 package com.instabug.reactlibrary;
 
-import android.app.Application;
-import android.util.Log;
+import androidx.annotation.NonNull;
 
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
-import com.instabug.bug.BugReporting;
-import com.instabug.crash.CrashReporting;
-import com.instabug.library.Platform;
-import com.instabug.library.Feature;
-import com.instabug.library.Instabug;
-import com.instabug.library.InstabugColorTheme;
-import com.instabug.library.invocation.InstabugInvocationEvent;
-import com.instabug.library.invocation.util.InstabugFloatingButtonEdge;
-import com.instabug.library.visualusersteps.State;
-import com.instabug.reactlibrary.utils.InstabugUtil;
-import com.instabug.reactlibrary.utils.MainThreadHandler;
-import com.instabug.apm.APM;
 
-import android.graphics.Color;
-
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -31,110 +14,14 @@ import java.util.List;
 public class RNInstabugReactnativePackage implements ReactPackage {
 
     private static final String TAG = RNInstabugReactnativePackage.class.getSimpleName();
-    
-    private Application androidApplication;
-    private String mAndroidApplicationToken;
-    private Instabug mInstabug;
-    private Instabug.Builder mBuilder;
-    private ArrayList<InstabugInvocationEvent> invocationEvents = new ArrayList<>();
-    private InstabugColorTheme instabugColorTheme = InstabugColorTheme.InstabugColorThemeLight;
 
     public RNInstabugReactnativePackage() {}
 
-    public RNInstabugReactnativePackage(String androidApplicationToken, Application androidApplication,
-                                        String[] invocationEventValues, String primaryColor,
-                                        InstabugFloatingButtonEdge floatingButtonEdge, Integer offset, boolean crashReportingEnabled) {
-        this.androidApplication = androidApplication;
-        this.mAndroidApplicationToken = androidApplicationToken;
-
-        //setting invocation event
-        this.parseInvocationEvent(invocationEventValues);
-
-        setBaseUrlForDeprecationLogs();
-        setCurrentPlatform();
-
-        new Instabug.Builder(this.androidApplication, this.mAndroidApplicationToken)
-                .setInvocationEvents(this.invocationEvents.toArray(new InstabugInvocationEvent[0]))
-                .build();
-        if (crashReportingEnabled)
-            CrashReporting.setState(Feature.State.ENABLED);
-        else
-            CrashReporting.setState(Feature.State.DISABLED);
-
-        if(primaryColor != null)
-            Instabug.setPrimaryColor(Color.parseColor(primaryColor));
-        if(floatingButtonEdge != null)
-            BugReporting.setFloatingButtonEdge(floatingButtonEdge);
-        if(offset != null)
-            BugReporting.setFloatingButtonOffset(offset);
-
-        // Temporarily disabling APM hot launches
-        APM.setHotAppLaunchEnabled(false);
-    }
-
-    public RNInstabugReactnativePackage(String androidApplicationToken, Application androidApplication,
-                                        String[] invocationEventValues, String primaryColor) {
-        new RNInstabugReactnativePackage(androidApplicationToken,androidApplication,invocationEventValues,primaryColor,
-                InstabugFloatingButtonEdge.LEFT,250, true);
-    }
-
-    private void parseInvocationEvent(String[] invocationEventValues) {
-
-        for (int i = 0; i < invocationEventValues.length; i++) {
-            if (invocationEventValues[i].equals("button")) {
-                this.invocationEvents.add(InstabugInvocationEvent.FLOATING_BUTTON);
-            } else if (invocationEventValues[i].equals("swipe")) {
-                this.invocationEvents.add(InstabugInvocationEvent.TWO_FINGER_SWIPE_LEFT);
-
-            } else if (invocationEventValues[i].equals("shake")) {
-                this.invocationEvents.add(InstabugInvocationEvent.SHAKE);
-
-            } else if (invocationEventValues[i].equals("screenshot")) {
-                this.invocationEvents.add(InstabugInvocationEvent.SCREENSHOT);
-
-            } else if (invocationEventValues[i].equals("none")) {
-                this.invocationEvents.add(InstabugInvocationEvent.NONE);
-            }
-        }
-
-        if (invocationEvents.isEmpty()) {
-            invocationEvents.add(InstabugInvocationEvent.SHAKE);
-        }
-    }
-
-    private void setCurrentPlatform() {
-        try {
-            Method method = InstabugUtil.getMethod(Class.forName("com.instabug.library.Instabug"), "setCurrentPlatform", int.class);
-            if (method != null) {
-                Log.i("IB-CP-Bridge", "invoking setCurrentPlatform with platform: " + Platform.RN);
-                method.invoke(null, Platform.RN);
-            } else {
-                Log.e("IB-CP-Bridge", "setCurrentPlatform was not found by reflection");
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
-
-    private void setBaseUrlForDeprecationLogs() {
-        try {
-            Method method = InstabugUtil.getMethod(Class.forName("com.instabug.library.util.InstabugDeprecationLogger"), "setBaseUrl", String.class);
-            if (method != null) {
-                method.invoke(null, "https://docs.instabug.com/docs/react-native-sdk-migration-guide");
-            }
-        } catch (ClassNotFoundException e) {
-            e.printStackTrace();
-        } catch (IllegalAccessException e) {
-            e.printStackTrace();
-        } catch (InvocationTargetException e) {
-            e.printStackTrace();
-        }
-    }
-
+    @NonNull
     @Override
-    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+    public List<NativeModule> createNativeModules(@NonNull ReactApplicationContext reactContext) {
         List<NativeModule> modules = new ArrayList<>();
-        modules.add(new RNInstabugReactnativeModule(reactContext, this.androidApplication, this.mInstabug));
+        modules.add(new RNInstabugReactnativeModule(reactContext));
         modules.add(new RNInstabugBugReportingModule(reactContext));
         modules.add(new RNInstabugSurveysModule(reactContext));
         modules.add(new RNInstabugFeatureRequestsModule(reactContext));
@@ -143,74 +30,9 @@ public class RNInstabugReactnativePackage implements ReactPackage {
         return modules;
     }
 
+    @NonNull
     @Override
-    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+    public List<ViewManager> createViewManagers(@NonNull ReactApplicationContext reactContext) {
         return Collections.emptyList();
     }
-
-
-    public static class Builder {
-        //FloatingButtonEdge
-        private final String FLOATING_BUTTON_EDGE_RIGHT = "right";
-        private final String FLOATING_BUTTON_EDGE_LEFT = "left";
-
-        String androidApplicationToken;
-        Application application;
-        String[] invocationEvents;
-        String primaryColor;
-        InstabugFloatingButtonEdge floatingButtonEdge;
-        int offset;
-        boolean isCrashReportingEnabled = true;
-
-        public Builder(String androidApplicationToken, Application application) {
-            this.androidApplicationToken = androidApplicationToken;
-            this.application = application;
-        }
-
-        public Builder setInvocationEvent(String... invocationEvents) {
-            this.invocationEvents = invocationEvents;
-            return this;
-        }
-
-        public Builder setCrashReportingEnabled(boolean enabled) {
-            this.isCrashReportingEnabled = enabled;
-            return this;
-        }
-
-        public Builder setPrimaryColor(String primaryColor) {
-            this.primaryColor = primaryColor;
-            return this;
-        }
-
-        public Builder setFloatingEdge(String floatingEdge) {
-            this.floatingButtonEdge = getFloatingButtonEdge(floatingEdge);
-            return this;
-        }
-
-        public Builder setFloatingButtonOffsetFromTop(int offset) {
-            this.offset = offset;
-            return this;
-        }
-
-        public RNInstabugReactnativePackage build() {
-            return new RNInstabugReactnativePackage(androidApplicationToken,application,invocationEvents,primaryColor,floatingButtonEdge,offset, isCrashReportingEnabled);
-        }
-
-        private InstabugFloatingButtonEdge getFloatingButtonEdge(String floatingButtonEdgeValue) {
-            InstabugFloatingButtonEdge floatingButtonEdge = InstabugFloatingButtonEdge.RIGHT;
-            try {
-                if (floatingButtonEdgeValue.equals(FLOATING_BUTTON_EDGE_LEFT)) {
-                    floatingButtonEdge = InstabugFloatingButtonEdge.LEFT;
-                } else if (floatingButtonEdgeValue.equals(FLOATING_BUTTON_EDGE_RIGHT)) {
-                    floatingButtonEdge = InstabugFloatingButtonEdge.RIGHT;
-                }
-                return floatingButtonEdge;
-
-            } catch(Exception e) {
-                e.printStackTrace();
-                return floatingButtonEdge;
-            }
-        }
-    }
-
 }

--- a/android/src/test/java/com/instabug/reactlibrary/RNInstabugReactnativeModuleTest.java
+++ b/android/src/test/java/com/instabug/reactlibrary/RNInstabugReactnativeModuleTest.java
@@ -51,7 +51,7 @@ import static org.mockito.Mockito.when;
 
 
 public class RNInstabugReactnativeModuleTest {
-    private RNInstabugReactnativeModule rnModule = new RNInstabugReactnativeModule(null,null,null);
+    private RNInstabugReactnativeModule rnModule = new RNInstabugReactnativeModule(null);
 
     private final static ScheduledExecutorService mainThread = Executors.newSingleThreadScheduledExecutor();
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -579,7 +579,7 @@ export namespace APM {
  * Starts the SDK.
  * This is the main SDK method that does all the magic. This is the only
  * method that SHOULD be called.
- * Should be called in constructor of the app registery component
+ * Should be called in constructor of the AppRegistry component
  * @param {string} token The token that identifies the app, you can find
  * it on your dashboard.
  * @param {invocationEvent} invocationEvent The event that invokes

--- a/index.js
+++ b/index.js
@@ -34,16 +34,14 @@ const InstabugModule = {
    * Starts the SDK.
    * This is the main SDK method that does all the magic. This is the only
    * method that SHOULD be called.
-   * Should be called in constructor of the app registery component
+   * Should be called in constructor of the AppRegistry component
    * @param {string} token The token that identifies the app, you can find
    * it on your dashboard.
    * @param {invocationEvent} invocationEvent The event that invokes
    * the SDK's UI.
    */
   start: function (token, invocationEvent) {
-    if (Platform.OS === 'ios') {
-      Instabug.start(token, invocationEvent);
-    }
+    Instabug.start(token, invocationEvent);
     _isFirstScreen = true;
     _currentScreen = firstScreen;
     setTimeout(function () {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
       "preunlink": "node node_modules/instabug-reactnative/unlink_bridge.js"
     },
     "android": {
-      "packageInstance": "\t\tnew RNInstabugReactnativePackage.Builder(\"YOUR_ANDROID_APPLICATION_TOKEN\",MainApplication.this)\n\t\t\t\t\t\t\t.setInvocationEvent(\"shake\")\n\t\t\t\t\t\t\t.setPrimaryColor(\"#1D82DC\")\n\t\t\t\t\t\t\t.setFloatingEdge(\"left\")\n\t\t\t\t\t\t\t.setFloatingButtonOffsetFromTop(250)\n\t\t\t\t\t\t\t.build()"
+      "packageInstance": "new RNInstabugReactnativePackage()"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
## Description of the change

Use Instabug.start to initialize SDK from JS without any extra native code on Android.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
