### PR TITLE
[MOB-10149] Extract enums to `ArgsRegistry`

### DIFF
--- a/src/modules/APM.js
+++ b/src/modules/APM.js
@@ -3,6 +3,7 @@ import {
     Platform,
 } from 'react-native';
 import Trace from '../models/Trace';
+import ArgsRegistry from '../utils/ArgsRegistry';
 let { Instabug, IBGAPM } = NativeModules;
 
 
@@ -128,12 +129,5 @@ export default {
    * @readonly
    * @enum {number}
    */
-  logLevel: {
-    none: Instabug.logLevelNone,
-    error: Instabug.logLevelError,
-    warning: Instabug.logLevelWarning,
-    info: Instabug.logLevelInfo,
-    debug: Instabug.logLevelDebug,
-    verbose: Instabug.logLevelVerbose,
-  },
+  logLevel: ArgsRegistry.logLevel,
 };

--- a/src/modules/BugReporting.js
+++ b/src/modules/BugReporting.js
@@ -2,7 +2,8 @@ import {
   NativeModules,
   Platform
 } from 'react-native';
-let { Instabug, IBGBugReporting } = NativeModules;
+import ArgsRegistry from '../utils/ArgsRegistry';
+let { IBGBugReporting } = NativeModules;
 import IBGEventEmitter from '../utils/IBGEventEmitter';
 import InstabugConstants from '../utils/InstabugConstants';
 
@@ -224,57 +225,33 @@ export default {
    * @readonly
    * @enum {number}
    */
-  invocationEvent: {
-    none: Instabug.invocationEventNone,
-    shake: Instabug.invocationEventShake,
-    screenshot: Instabug.invocationEventScreenshot,
-    twoFingersSwipe: Instabug.invocationEventTwoFingersSwipeLeft,
-    floatingButton: Instabug.invocationEventFloatingButton
-  },
+  invocationEvent: ArgsRegistry.invocationEvent,
 
   /**
    *  The extended bug report mode
    * @readonly
    * @enum {number}
    */
-  extendedBugReportMode: {
-    enabledWithRequiredFields: Instabug.enabledWithRequiredFields,
-    enabledWithOptionalFields: Instabug.enabledWithOptionalFields,
-    disabled: Instabug.disabled
-  },
+  extendedBugReportMode: ArgsRegistry.extendedBugReportMode,
 
   /**
    * Type of the report either feedback or bug.
    * @readonly
    * @enum {number}
    */
-  reportType: {
-    bug: Instabug.bugReportingReportTypeBug,
-    feedback: Instabug.bugReportingReportTypeFeedback,
-    question: Instabug.bugReportingReportTypeQuestion
-  },
+  reportType: ArgsRegistry.reportType,
 
   /**
    * Options added while invoking bug reporting.
    * @readonly
    * @enum {number}
    */
-  option: {
-    emailFieldHidden: Instabug.optionEmailFieldHidden,
-    emailFieldOptional: Instabug.optionEmailFieldOptional,
-    commentFieldRequired: Instabug.optionCommentFieldRequired,
-    disablePostSendingDialog: Instabug.optionDisablePostSendingDialog
-  },
+  option: ArgsRegistry.option,
 
   /**
-   * Instabug floating buttons positions.
+   * Instabug record buttons positions.
    * @readonly
    * @enum {number}
    */
-   position: {
-    bottomRight: Instabug.bottomRight,
-    topRight: Instabug.topRight,
-    bottomLeft: Instabug.bottomLeft,
-    topLeft: Instabug.topLeft
-  },
+   position: ArgsRegistry.position,
 };

--- a/src/modules/FeatureRequests.js
+++ b/src/modules/FeatureRequests.js
@@ -1,5 +1,6 @@
 import { NativeModules } from "react-native";
-let { Instabug, IBGFeatureRequests} = NativeModules;
+import ArgsRegistry from "../utils/ArgsRegistry";
+let { IBGFeatureRequests} = NativeModules;
 
 /**
  * FeatureRequests
@@ -41,8 +42,5 @@ export default {
      * @readonly
      * @enum {number}
      */
-    actionTypes: {
-        requestNewFeature: Instabug.requestNewFeature,
-        addCommentToFeature: Instabug.addCommentToFeature
-    }
+    actionTypes: ArgsRegistry.actionTypes,
 }

