### PR TITLE
[MOB-9980] Add `sync_generated_files` CI Job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,21 @@ jobs:
           name: Validate iOS Script
           command: bash -n ios/upload_sourcemap.sh
 
+  # Make sure that files like yarn.lock and project.pbxproj
+  # are in sync with the latest changes in package.json and 
+  # ios/upload_sourcemap.sh files respectively.
+  validate_changes:
+    macos:
+      xcode: 13.4.1
+    working_directory: ~/project
+    steps:
+      - checkout
+      - run: yarn
+      - run: cd InstabugSample && yarn
+      - run: cd InstabugSample/ios && pod install
+      - run: git --no-pager diff
+      - run: git diff-index --exit-code HEAD
+
   test_ios:
     macos:
       xcode: "13.4.1"
@@ -214,6 +229,7 @@ workflows:
       - test_sample
       - test_android
       - validate_shell_files
+      - validate_changes
       - test_ios
       - e2e_ios
       - e2e_android
@@ -223,6 +239,7 @@ workflows:
             - test_sample
             - test_android
             - validate_shell_files
+            - validate_changes
             - test_ios
             - e2e_ios
             - e2e_android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
   # Make sure that files like yarn.lock and project.pbxproj
   # are in sync with the latest changes in package.json and 
   # ios/upload_sourcemap.sh files respectively.
-  validate_changes:
+  validate_sync:
     macos:
       xcode: 13.4.1
     working_directory: ~/project
@@ -229,7 +229,7 @@ workflows:
       - test_sample
       - test_android
       - validate_shell_files
-      - validate_changes
+      - validate_sync
       - test_ios
       - e2e_ios
       - e2e_android
@@ -239,7 +239,7 @@ workflows:
             - test_sample
             - test_android
             - validate_shell_files
-            - validate_changes
+            - validate_sync
             - test_ios
             - e2e_ios
             - e2e_android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
   # Make sure that files like yarn.lock and project.pbxproj
   # are in sync with the latest changes in package.json and 
   # ios/upload_sourcemap.sh files respectively.
-  validate_sync:
+  sync_generated_files:
     macos:
       xcode: 13.4.1
     working_directory: ~/project
@@ -116,7 +116,7 @@ jobs:
       - run: cd InstabugSample && yarn
       - run: cd InstabugSample/ios && pod install
       - run: git --no-pager diff
-      - run: git diff-index HEAD -p -I EXCLUDED_ARCHS --exit-code
+      - run: git diff-index HEAD --exit-code -p -I EXCLUDED_ARCHS # Ignore Arch Changes
 
   test_ios:
     macos:
@@ -229,7 +229,7 @@ workflows:
       - test_sample
       - test_android
       - validate_shell_files
-      - validate_sync
+      - sync_generated_files
       - test_ios
       - e2e_ios
       - e2e_android
@@ -239,7 +239,7 @@ workflows:
             - test_sample
             - test_android
             - validate_shell_files
-            - validate_sync
+            - sync_generated_files
             - test_ios
             - e2e_ios
             - e2e_android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ jobs:
       - run: cd InstabugSample && yarn
       - run: cd InstabugSample/ios && pod install
       - run: git --no-pager diff
-      - run: git diff-index --exit-code HEAD
+      - run: git diff-index HEAD -p -I EXCLUDED_ARCHS --exit-code
 
   test_ios:
     macos:


### PR DESCRIPTION
## Description of the change

Make sure that files like `yarn.lock` and `project.pbxproj` are in sync with the latest changes in `package.json` and `ios/upload_sourcemap.sh` files respectively.

This job helps catch out of sync changes early on.
These are PRs that would not be neseccariy anymore after merging this: 

- #746 
- #747 
- #752 

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
