### PR TITLE
[MOB-10859] Add `NetworkLogger.setFilter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Deprecated
+
+- Deprecate `NetworkLogger.setRequestFilterExpression` in favour of `NetworkLogger.setFilter` ([#708](https://github.com/Instabug/Instabug-React-Native/pull/708)). 
+
 ## [11.9.1](https://github.com/Instabug/Instabug-React-Native/compare/v11.9.0...v11.9.1) (March 01, 2023)
 
 ### Changed

--- a/test/modules/NetworkLogger.spec.ts
+++ b/test/modules/NetworkLogger.spec.ts
@@ -158,6 +158,20 @@ describe('NetworkLogger Module', () => {
     consoleSpy.mockRestore();
   });
 
+  it('should not send log network when network data matches filter', async () => {
+    Interceptor.setOnDoneCallback = jest
+      .fn()
+      .mockImplementation((callback) => callback(clone(network)));
+
+    NetworkLogger.setFilter(
+      (network) => network.requestHeaders['Content-type'] === 'application/json',
+    );
+    NetworkLogger.setEnabled(true);
+
+    expect(NativeInstabug.networkLog).not.toBeCalled();
+    expect(NativeAPM.networkLog).not.toBeCalled();
+  });
+
   it('should not send log network when network data matches filter expression', async () => {
     Interceptor.setOnDoneCallback = jest
       .fn()


### PR DESCRIPTION
## Description of the change

Allows passing predicates instead of strings to filter network requests.

#### The deprecated method

```javascript
NetworkLogger.setRequestFilterExpression('network.requestHeaders[\'accept\'] === \'application/json\'');
```

#### The new method

```javascript
NetworkLogger.setFilter(network => network.requestHeaders['accept'] === 'application/json');
```


## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
