### PR TITLE
[MOB-8883] Fix Android upload_sourcemap.sh

### DIFF
--- a/android/upload_sourcemap.sh
+++ b/android/upload_sourcemap.sh
@@ -41,7 +41,6 @@ else
         echo "Instabug: err: entry file not found. Make sure" "\"${ENTRY_FILE}\"" "exists in your projects root directory. Or add the environment variable INSTABUG_ENTRY_FILE with the name of your entry file"
         exit 0
     fi
-    fi
     VERSION='{"code":"'"$INSTABUG_APP_VERSION_CODE"'","name":"'"$INSTABUG_APP_VERSION_NAME"'"}'
     echo "Instabug: Token found" "\""${INSTABUG_APP_TOKEN}"\""
     echo "Instabug: Version Code found" "\""${INSTABUG_APP_VERSION_CODE}"\""


### PR DESCRIPTION
## Description of the change
Android build process fails on the upload_sourcemap step, producing the following error:
```bash
./upload_sourcemap.sh: line 102: syntax error near unexpected token `fi'
./upload_sourcemap.sh: line 102: `fi'
...
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':instabug-reactnative:upload_sourcemap'.
> Process 'command 'sh'' finished with non-zero exit value 2
```

Upon closer inspection, it was found that there was one too many `fi` tokens in the bash script, meaning that the final line of the script was an unmatched `fi` (hence the error). This PR removes the additional token to ensure that the script runs without error.
## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