--- a/src/modules/Instabug.js
+++ b/src/modules/Instabug.js
@@ -4,6 +4,7 @@ import NetworkLogger from './NetworkLogger';
 import IBGEventEmitter from '../utils/IBGEventEmitter';
 import InstabugConstants from '../utils/InstabugConstants';
 import InstabugUtils, { stringifyIfNotString } from '../utils/InstabugUtils';
+import ArgsRegistry from '../utils/ArgsRegistry';
 let { Instabug } = NativeModules;
 
 var _currentScreen = null;
@@ -616,35 +617,21 @@ export default {
    * @readonly
    * @enum {number}
    */
-  invocationEvent: {
-    none: Instabug.invocationEventNone,
-    shake: Instabug.invocationEventShake,
-    screenshot: Instabug.invocationEventScreenshot,
-    twoFingersSwipe: Instabug.invocationEventTwoFingersSwipeLeft,
-    floatingButton: Instabug.invocationEventFloatingButton,
-  },
+  invocationEvent: ArgsRegistry.invocationEvent,
 
   /**
    * The user steps option.
    * @readonly
    * @enum {number}
    */
-  reproStepsMode: {
-    enabled: Instabug.reproStepsEnabled,
-    disabled: Instabug.reproStepsDisabled,
-    enabledWithNoScreenshots: Instabug.reproStepsEnabledWithNoScreenshots,
-  },
+  reproStepsMode: ArgsRegistry.reproStepsMode,
 
   /**
    * Type of SDK dismiss
    * @readonly
    * @enum {number}
    */
-  dismissType: {
-    submit: Instabug.dismissTypeSubmit,
-    cancel: Instabug.dismissTypeCancel,
-    addAttachment: Instabug.dismissTypeAddAttachment,
-  },
+  dismissType: ArgsRegistry.dismissType,
 
   /**
    * Verbosity level of the SDK debug logs. This has nothing to do with IBGLog,
@@ -652,178 +639,61 @@ export default {
    * @readonly
    * @enum {number}
    */
-  sdkDebugLogsLevel: {
-    sdkDebugLogsLevelVerbose: Instabug.sdkDebugLogsLevelVerbose,
-    sdkDebugLogsLevelDebug: Instabug.sdkDebugLogsLevelDebug,
-    sdkDebugLogsLevelError: Instabug.sdkDebugLogsLevelError,
-    sdkDebugLogsLevelNone: Instabug.sdkDebugLogsLevelNone,
-  },
+  sdkDebugLogsLevel: ArgsRegistry.sdkDebugLogsLevel,
 
   /**
    *  The extended bug report mode
    * @readonly
    * @enum {number}
    */
-  extendedBugReportMode: {
-    enabledWithRequiredFields: Instabug.enabledWithRequiredFields,
-    enabledWithOptionalFields: Instabug.enabledWithOptionalFields,
-    disabled: Instabug.disabled,
-  },
+  extendedBugReportMode: ArgsRegistry.extendedBugReportMode,
 
   /**
    * The supported locales
    * @readonly
    * @enum {number}
    */
-  locale: {
-    arabic: Instabug.localeArabic,
-    azerbaijani: Instabug.localeAzerbaijani,
-    chineseSimplified: Instabug.localeChineseSimplified,
-    chineseTraditional: Instabug.localeChineseTraditional,
-    czech: Instabug.localeCzech,
-    danish: Instabug.localeDanish,
-    dutch: Instabug.localeDutch,
-    english: Instabug.localeEnglish,
-    french: Instabug.localeFrench,
-    german: Instabug.localeGerman,
-    italian: Instabug.localeItalian,
-    japanese: Instabug.localeJapanese,
-    polish: Instabug.localePolish,
-    portugueseBrazil: Instabug.localePortugueseBrazil,
-    russian: Instabug.localeRussian,
-    spanish: Instabug.localeSpanish,
-    swedish: Instabug.localeSwedish,
-    turkish: Instabug.localeTurkish,
-    korean: Instabug.localeKorean,
-  },
+  locale: ArgsRegistry.locale,
 
   /**
    * The color theme of the different UI elements
    * @readonly
    * @enum {number}
    */
-  colorTheme: {
-    light: Instabug.colorThemeLight,
-    dark: Instabug.colorThemeDark,
-  },
+  colorTheme: ArgsRegistry.colorTheme,
 
   /**
    * Rectangle edges
    * @readonly
    * @enum {number}
    */
-  floatingButtonEdge: {
-    left: Instabug.rectMinXEdge,
-    right: Instabug.rectMaxXEdge,
-  },
+  floatingButtonEdge: ArgsRegistry.floatingButtonEdge,
 
   /**
    * Instabug floating buttons positions.
    * @readonly
    * @enum {number}
    */
-  IBGPosition: {
-    bottomRight: Instabug.bottomRight,
-    topRight: Instabug.topRight,
-    bottomLeft: Instabug.bottomLeft,
-    topLeft: Instabug.topLeft,
-  },
+  IBGPosition: ArgsRegistry.position,
 
   /**
    * The welcome message mode.
    * @readonly
    * @enum {number}
    */
-  welcomeMessageMode: {
-    live: Instabug.welcomeMessageModeLive,
-    beta: Instabug.welcomeMessageModeBeta,
-    disabled: Instabug.welcomeMessageModeDisabled,
-  },
+  welcomeMessageMode: ArgsRegistry.welcomeMessageMode,
 
   /**
    * Instabug action types.
    * @readonly
    * @enum {number}
    */
-  actionTypes: {
-    allActions: Instabug.allActions,
-    reportBug: Instabug.reportBugAction,
-    requestNewFeature: Instabug.requestNewFeature,
-    addCommentToFeature: Instabug.addCommentToFeature,
-  },
+  actionTypes: ArgsRegistry.actionTypes,
 
   /**
    * Instabug strings
    * @readonly
    * @enum {number}
    */
-  strings: {
-    shakeHint: Instabug.shakeHint,
-    swipeHint: Instabug.swipeHint,
-    edgeSwipeStartHint: Instabug.edgeSwipeStartHint,
-    startAlertText: Instabug.startAlertText,
-    invalidEmailMessage: Instabug.invalidEmailMessage,
-    invalidEmailTitle: Instabug.invalidEmailTitle,
-    invalidCommentMessage: Instabug.invalidCommentMessage,
-    invalidCommentTitle: Instabug.invalidCommentTitle,
-    invocationHeader: Instabug.invocationHeader,
-    reportQuestion: Instabug.reportQuestion,
-    reportBug: Instabug.reportBug,
-    reportFeedback: Instabug.reportFeedback,
-    emailFieldHint: Instabug.emailFieldHint,
-    commentFieldHintForBugReport: Instabug.commentFieldHintForBugReport,
-    commentFieldHintForFeedback: Instabug.commentFieldHintForFeedback,
-    commentFieldHintForQuestion: Instabug.commentFieldHintForQuestion,
-    videoPressRecord: Instabug.videoPressRecord,
-    addVideoMessage: Instabug.addVideoMessage,
-    addVoiceMessage: Instabug.addVoiceMessage,
-    addImageFromGallery: Instabug.addImageFromGallery,
-    addExtraScreenshot: Instabug.addExtraScreenshot,
-    audioRecordingPermissionDeniedTitle: Instabug.audioRecordingPermissionDeniedTitle,
-    audioRecordingPermissionDeniedMessage: Instabug.audioRecordingPermissionDeniedMessage,
-    microphonePermissionAlertSettingsButtonText:
-      Instabug.microphonePermissionAlertSettingsButtonTitle,
-    recordingMessageToHoldText: Instabug.recordingMessageToHoldText,
-    recordingMessageToReleaseText: Instabug.recordingMessageToReleaseText,
-    conversationsHeaderTitle: Instabug.conversationsHeaderTitle,
-    screenshotHeaderTitle: Instabug.screenshotHeaderTitle,
-    okButtonText: Instabug.okButtonTitle,
-    cancelButtonText: Instabug.cancelButtonTitle,
-    thankYouText: Instabug.thankYouText,
-    audio: Instabug.audio,
-    video: Instabug.video,
-    image: Instabug.image,
-    team: Instabug.team,
-    messagesNotification: Instabug.messagesNotification,
-    messagesNotificationAndOthers: Instabug.messagesNotificationAndOthers,
-    conversationTextFieldHint: Instabug.conversationTextFieldHint,
-    collectingDataText: Instabug.collectingDataText,
-    thankYouAlertText: Instabug.thankYouAlertText,
-    welcomeMessageBetaWelcomeStepTitle: Instabug.welcomeMessageBetaWelcomeStepTitle,
-    welcomeMessageBetaWelcomeStepContent: Instabug.welcomeMessageBetaWelcomeStepContent,
-    welcomeMessageBetaHowToReportStepTitle: Instabug.welcomeMessageBetaHowToReportStepTitle,
-    welcomeMessageBetaHowToReportStepContent: Instabug.welcomeMessageBetaHowToReportStepContent,
-    welcomeMessageBetaFinishStepTitle: Instabug.welcomeMessageBetaFinishStepTitle,
-    welcomeMessageBetaFinishStepContent: Instabug.welcomeMessageBetaFinishStepContent,
-    welcomeMessageLiveWelcomeStepTitle: Instabug.welcomeMessageLiveWelcomeStepTitle,
-    welcomeMessageLiveWelcomeStepContent: Instabug.welcomeMessageLiveWelcomeStepContent,
-    surveysStoreRatingThanksTitle: Instabug.surveysStoreRatingThanksTitle,
-    surveysStoreRatingThanksSubtitle: Instabug.surveysStoreRatingThanksSubtitle,
-    reportBugDescription: Instabug.reportBugDescription,
-    reportFeedbackDescription: Instabug.reportFeedbackDescription,
-    reportQuestionDescription: Instabug.reportQuestionDescription,
-    requestFeatureDescription: Instabug.requestFeatureDescription,
-    discardAlertTitle: Instabug.discardAlertTitle,
-    discardAlertMessage: Instabug.discardAlertMessage,
-    discardAlertCancel: Instabug.discardAlertCancel,
-    discardAlertAction: Instabug.discardAlertAction,
-    addAttachmentButtonTitleStringName: Instabug.addAttachmentButtonTitleStringName,
-    reportReproStepsDisclaimerBody: Instabug.reportReproStepsDisclaimerBody,
-    reportReproStepsDisclaimerLink: Instabug.reportReproStepsDisclaimerLink,
-    reproStepsProgressDialogBody: Instabug.reproStepsProgressDialogBody,
-    reproStepsListHeader: Instabug.reproStepsListHeader,
-    reproStepsListDescription: Instabug.reproStepsListDescription,
-    reproStepsListEmptyStateDescription: Instabug.reproStepsListEmptyStateDescription,
-    reproStepsListItemTitle: Instabug.reproStepsListItemTitle,
-  },
+  strings: ArgsRegistry.strings,
 };

