### PR TITLE
[MOB-9109] Bump deprecated Xcode versions for affected CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
 
   test_ios:
     macos:
-      xcode: "12.3.0"
+      xcode: "13.4.1"
     working_directory: ~/project/InstabugSample
     environment:
       FL_OUTPUT_DIR: output
@@ -123,11 +123,11 @@ jobs:
           command: cd ios && pod install
       - run:
           name: Build and run tests
-          command: cd ios && xcodebuild  -allowProvisioningUpdates   -workspace InstabugSample.xcworkspace    -scheme InstabugSample    -sdk iphonesimulator    -destination 'platform=iOS Simulator,name=iPhone 12 Pro Max,OS=14.3'    test | xcpretty
+          command: cd ios && xcodebuild  -allowProvisioningUpdates   -workspace InstabugSample.xcworkspace    -scheme InstabugSample    -sdk iphonesimulator    -destination 'platform=iOS Simulator,name=iPhone 13 Pro Max,OS=15.5'    test | xcpretty
           no_output_timeout: 30m
   e2e_ios:
     macos:
-      xcode: "12.3.0"
+      xcode: "13.4.1"
     working_directory: ~/project/InstabugSample
     environment:
       FL_OUTPUT_DIR: output
@@ -154,7 +154,7 @@ jobs:
           command: cd ios && pod install
       - run:
           name: Detox - Build Release App
-          command: detox build --configuration ios.sim.release
+          command: detox build --configuration ios.sim.release --cleanup
       - run:
           name: Detox - Run E2E Tests
           command: detox test --configuration ios.sim.release --cleanup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,7 +196,7 @@ jobs:
 
   publish:
     macos:
-      xcode: "12.5.1"
+      xcode: "13.4.1"
     working_directory: "~"
     steps:
       - checkout:

--- a/InstabugSample/.detoxrc.json
+++ b/InstabugSample/.detoxrc.json
@@ -6,13 +6,13 @@
       "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/InstabugSample.app",
       "build": "xcodebuild -workspace ios/InstabugSample.xcworkspace -scheme InstabugSample -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build",
       "type": "ios.simulator",
-      "name": "iPhone 12"
+      "name": "iPhone 13 Pro Max"
     },
     "ios.sim.release": {
       "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/InstabugSample.app",
       "build": "xcodebuild -workspace ios/InstabugSample.xcworkspace -scheme InstabugSample -configuration Release -sdk iphonesimulator -derivedDataPath ios/build",
       "type": "ios.simulator",
-      "name": "iPhone 12"
+      "name": "iPhone 13 Pro Max"
     },
     "android.emu.debug": {
       "binaryPath": "android/app/build/outputs/apk/debug/app-debug.apk",

--- a/InstabugSample/package.json
+++ b/InstabugSample/package.json
@@ -23,7 +23,7 @@
     "@babel/runtime": "^7.15.4",
     "@react-native-community/eslint-config": "^3.0.1",
     "babel-jest": "^27.2.5",
-    "detox": "^19.5.7",
+    "detox": "^19.8.4",
     "eslint": "^7.32.0",
     "jest": "^27.2.5",
     "metro-react-native-babel-preset": "^0.66.2",


### PR DESCRIPTION
## Description of the change
- Bumps xcode version to v13.4.1 for `test_ios`, `e2e_ios` and `publish` jobs
- Bumps Detox version to v19.8.4
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request 
