### PR TITLE
[MOB-8883] Add CI job to validate shell files and increase e2e_android resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,6 +163,7 @@ jobs:
     executor:
       name: android/android-machine
       tag: "2022.03.1"
+      resource-class: large
     working_directory: ~/project/InstabugSample/android
     steps:
       - checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,20 @@ jobs:
           working-directory: ./android
           test-command: ./gradlew test
 
+  validate_shell_files:
+    machine:
+      image: ubuntu-2004:current
+    working_directory: ~/project
+    steps:
+      - checkout:
+          path: ~/project
+      - run:
+          name: Validate Android Script
+          command: bash -n android/upload_sourcemap.sh
+      - run:
+          name: Validate iOS Script
+          command: bash -n ios/upload_sourcemap.sh
+
   test_ios:
     macos:
       xcode: "12.3.0"
@@ -198,6 +212,7 @@ workflows:
       - test_module
       - test_sample
       - test_android
+      - validate_shell_files
       - test_ios
       - e2e_ios
       - e2e_android
@@ -206,6 +221,7 @@ workflows:
             - test_module
             - test_sample
             - test_android
+            - validate_shell_files
             - test_ios
             - e2e_ios
             - e2e_android

--- a/android/upload_sourcemap.sh
+++ b/android/upload_sourcemap.sh
@@ -41,7 +41,6 @@ else
         echo "Instabug: err: entry file not found. Make sure" "\"${ENTRY_FILE}\"" "exists in your projects root directory. Or add the environment variable INSTABUG_ENTRY_FILE with the name of your entry file"
         exit 0
     fi
-    fi
     VERSION='{"code":"'"$INSTABUG_APP_VERSION_CODE"'","name":"'"$INSTABUG_APP_VERSION_NAME"'"}'
     echo "Instabug: Token found" "\""${INSTABUG_APP_TOKEN}"\""
     echo "Instabug: Version Code found" "\""${INSTABUG_APP_VERSION_CODE}"\""


### PR DESCRIPTION
## Description of the change
- Add CI job to validate shell files
- Fix Android shell script error
- Fix e2e_android flaky runs due to low resources

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)

## Checklists
### Code review 
- [X] This pull request has a descriptive title and information useful to a reviewer
- [X] Issue from task tracker has a link to this pull request 
