### PR TITLE
[MOB-9974] Resolve deprecated API calls in the sample app

### DIFF
--- a/InstabugSample/App.js
+++ b/InstabugSample/App.js
@@ -103,10 +103,6 @@ class Home extends Component<{}> {
     );
   }
 
-  showIntroMessage() {
-    Instabug.showIntroMessage();
-  }
-
   invoke() {
     Instabug.show();
   }

--- a/InstabugSample/App.js
+++ b/InstabugSample/App.js
@@ -124,7 +124,7 @@ class Home extends Component<{}> {
   }
 
   sendBugReport() {
-    BugReporting.showWithOptions(BugReporting.reportType.bug);
+    BugReporting.show(BugReporting.reportType.bug);
   }
 
   sendCrashReport() {


### PR DESCRIPTION
## Description of the change

This method was deprecated and then removed in #703, so it crashes the sample app when you press the "SEND BUG REPORT" button, for that, I changed it to the current version of it, `BugReporting.show`.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