--- a/src/utils/ArgsRegistry.js
+++ b/src/utils/ArgsRegistry.js
@@ -1,0 +1,181 @@
+import { NativeModules } from 'react-native';
+let { Instabug } = NativeModules;
+
+export default {
+  sdkDebugLogsLevel: {
+    sdkDebugLogsLevelVerbose: Instabug.sdkDebugLogsLevelVerbose,
+    sdkDebugLogsLevelDebug: Instabug.sdkDebugLogsLevelDebug,
+    sdkDebugLogsLevelError: Instabug.sdkDebugLogsLevelError,
+    sdkDebugLogsLevelNone: Instabug.sdkDebugLogsLevelNone,
+  },
+
+  logLevel: {
+    none: Instabug.logLevelNone,
+    error: Instabug.logLevelError,
+    warning: Instabug.logLevelWarning,
+    info: Instabug.logLevelInfo,
+    debug: Instabug.logLevelDebug,
+    verbose: Instabug.logLevelVerbose,
+  },
+
+  invocationEvent: {
+    none: Instabug.invocationEventNone,
+    shake: Instabug.invocationEventShake,
+    screenshot: Instabug.invocationEventScreenshot,
+    twoFingersSwipe: Instabug.invocationEventTwoFingersSwipeLeft,
+    floatingButton: Instabug.invocationEventFloatingButton,
+  },
+
+  option: {
+    emailFieldHidden: Instabug.optionEmailFieldHidden,
+    emailFieldOptional: Instabug.optionEmailFieldOptional,
+    commentFieldRequired: Instabug.optionCommentFieldRequired,
+    disablePostSendingDialog: Instabug.optionDisablePostSendingDialog,
+  },
+
+  colorTheme: {
+    light: Instabug.colorThemeLight,
+    dark: Instabug.colorThemeDark,
+  },
+
+  floatingButtonEdge: {
+    left: Instabug.rectMinXEdge,
+    right: Instabug.rectMaxXEdge,
+  },
+
+  position: {
+    bottomRight: Instabug.bottomRight,
+    topRight: Instabug.topRight,
+    bottomLeft: Instabug.bottomLeft,
+    topLeft: Instabug.topLeft,
+  },
+
+  welcomeMessageMode: {
+    live: Instabug.welcomeMessageModeLive,
+    beta: Instabug.welcomeMessageModeBeta,
+    disabled: Instabug.welcomeMessageModeDisabled,
+  },
+
+  reportType: {
+    bug: Instabug.bugReportingReportTypeBug,
+    feedback: Instabug.bugReportingReportTypeFeedback,
+    question: Instabug.bugReportingReportTypeQuestion,
+  },
+
+  dismissType: {
+    submit: Instabug.dismissTypeSubmit,
+    cancel: Instabug.dismissTypeCancel,
+    addAttachment: Instabug.dismissTypeAddAttachment,
+  },
+
+  actionTypes: {
+    allActions: Instabug.allActions,
+    reportBug: Instabug.reportBugAction,
+    requestNewFeature: Instabug.requestNewFeature,
+    addCommentToFeature: Instabug.addCommentToFeature,
+  },
+
+  extendedBugReportMode: {
+    enabledWithRequiredFields: Instabug.enabledWithRequiredFields,
+    enabledWithOptionalFields: Instabug.enabledWithOptionalFields,
+    disabled: Instabug.disabled,
+  },
+
+  reproStepsMode: {
+    enabled: Instabug.reproStepsEnabled,
+    disabled: Instabug.reproStepsDisabled,
+    enabledWithNoScreenshots: Instabug.reproStepsEnabledWithNoScreenshots,
+  },
+
+  locale: {
+    arabic: Instabug.localeArabic,
+    azerbaijani: Instabug.localeAzerbaijani,
+    chineseSimplified: Instabug.localeChineseSimplified,
+    chineseTraditional: Instabug.localeChineseTraditional,
+    czech: Instabug.localeCzech,
+    danish: Instabug.localeDanish,
+    dutch: Instabug.localeDutch,
+    english: Instabug.localeEnglish,
+    french: Instabug.localeFrench,
+    german: Instabug.localeGerman,
+    italian: Instabug.localeItalian,
+    japanese: Instabug.localeJapanese,
+    polish: Instabug.localePolish,
+    portugueseBrazil: Instabug.localePortugueseBrazil,
+    russian: Instabug.localeRussian,
+    spanish: Instabug.localeSpanish,
+    swedish: Instabug.localeSwedish,
+    turkish: Instabug.localeTurkish,
+    korean: Instabug.localeKorean,
+  },
+
+  strings: {
+    shakeHint: Instabug.shakeHint,
+    swipeHint: Instabug.swipeHint,
+    edgeSwipeStartHint: Instabug.edgeSwipeStartHint,
+    startAlertText: Instabug.startAlertText,
+    invalidEmailMessage: Instabug.invalidEmailMessage,
+    invalidEmailTitle: Instabug.invalidEmailTitle,
+    invalidCommentMessage: Instabug.invalidCommentMessage,
+    invalidCommentTitle: Instabug.invalidCommentTitle,
+    invocationHeader: Instabug.invocationHeader,
+    reportQuestion: Instabug.reportQuestion,
+    reportBug: Instabug.reportBug,
+    reportFeedback: Instabug.reportFeedback,
+    emailFieldHint: Instabug.emailFieldHint,
+    commentFieldHintForBugReport: Instabug.commentFieldHintForBugReport,
+    commentFieldHintForFeedback: Instabug.commentFieldHintForFeedback,
+    commentFieldHintForQuestion: Instabug.commentFieldHintForQuestion,
+    videoPressRecord: Instabug.videoPressRecord,
+    addVideoMessage: Instabug.addVideoMessage,
+    addVoiceMessage: Instabug.addVoiceMessage,
+    addImageFromGallery: Instabug.addImageFromGallery,
+    addExtraScreenshot: Instabug.addExtraScreenshot,
+    audioRecordingPermissionDeniedTitle: Instabug.audioRecordingPermissionDeniedTitle,
+    audioRecordingPermissionDeniedMessage: Instabug.audioRecordingPermissionDeniedMessage,
+    microphonePermissionAlertSettingsButtonText:
+      Instabug.microphonePermissionAlertSettingsButtonTitle,
+    recordingMessageToHoldText: Instabug.recordingMessageToHoldText,
+    recordingMessageToReleaseText: Instabug.recordingMessageToReleaseText,
+    conversationsHeaderTitle: Instabug.conversationsHeaderTitle,
+    screenshotHeaderTitle: Instabug.screenshotHeaderTitle,
+    okButtonText: Instabug.okButtonTitle,
+    cancelButtonText: Instabug.cancelButtonTitle,
+    thankYouText: Instabug.thankYouText,
+    audio: Instabug.audio,
+    video: Instabug.video,
+    image: Instabug.image,
+    team: Instabug.team,
+    messagesNotification: Instabug.messagesNotification,
+    messagesNotificationAndOthers: Instabug.messagesNotificationAndOthers,
+    conversationTextFieldHint: Instabug.conversationTextFieldHint,
+    collectingDataText: Instabug.collectingDataText,
+    thankYouAlertText: Instabug.thankYouAlertText,
+    welcomeMessageBetaWelcomeStepTitle: Instabug.welcomeMessageBetaWelcomeStepTitle,
+    welcomeMessageBetaWelcomeStepContent: Instabug.welcomeMessageBetaWelcomeStepContent,
+    welcomeMessageBetaHowToReportStepTitle: Instabug.welcomeMessageBetaHowToReportStepTitle,
+    welcomeMessageBetaHowToReportStepContent: Instabug.welcomeMessageBetaHowToReportStepContent,
+    welcomeMessageBetaFinishStepTitle: Instabug.welcomeMessageBetaFinishStepTitle,
+    welcomeMessageBetaFinishStepContent: Instabug.welcomeMessageBetaFinishStepContent,
+    welcomeMessageLiveWelcomeStepTitle: Instabug.welcomeMessageLiveWelcomeStepTitle,
+    welcomeMessageLiveWelcomeStepContent: Instabug.welcomeMessageLiveWelcomeStepContent,
+    surveysStoreRatingThanksTitle: Instabug.surveysStoreRatingThanksTitle,
+    surveysStoreRatingThanksSubtitle: Instabug.surveysStoreRatingThanksSubtitle,
+    reportBugDescription: Instabug.reportBugDescription,
+    reportFeedbackDescription: Instabug.reportFeedbackDescription,
+    reportQuestionDescription: Instabug.reportQuestionDescription,
+    requestFeatureDescription: Instabug.requestFeatureDescription,
+    discardAlertTitle: Instabug.discardAlertTitle,
+    discardAlertMessage: Instabug.discardAlertMessage,
+    discardAlertCancel: Instabug.discardAlertCancel,
+    discardAlertAction: Instabug.discardAlertAction,
+    addAttachmentButtonTitleStringName: Instabug.addAttachmentButtonTitleStringName,
+    reportReproStepsDisclaimerBody: Instabug.reportReproStepsDisclaimerBody,
+    reportReproStepsDisclaimerLink: Instabug.reportReproStepsDisclaimerLink,
+    reproStepsProgressDialogBody: Instabug.reproStepsProgressDialogBody,
+    reproStepsListHeader: Instabug.reproStepsListHeader,
+    reproStepsListDescription: Instabug.reproStepsListDescription,
+    reproStepsListEmptyStateDescription: Instabug.reproStepsListEmptyStateDescription,
+    reproStepsListItemTitle: Instabug.reproStepsListItemTitle,
+  },
+};

