### PR TITLE
[MOB-9965] Fix Hermes source maps script on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Bumps the minimum supported React Native version to 0.60.0
 * Drops manual linking support
 * Adjusts source maps auto upload script on Android to support the bundled Hermes in RN v0.69
+* Fixes an issue with Hermes source maps generation script causing JS crashes on Android not getting deobfuscated correctly
 
 ## 11.0.2 (2022-07-20)
 

--- a/android/upload_sourcemap.sh
+++ b/android/upload_sourcemap.sh
@@ -75,6 +75,7 @@ else
         --dev false \
         --bundle-output index.android.bundle \
         --sourcemap-output index.android.bundle.packager.map \
+        --minify false
 
         $HERMES_PATH -emit-binary -out index.android.bundle.hbc index.android.bundle -O -output-source-map > /dev/null 2>&1
 


### PR DESCRIPTION
## Description of the change
Disable minification in Hermes source maps generation script by adding the argument `--minify false`
## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request 
