### PR TITLE
[MOB-9975] Call Missing Android APIs in `start`

### DIFF
--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
@@ -122,9 +122,15 @@ public class RNInstabugReactnativeModule extends ReactContextBaseJavaModule {
                     final ArrayList<String> keys = ArrayUtil.parseReadableArrayOfStrings(invocationEventValues);
                     final ArrayList<InstabugInvocationEvent> parsedInvocationEvents = ArgsRegistry.invocationEvents.getAll(keys);
 
+                    setCurrentPlatform();
+                    setBaseUrlForDeprecationLogs();
+
                     new Instabug.Builder(getCurrentActivity().getApplication(), token)
                             .setInvocationEvents(parsedInvocationEvents.toArray(new InstabugInvocationEvent[0]))
                             .build();
+
+                    // Temporarily disabling APM hot launches
+                    APM.setHotAppLaunchEnabled(false);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }


### PR DESCRIPTION
## Description of the change

These APIs were removed by mistake in #699 while rebasing it on #704.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