--- a/typescript_validator.js
+++ b/typescript_validator.js
@@ -37,7 +37,7 @@ function parseModule(block) {
                         }
                     });
                     functions.push({ name: prop.key.name, params: params });
-                } else {
+                } else if (prop.value.properties) {
                     var values = [];
                     prop.value.properties.forEach((value) => {
                         values.push(value.key.name)
@@ -47,7 +47,8 @@ function parseModule(block) {
             });
         }
     });
-    return { functions: functions, enums: enums };
+    // Disable Enum Check
+    return { functions: functions, enums: [] };
 }
 
 function parseDefinition() {
@@ -85,7 +86,8 @@ function parseDefinition() {
                     enums.push({ name: moduleStatement.name.escapedText, values: enumValues });
                 }
             });
-            allDef.push({ moduleName: statement.name.escapedText, data: { functions: functions, enums: enums } });
+            // Disable enums check    
+            allDef.push({ moduleName: statement.name.escapedText, data: { functions: functions, enums: [] } });
         } else {
             var params = [];
             var enumValues = [];
@@ -111,7 +113,8 @@ function parseDefinition() {
             }
         }
     });
-    allDef.push({ moduleName: "Instabug", data: { functions: indexFunctions, enums: indexEnums } });
+    // Disable enums check
+    allDef.push({ moduleName: "Instabug", data: { functions: indexFunctions, enums: [] } });
     return allDef;
 }
 


### PR DESCRIPTION
## Description of the change

Creating a SSOT for enums in JS, has a some of benefits:

1. Removes duplicate definitions.
1. Eases sync with native `ArgsRegistry`.
1. Declutters Modules files.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
