### PR TITLE
[MOB-10117] Migrate Sinon Mocks to Jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "jest": {
     "preset": "react-native",
+    "resetMocks": true,
     "coverageDirectory": "./coverage/",
     "collectCoverage": true,
     "modulePathIgnorePatterns": [

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "jest": {
     "preset": "react-native",
-    "resetMocks": true,
+    "clearMocks": true,
     "coverageDirectory": "./coverage/",
     "collectCoverage": true,
     "modulePathIgnorePatterns": [

--- a/test/apm.spec.js
+++ b/test/apm.spec.js
@@ -7,24 +7,12 @@ import "react-native";
 import { NativeModules, Platform } from "react-native";
 import "./jest/mockAPM";
 import APM from "../src/modules/APM";
-import sinon from "sinon";
 
 import IBGEventEmitter from "../src/utils/IBGEventEmitter";
 
-describe("APM Module", () => {
-  const setEnabled = sinon.spy(NativeModules.IBGAPM, "setEnabled");
-  const setAppLaunchEnabled = sinon.spy(NativeModules.IBGAPM, "setAppLaunchEnabled");
-  const setLogLevel = sinon.spy(NativeModules.IBGAPM, "setLogLevel");
-  const setAutoUITraceEnabled = sinon.spy(NativeModules.IBGAPM, "setAutoUITraceEnabled");
-  const startExecutionTrace = sinon.spy(NativeModules.IBGAPM, "startExecutionTrace");
-  const setExecutionTraceAttribute = sinon.spy(NativeModules.IBGAPM, "setExecutionTraceAttribute");
-  const endExecutionTrace = sinon.spy(NativeModules.IBGAPM, "endExecutionTrace");
-  const startUITrace = sinon.spy(NativeModules.IBGAPM, "startUITrace");
-  const endUITrace = sinon.spy(NativeModules.IBGAPM, "endUITrace");
-  const endAppLaunch = sinon.spy(NativeModules.IBGAPM, "endAppLaunch");
-  const setNetworkLoggingEnabled = sinon.spy(NativeModules.Instabug, "setNetworkLoggingEnabled");
-  const _ibgSleep = sinon.spy(NativeModules.IBGAPM, "ibgSleep");
+const { Instabug: NativeInstabug, IBGAPM: NativeIBGAPM } = NativeModules;
 
+describe("APM Module", () => {
   beforeEach(() => {
     IBGEventEmitter.removeAllListeners();
   });
@@ -32,75 +20,89 @@ describe("APM Module", () => {
   it("should call the native method setEnabled", () => {
     APM.setEnabled(true);
 
-    expect(setEnabled.calledOnceWithExactly(true)).toBe(true);
+    expect(NativeIBGAPM.setEnabled).toBeCalledTimes(1);
+    expect(NativeIBGAPM.setEnabled).toBeCalledWith(true);
   });
 
   it("should call the native method setAppLaunchEnabled", () => {
     APM.setAppLaunchEnabled(true);
 
-    expect(setAppLaunchEnabled.calledOnceWithExactly(true)).toBe(true);
+    expect(NativeIBGAPM.setAppLaunchEnabled).toBeCalledTimes(1);
+    expect(NativeIBGAPM.setAppLaunchEnabled).toBeCalledWith(true);
   });
 
   it("should call the native method setNetworkEnabledIOS", () => {
     Platform.OS = 'ios';
     APM.setNetworkEnabledIOS(true);
 
-    expect(setNetworkLoggingEnabled.calledOnceWithExactly(true)).toBe(true);
+    expect(NativeInstabug.setNetworkLoggingEnabled).toBeCalledTimes(1);
+    expect(NativeInstabug.setNetworkLoggingEnabled).toBeCalledWith(true);
   });
 
   it("should call the native method endAppLaunch", () => {
     APM.endAppLaunch();
 
-    expect(endAppLaunch.calledOnceWithExactly()).toBe(true);
+    expect(NativeIBGAPM.endAppLaunch).toBeCalledTimes(1);
+    expect(NativeIBGAPM.endAppLaunch).toBeCalledWith();
   });
 
   it("should call the native method setAutoUITraceEnabled", () => {
     APM.setAutoUITraceEnabled(true);
 
-    expect(setAutoUITraceEnabled.calledOnceWithExactly(true)).toBe(true);
+    expect(NativeIBGAPM.setAutoUITraceEnabled).toBeCalledTimes(1);
+    expect(NativeIBGAPM.setAutoUITraceEnabled).toBeCalledWith(true);
   });
 
   it("should call the native method setLogLevel", () => {
     APM.setLogLevel(APM.logLevel.verbose);
 
-    expect(setLogLevel.calledOnceWithExactly(APM.logLevel.verbose)).toBe(true);
+    expect(NativeIBGAPM.setLogLevel).toBeCalledTimes(1);
+    expect(NativeIBGAPM.setLogLevel).toBeCalledWith(APM.logLevel.verbose);
   });
 
   it("should call the native method startExecutionTrace", () => {
     APM.startExecutionTrace("trace");
 
-    expect(startExecutionTrace.calledOnceWith("trace")).toBe(true);
+    expect(NativeIBGAPM.startExecutionTrace).toBeCalledTimes(1);
+    expect(NativeIBGAPM.startExecutionTrace).toBeCalledWith("trace", expect.any(String), expect.any(Function));
   });
 
   it("should call the native method setExecutionTraceAttribute", () => {
     const trace = APM.startExecutionTrace("trace").then(() => {
       trace.setAttribute("key", "value");
-      expect(setExecutionTraceAttribute.calledOnceWithExactly(expect.any(String), "key", "value")).toBe(true);
+
+      expect(NativeIBGAPM.setExecutionTraceAttribute).toBeCalledTimes(1);
+      expect(NativeIBGAPM.setExecutionTraceAttribute).toBeCalledWith(expect.any(String), "key", "value");
     });
   });
 
   it("should call the native method endExecutionTrace", () => {
     const trace = APM.startExecutionTrace("trace").then(() => {
       trace.end();
-      expect(endExecutionTrace.calledOnceWithExactly(expect.any(String))).toBe(true);
+
+      expect(NativeIBGAPM.endExecutionTrace).toBeCalledTimes(1);
+      expect(NativeIBGAPM.endExecutionTrace).toBeCalledWith(expect.any(String));
     });
   });
 
   it("should call the native method startUITrace", () => {
     APM.startUITrace("uiTrace");
 
-    expect(startUITrace.calledOnceWithExactly("uiTrace")).toBe(true);
+    expect(NativeIBGAPM.startUITrace).toBeCalledTimes(1);
+    expect(NativeIBGAPM.startUITrace).toBeCalledWith("uiTrace");
   });
 
   it("should call the native method endUITrace", () => {
     APM.endUITrace();
 
-    expect(endUITrace.calledOnceWithExactly()).toBe(true);
+    expect(NativeIBGAPM.endUITrace).toBeCalledTimes(1);
+    expect(NativeIBGAPM.endUITrace).toBeCalledWith();
   });
 
   it("should call the native method _ibgSleep", () => {
     APM._ibgSleep();
 
-    expect(_ibgSleep.calledOnceWithExactly()).toBe(true);
+    expect(NativeIBGAPM.ibgSleep).toBeCalledTimes(1);
+    expect(NativeIBGAPM.ibgSleep).toBeCalledWith();
   });
 });

--- a/test/bugReporting.spec.js
+++ b/test/bugReporting.spec.js
@@ -12,39 +12,11 @@ import BugReporting from '../src/modules/BugReporting'
 import Instabug from '../src/';
 import IBGEventEmitter from '../src/utils/IBGEventEmitter';
 import IBGConstants from '../src/utils/InstabugConstants';
-import sinon from 'sinon';
 
-
+const { IBGBugReporting: NativeIBGBugReporting } = NativeModules;
 
 describe('Testing BugReporting Module', () => {
-  
-  const setEnabled = sinon.spy(NativeModules.IBGBugReporting, 'setEnabled');
-  const setInvocationEvents = sinon.spy(NativeModules.IBGBugReporting, 'setInvocationEvents');
-  const setOptions = sinon.spy(NativeModules.IBGBugReporting, 'setOptions');
-  const setShakingThresholdForiPhone = sinon.spy(NativeModules.IBGBugReporting, 'setShakingThresholdForiPhone');
-  const setShakingThresholdForiPad = sinon.spy(NativeModules.IBGBugReporting, 'setShakingThresholdForiPad');
-  const setShakingThresholdForAndroid = sinon.spy(NativeModules.IBGBugReporting, 'setShakingThresholdForAndroid');
-  const setExtendedBugReportMode = sinon.spy(NativeModules.IBGBugReporting, 'setExtendedBugReportMode');
-  const setReportTypes = sinon.spy(NativeModules.IBGBugReporting, 'setReportTypes');
-  const show = sinon.spy(NativeModules.IBGBugReporting, 'show');
-  const setOnInvokeHandler = sinon.spy(NativeModules.IBGBugReporting, 'setOnInvokeHandler');
-  const setOnSDKDismissedHandler = sinon.spy(NativeModules.IBGBugReporting, 'setOnSDKDismissedHandler');
-  const setAutoScreenRecordingEnabled = sinon.spy(NativeModules.IBGBugReporting, 'setAutoScreenRecordingEnabled');
-  const setAutoScreenRecordingDuration = sinon.spy(NativeModules.IBGBugReporting, 'setAutoScreenRecordingDuration');
-  const setViewHierarchyEnabled = sinon.spy(NativeModules.IBGBugReporting, 'setViewHierarchyEnabled');
-  const didSelectPromptOptionHandler = sinon.spy(NativeModules.IBGBugReporting, 'setDidSelectPromptOptionHandler');
-  const setFloatingButtonEdge = sinon.spy(NativeModules.IBGBugReporting, 'setFloatingButtonEdge');
-  const setEnabledAttachmentTypes = sinon.spy(NativeModules.IBGBugReporting, 'setEnabledAttachmentTypes');
-  const setVideoRecordingFloatingButtonPosition = sinon.spy(NativeModules.IBGBugReporting, 'setVideoRecordingFloatingButtonPosition');
-
-
   beforeEach(() => {
-    setShakingThresholdForiPhone.resetHistory();
-    setShakingThresholdForiPad.resetHistory();
-    setShakingThresholdForAndroid.resetHistory();
-    setOnInvokeHandler.resetHistory();
-    setOnSDKDismissedHandler.resetHistory();
-    didSelectPromptOptionHandler.resetHistory();
     IBGEventEmitter.removeAllListeners();
   });
 
@@ -52,7 +24,8 @@ describe('Testing BugReporting Module', () => {
 
     BugReporting.setEnabled(true);
 
-    expect(setEnabled.calledOnceWithExactly(true)).toBe(true);
+    expect(NativeIBGBugReporting.setEnabled).toBeCalledTimes(1);
+    expect(NativeIBGBugReporting.setEnabled).toBeCalledWith(true);
 
   });
 
@@ -61,7 +34,8 @@ describe('Testing BugReporting Module', () => {
     const arrayOfInvocationEvents = [BugReporting.invocationEvent.floatingButton, BugReporting.invocationEvent.shake];
     BugReporting.setInvocationEvents(arrayOfInvocationEvents);
 
-    expect(setInvocationEvents.calledOnceWithExactly(arrayOfInvocationEvents)).toBe(true);
+    expect(NativeIBGBugReporting.setInvocationEvents).toBeCalledTimes(1);
+    expect(NativeIBGBugReporting.setInvocationEvents).toBeCalledWith(arrayOfInvocationEvents);
 
   });
 
@@ -70,7 +44,8 @@ describe('Testing BugReporting Module', () => {
     const arrayOfOptions = [BugReporting.option.commentFieldRequired];
     BugReporting.setOptions(arrayOfOptions);
 
-    expect(setOptions.calledOnceWithExactly(arrayOfOptions)).toBe(true);
+    expect(NativeIBGBugReporting.setOptions).toBeCalledTimes(1);
+    expect(NativeIBGBugReporting.setOptions).toBeCalledWith(arrayOfOptions);
 
   });
 
@@ -80,7 +55,8 @@ describe('Testing BugReporting Module', () => {
     const value = 2.5;
     BugReporting.setShakingThresholdForiPhone(value);
 
-    expect(setShakingThresholdForiPhone.calledOnceWithExactly(value)).toBe(true);
+    expect(NativeIBGBugReporting.setShakingThresholdForiPhone).toBeCalledTimes(1);
+    expect(NativeIBGBugReporting.setShakingThresholdForiPhone).toBeCalledWith(value);
 
   });
 
@@ -89,7 +65,7 @@ describe('Testing BugReporting Module', () => {
     Platform.OS = 'android';
     BugReporting.setShakingThresholdForiPhone(2.5);
 
-    expect(setShakingThresholdForiPhone.notCalled).toBe(true);
+    expect(NativeIBGBugReporting.setShakingThresholdForiPhone).not.toBeCalled();
 
   });
 
@@ -99,7 +75,8 @@ describe('Testing BugReporting Module', () => {
     const value = 0.6;
     BugReporting.setShakingThresholdForiPad(value);
 
-    expect(setShakingThresholdForiPad.calledOnceWithExactly(value)).toBe(true);
+    expect(NativeIBGBugReporting.setShakingThresholdForiPad).toBeCalledTimes(1);
+    expect(NativeIBGBugReporting.setShakingThresholdForiPad).toBeCalledWith(value);
 
   });
 
@@ -108,7 +85,7 @@ describe('Testing BugReporting Module', () => {
     Platform.OS = 'android';
     BugReporting.setShakingThresholdForiPad(0.6);
 
-    expect(setShakingThresholdForiPad.notCalled).toBe(true);
+    expect(NativeIBGBugReporting.setShakingThresholdForiPad).not.toBeCalled();
 
   });
 
@@ -118,7 +95,8 @@ describe('Testing BugReporting Module', () => {
     const value = 350;
     BugReporting.setShakingThresholdForAndroid(value);
 
-    expect(setShakingThresholdForAndroid.calledOnceWithExactly(value)).toBe(true);
+    expect(NativeIBGBugReporting.setShakingThresholdForAndroid).toBeCalledTimes(1);
+    expect(NativeIBGBugReporting.setShakingThresholdForAndroid).toBeCalledWith(value);
 
   });
 
@@ -127,7 +105,7 @@ describe('Testing BugReporting Module', () => {
     Platform.OS = 'ios';
     BugReporting.setShakingThresholdForAndroid(350);
 
-    expect(setShakingThresholdForAndroid.notCalled).toBe(true);
+    expect(NativeIBGBugReporting.setShakingThresholdForAndroid).not.toBeCalled();
 
   });
   
@@ -135,7 +113,8 @@ describe('Testing BugReporting Module', () => {
 
     BugReporting.setExtendedBugReportMode(true);
 
-    expect(setExtendedBugReportMode.calledOnceWithExactly(true)).toBe(true);
+    expect(NativeIBGBugReporting.setExtendedBugReportMode).toBeCalledTimes(1);
+    expect(NativeIBGBugReporting.setExtendedBugReportMode).toBeCalledWith(true);
 
   });
 
@@ -144,7 +123,8 @@ describe('Testing BugReporting Module', () => {
     const arrayOfReportTypes = [BugReporting.reportType.bug];
     BugReporting.setReportTypes(arrayOfReportTypes);
 
-    expect(setReportTypes.calledOnceWithExactly(arrayOfReportTypes)).toBe(true);
+    expect(NativeIBGBugReporting.setReportTypes).toBeCalledTimes(1);
+    expect(NativeIBGBugReporting.setReportTypes).toBeCalledWith(arrayOfReportTypes);
 
   });
 
@@ -154,7 +134,8 @@ describe('Testing BugReporting Module', () => {
     const arrayOfOptions = [BugReporting.option.commentFieldRequired];
     BugReporting.show(reportType, arrayOfOptions);
 
-    expect(show.calledOnceWithExactly(reportType, arrayOfOptions)).toBe(true);
+    expect(NativeIBGBugReporting.show).toBeCalledTimes(1);
+    expect(NativeIBGBugReporting.show).toBeCalledWith(reportType, arrayOfOptions);
 
   });
 
@@ -163,7 +144,8 @@ describe('Testing BugReporting Module', () => {
     const callback = jest.fn()
     BugReporting.onInvokeHandler(callback);
 
-    expect(setOnInvokeHandler.calledOnceWithExactly(callback)).toBe(true);
+    expect(NativeIBGBugReporting.setOnInvokeHandler).toBeCalledTimes(1);
+    expect(NativeIBGBugReporting.setOnInvokeHandler).toBeCalledWith(callback);
 
   });
 
@@ -183,45 +165,47 @@ describe('Testing BugReporting Module', () => {
     const callback = jest.fn()
     BugReporting.onSDKDismissedHandler(callback);
 
-    expect(setOnSDKDismissedHandler.calledOnceWithExactly(callback)).toBe(true);
+    expect(NativeIBGBugReporting.setOnSDKDismissedHandler).toBeCalledTimes(1);
+    expect(NativeIBGBugReporting.setOnSDKDismissedHandler).toBeCalledWith(callback);
 
   });
 
-  it('should invoke callback on emitting the event IBGpostInvocationHandler', (done) => {
+  it('should invoke callback on emitting the event IBGpostInvocationHandler', () => {
 
     const dismissType = 'cancel';
     const reportType = 'bug';
-    const callback = (dismiss, report) => {
-      expect(dismiss).toBe(dismissType);
-      expect(report).toBe(reportType);
-      done();
-    }
+    const callback = jest.fn();
+
     BugReporting.onSDKDismissedHandler(callback);
     IBGEventEmitter.emit(IBGConstants.ON_SDK_DISMISSED_HANDLER, {dismissType: dismissType, reportType: reportType});
 
     expect(IBGEventEmitter.getListeners(IBGConstants.ON_SDK_DISMISSED_HANDLER).length).toEqual(1);
-
+    expect(callback).toBeCalledTimes(1);
+    expect(callback).toBeCalledWith(dismissType, reportType);
   });
 
   it('should call the native method setAutoScreenRecordingEnabled', () => {
 
     BugReporting.setAutoScreenRecordingEnabled(true);
 
-    expect(setAutoScreenRecordingEnabled.calledOnceWithExactly(true)).toBe(true);
+    expect(NativeIBGBugReporting.setAutoScreenRecordingEnabled).toBeCalledTimes(1);
+    expect(NativeIBGBugReporting.setAutoScreenRecordingEnabled).toBeCalledWith(true);
 
   });
 
   it('should call the native method setAutoScreenRecordingDuration on iOS', () => {
     Platform.OS = 'ios';
     BugReporting.setAutoScreenRecordingDurationIOS(30);
-    expect(setAutoScreenRecordingDuration.calledOnceWithExactly(30)).toBe(true);
+    expect(NativeIBGBugReporting.setAutoScreenRecordingDuration).toBeCalledTimes(1);
+    expect(NativeIBGBugReporting.setAutoScreenRecordingDuration).toBeCalledWith(30);
   });
 
   it('should call the native method setViewHierarchyEnabled', () => {
 
     BugReporting.setViewHierarchyEnabled(true);
 
-    expect(setViewHierarchyEnabled.calledOnceWithExactly(true)).toBe(true);
+    expect(NativeIBGBugReporting.setViewHierarchyEnabled).toBeCalledTimes(1);
+    expect(NativeIBGBugReporting.setViewHierarchyEnabled).toBeCalledWith(true);
 
   });
 
@@ -232,17 +216,18 @@ describe('Testing BugReporting Module', () => {
     BugReporting.setDidSelectPromptOptionHandler(jest.fn());
     IBGEventEmitter.emit(IBGConstants.DID_SELECT_PROMPT_OPTION_HANDLER, {});
 
-    expect(didSelectPromptOptionHandler.notCalled).toBe(true);
+    expect(NativeIBGBugReporting.setDidSelectPromptOptionHandler).not.toBeCalled();
     expect(IBGEventEmitter.getListeners(IBGConstants.DID_SELECT_PROMPT_OPTION_HANDLER).length).toEqual(0);
   });
 
-  it('should call the native method didSelectPromptOptionHandler with a function', () => {
+  it('should call the native method setDidSelectPromptOptionHandler with a function', () => {
 
     Platform.OS = 'ios';
     const callback = jest.fn()
     BugReporting.setDidSelectPromptOptionHandler(callback);
 
-    expect(didSelectPromptOptionHandler.calledOnceWithExactly(callback)).toBe(true);
+    expect(NativeIBGBugReporting.setDidSelectPromptOptionHandler).toBeCalledTimes(1);
+    expect(NativeIBGBugReporting.setDidSelectPromptOptionHandler).toBeCalledWith(callback);
 
   });
 
@@ -252,7 +237,8 @@ describe('Testing BugReporting Module', () => {
     const edge = Instabug.floatingButtonEdge.left;
     BugReporting.setFloatingButtonEdge(edge, offsetFromTop);
 
-    expect(setFloatingButtonEdge.calledOnceWithExactly(edge, offsetFromTop)).toBe(true);
+    expect(NativeIBGBugReporting.setFloatingButtonEdge).toBeCalledTimes(1);
+    expect(NativeIBGBugReporting.setFloatingButtonEdge).toBeCalledWith(edge, offsetFromTop);
 
   });
 
@@ -260,7 +246,8 @@ describe('Testing BugReporting Module', () => {
 
     BugReporting.setEnabledAttachmentTypes(true, true, false, true);
 
-    expect(setEnabledAttachmentTypes.calledOnceWithExactly(true, true, false, true)).toBe(true);
+    expect(NativeIBGBugReporting.setEnabledAttachmentTypes).toBeCalledTimes(1);
+    expect(NativeIBGBugReporting.setEnabledAttachmentTypes).toBeCalledWith(true, true, false, true);
 
   });
 
@@ -269,7 +256,8 @@ describe('Testing BugReporting Module', () => {
     const position = 30;
     BugReporting.setVideoRecordingFloatingButtonPosition(position);
 
-    expect(setVideoRecordingFloatingButtonPosition.calledOnceWithExactly(position)).toBe(true);
+    expect(NativeIBGBugReporting.setVideoRecordingFloatingButtonPosition).toBeCalledTimes(1);
+    expect(NativeIBGBugReporting.setVideoRecordingFloatingButtonPosition).toBeCalledWith(position);
 
   });
 });

--- a/test/featureRequests.spec.js
+++ b/test/featureRequests.spec.js
@@ -7,20 +7,17 @@ import 'react-native';
 import { NativeModules } from 'react-native';
 import './jest/mockFeatureRequests';
 import FeatureRequests from '../src/modules/FeatureRequests'
-import sinon from 'sinon';
+
+const { IBGFeatureRequests: NativeIBGFeatureRequests } = NativeModules;
 
 describe('Feature Requests Module', () => {
-  
-  const setEmailFieldRequiredForFeatureRequests = sinon.spy(NativeModules.IBGFeatureRequests, 'setEmailFieldRequiredForFeatureRequests');
-  const showFeatureRequests = sinon.spy(NativeModules.IBGFeatureRequests, 'show');
-  const setEnabled = sinon.spy(NativeModules.IBGFeatureRequests, 'setEnabled');
-
   it('should call the native method setEmailFieldRequiredForFeatureRequests', () => {
 
     const actionTypes = [FeatureRequests.actionTypes.reportBug]
     FeatureRequests.setEmailFieldRequired(true, actionTypes);
 
-    expect(setEmailFieldRequiredForFeatureRequests.calledOnceWithExactly(true, actionTypes)).toBe(true);
+    expect(NativeIBGFeatureRequests.setEmailFieldRequiredForFeatureRequests).toBeCalledTimes(1);
+    expect(NativeIBGFeatureRequests.setEmailFieldRequiredForFeatureRequests).toBeCalledWith(true, actionTypes);
 
   });
 
@@ -28,7 +25,7 @@ describe('Feature Requests Module', () => {
 
     FeatureRequests.show();
 
-    expect(showFeatureRequests.calledOnce).toBe(true);
+    expect(NativeIBGFeatureRequests.show).toBeCalledTimes(1);
 
   });
 
@@ -36,7 +33,8 @@ describe('Feature Requests Module', () => {
 
     FeatureRequests.setEnabled(true);
 
-    expect(setEnabled.calledOnceWithExactly(true)).toBe(true);
+    expect(NativeIBGFeatureRequests.setEnabled).toBeCalledTimes(1);
+    expect(NativeIBGFeatureRequests.setEnabled).toBeCalledWith(true);
 
   });
 

--- a/test/instabug.spec.js
+++ b/test/instabug.spec.js
@@ -6,144 +6,84 @@
 import 'react-native';
 import React from 'react';
 import { NativeModules, Platform, processColor, findNodeHandle, Text } from 'react-native';
+import waitForExpect from 'wait-for-expect';
 import './jest/mockInstabug';
 import './jest/mockInstabugUtils';
 import './jest/mockXhrNetworkInterceotor';
 import Instabug from '../src/modules/Instabug';
 import Report from '../src/models/Report';
-import sinon from 'sinon';
 
 import IBGConstants from '../src/utils/InstabugConstants';
 import IBGEventEmitter from '../src/utils/IBGEventEmitter';
 import { green } from 'ansi-colors';
 import InstabugUtils from '../src/utils/InstabugUtils';
 
+const { Instabug: NativeInstabug } = NativeModules;
+
 describe('Instabug Module', () => {
-
-  const start = sinon.spy(NativeModules.Instabug, 'start');
-  const setUserData = sinon.spy(NativeModules.Instabug, 'setUserData');
-  const setTrackUserSteps = sinon.spy(NativeModules.Instabug, 'setTrackUserSteps');
-  const setIBGLogPrintsToConsole = sinon.spy(NativeModules.Instabug, 'setIBGLogPrintsToConsole');
-  const setSessionProfilerEnabled = sinon.spy(NativeModules.Instabug, 'setSessionProfilerEnabled');
-  const setLocale = sinon.spy(NativeModules.Instabug, 'setLocale');
-  const setColorTheme = sinon.spy(NativeModules.Instabug, 'setColorTheme');
-  const setPrimaryColor = sinon.spy(NativeModules.Instabug, 'setPrimaryColor');
-  const appendTags = sinon.spy(NativeModules.Instabug, 'appendTags');
-  const resetTags = sinon.spy(NativeModules.Instabug, 'resetTags');
-  const getTags = sinon.spy(NativeModules.Instabug, 'getTags');
-  const setString = sinon.spy(NativeModules.Instabug, 'setString');
-  const identifyUser = sinon.spy(NativeModules.Instabug, 'identifyUser');
-  const logOut = sinon.spy(NativeModules.Instabug, 'logOut');
-  const logUserEvent = sinon.spy(NativeModules.Instabug, 'logUserEvent');
-  const log = sinon.spy(NativeModules.Instabug, 'log');
-  const logVerbose = sinon.spy(NativeModules.Instabug, 'logVerbose');
-  const logInfo = sinon.spy(NativeModules.Instabug, 'logInfo');
-  const logWarn = sinon.spy(NativeModules.Instabug, 'logWarn');
-  const logError = sinon.spy(NativeModules.Instabug, 'logError');
-  const logDebug = sinon.spy(NativeModules.Instabug, 'logDebug');
-  const clearLogs = sinon.spy(NativeModules.Instabug, 'clearLogs');
-  const setReproStepsMode = sinon.spy(NativeModules.Instabug, 'setReproStepsMode');
-  const setSdkDebugLogsLevel = sinon.spy(NativeModules.Instabug, 'setSdkDebugLogsLevel');
-  const setUserAttribute = sinon.spy(NativeModules.Instabug, 'setUserAttribute');
-  const getUserAttribute = sinon.spy(NativeModules.Instabug, 'getUserAttribute');
-  const removeUserAttribute = sinon.spy(NativeModules.Instabug, 'removeUserAttribute');
-  const getAllUserAttributes = sinon.spy(NativeModules.Instabug, 'getAllUserAttributes');
-  const clearAllUserAttributes = sinon.spy(NativeModules.Instabug, 'clearAllUserAttributes');
-  const setDebugEnabled = sinon.spy(NativeModules.Instabug, 'setDebugEnabled');
-  const enable = sinon.spy(NativeModules.Instabug, 'enable');
-  const disable = sinon.spy(NativeModules.Instabug, 'disable');
-  const isRunningLive = sinon.spy(NativeModules.Instabug, 'isRunningLive');
-  const showWelcomeMessageWithMode = sinon.spy(NativeModules.Instabug, 'showWelcomeMessageWithMode');
-  const setWelcomeMessageMode = sinon.spy(NativeModules.Instabug, 'setWelcomeMessageMode');
-  const setFileAttachment = sinon.spy(NativeModules.Instabug, 'setFileAttachment');
-  const addPrivateView = sinon.spy(NativeModules.Instabug, 'addPrivateView');
-  const removePrivateView = sinon.spy(NativeModules.Instabug, 'removePrivateView');
-  const show = sinon.spy(NativeModules.Instabug, 'show');
-  const setPreSendingHandler = sinon.spy(NativeModules.Instabug, 'setPreSendingHandler');
-  const callPrivateApi = sinon.spy(NativeModules.Instabug, 'callPrivateApi');
-  const sendHandledJSCrash = sinon.spy(NativeModules.Instabug, 'sendHandledJSCrash');
-  const sendJSCrash = sinon.spy(NativeModules.Instabug, 'sendJSCrash');
-  const reportScreenChange = sinon.spy(NativeModules.Instabug, 'reportScreenChange');
-  const addExperiments = sinon.spy(NativeModules.Instabug, 'addExperiments');
-  const removeExperiments = sinon.spy(NativeModules.Instabug, 'removeExperiments');
-  const clearAllExperiments = sinon.spy(NativeModules.Instabug, 'clearAllExperiments');
-
   beforeEach(() => {
-    start.resetHistory();
-    setTrackUserSteps.resetHistory();
-    setIBGLogPrintsToConsole.resetHistory();
-    log.resetHistory();
-    setSdkDebugLogsLevel.resetHistory();
-    setDebugEnabled.resetHistory();
-    enable.resetHistory();
-    disable.resetHistory();
-    isRunningLive.resetHistory();
-    setFileAttachment.resetHistory();
-    addPrivateView.resetHistory();
-    removePrivateView.resetHistory();
-    setPreSendingHandler.resetHistory();
     IBGEventEmitter.removeAllListeners();
   });
 
   it('componentDidAppearListener should call the native method reportScreenChange', () => {
-    const screenName = "some-screen";
-    var obj = {componentId: "1",
-              componentName: screenName,
-              "passProps": "screenName"};
+    const screenName = 'some-screen';
+    var obj = { componentId: '1', componentName: screenName, passProps: 'screenName' };
     Instabug.componentDidAppearListener(obj);
-    expect(reportScreenChange.calledOnceWithExactly(screenName)).toBe(true);
+    expect(NativeInstabug.reportScreenChange).toBeCalledTimes(1);
+    expect(NativeInstabug.reportScreenChange).toBeCalledWith(screenName);
   });
 
-  it('onNavigationStateChange should call the native method reportScreenChange', () => {
-    const screenName = "some-screen";
-    InstabugUtils.getActiveRouteName.mockImplementation((screenName) => screenName);
-    Instabug.onNavigationStateChange(screenName, screenName, screenName);
-    expect(reportScreenChange.calledOnceWithExactly(screenName)).toBe(true);
+  it('onNavigationStateChange should call the native method reportScreenChange', async () => {
+    InstabugUtils.getActiveRouteName.mockImplementation(screenName => screenName);
+    Instabug.onNavigationStateChange('home', 'settings');
+
+    await waitForExpect(() => {
+      expect(NativeInstabug.reportScreenChange).toBeCalledTimes(1);
+      expect(NativeInstabug.reportScreenChange).toBeCalledWith('settings');
+    });
   });
 
   it('should call the native method start', () => {
     const token = 'some-token';
-    const invocationEvents = [Instabug.invocationEvent.floatingButton, Instabug.invocationEvent.shake];
+    const invocationEvents = [
+      Instabug.invocationEvent.floatingButton,
+      Instabug.invocationEvent.shake,
+    ];
     Instabug.start(token, invocationEvents);
 
-    expect(start.calledOnceWithExactly(token, invocationEvents)).toBe(true);
-
+    expect(NativeInstabug.start).toBeCalledTimes(1);
+    expect(NativeInstabug.start).toBeCalledWith(token, invocationEvents);
   });
 
   it('should call the native method setUserData', () => {
-
-    const userData = "userData";
+    const userData = 'userData';
     Instabug.setUserData(userData);
 
-    expect(setUserData.calledOnceWithExactly(userData)).toBe(true);
-
+    expect(NativeInstabug.setUserData).toBeCalledTimes(1);
+    expect(NativeInstabug.setUserData).toBeCalledWith(userData);
   });
 
   it('should call the native method setTrackUserSteps', () => {
-
     Platform.OS = 'ios';
     Instabug.setTrackUserSteps(true);
 
-    expect(setTrackUserSteps.calledOnceWithExactly(true)).toBe(true);
-
+    expect(NativeInstabug.setTrackUserSteps).toBeCalledTimes(1);
+    expect(NativeInstabug.setTrackUserSteps).toBeCalledWith(true);
   });
 
   it('should not call the native method setTrackUserSteps when platform is android', () => {
-
     Platform.OS = 'android';
     Instabug.setTrackUserSteps(true);
 
-    expect(setTrackUserSteps.notCalled).toBe(true);
-
+    expect(NativeInstabug.setTrackUserSteps).not.toBeCalled();
   });
 
   it('should call the native method setIBGLogPrintsToConsole', () => {
-
     Platform.OS = 'ios';
     Instabug.setIBGLogPrintsToConsole(true);
 
-    expect(setIBGLogPrintsToConsole.calledOnceWithExactly(true)).toBe(true);
-
+    expect(NativeInstabug.setIBGLogPrintsToConsole).toBeCalledTimes(1);
+    expect(NativeInstabug.setIBGLogPrintsToConsole).toBeCalledWith(true);
   });
 
   it('should not call the native method setIBGLogPrintsToConsole when platform is android', () => {
@@ -151,409 +91,352 @@ describe('Instabug Module', () => {
     Platform.OS = 'android';
     Instabug.setIBGLogPrintsToConsole(true);
 
-    expect(setIBGLogPrintsToConsole.notCalled).toBe(true);
-
+    expect(NativeInstabug.setIBGLogPrintsToConsole).not.toBeCalled();
   });
 
   it('should call the native method setSessionProfilerEnabled', () => {
-
     Instabug.setSessionProfilerEnabled(true);
 
-    expect(setSessionProfilerEnabled.calledOnceWithExactly(true)).toBe(true);
-
+    expect(NativeInstabug.setSessionProfilerEnabled).toBeCalledTimes(1);
+    expect(NativeInstabug.setSessionProfilerEnabled).toBeCalledWith(true);
   });
 
   it('should call the native method setLocale', () => {
-
     const locale = Instabug.locale.english;
     Instabug.setLocale(locale);
 
-    expect(setLocale.calledOnceWithExactly(locale)).toBe(true);
-
+    expect(NativeInstabug.setLocale).toBeCalledTimes(1);
+    expect(NativeInstabug.setLocale).toBeCalledWith(locale);
   });
 
   it('should call the native method setColorTheme', () => {
-
     const theme = Instabug.colorTheme.dark;
-    Instabug.setColorTheme(theme)
+    Instabug.setColorTheme(theme);
 
-    expect(setColorTheme.calledOnceWithExactly(theme)).toBe(true);
-
+    expect(NativeInstabug.setColorTheme).toBeCalledTimes(1);
+    expect(NativeInstabug.setColorTheme).toBeCalledWith(theme);
   });
 
   it('should call the native method setPrimaryColor', () => {
-
     const color = green;
-    Instabug.setPrimaryColor(color)
+    Instabug.setPrimaryColor(color);
 
-    expect(setPrimaryColor.calledOnceWithExactly(processColor(color))).toBe(true);
-
+    expect(NativeInstabug.setPrimaryColor).toBeCalledTimes(1);
+    expect(NativeInstabug.setPrimaryColor).toBeCalledWith(processColor(color));
   });
 
   it('should call the native method appendTags', () => {
-
     const tags = ['tag1', 'tag2'];
     Instabug.appendTags(tags);
 
-    expect(appendTags.calledOnceWithExactly(tags)).toBe(true);
-
+    expect(NativeInstabug.appendTags).toBeCalledTimes(1);
+    expect(NativeInstabug.appendTags).toBeCalledWith(tags);
   });
 
   it('should call the native method resetTags', () => {
-
     Instabug.resetTags();
 
-    expect(resetTags.calledOnce).toBe(true);
-
+    expect(NativeInstabug.resetTags).toBeCalledTimes(1);
   });
 
-  it('should call native method getTags', (done) => {
-
-    const callback = (tags) => {
+  it('should call native method getTags', done => {
+    const callback = tags => {
       expect(tags).toBeDefined();
       done();
-    }
+    };
     Instabug.getTags(callback);
-    expect(getTags.calledOnceWithExactly(callback)).toBe(true);
-
+    expect(NativeInstabug.getTags).toBeCalledTimes(1);
+    expect(NativeInstabug.getTags).toBeCalledWith(callback);
   });
 
   it('should call the native method setString', () => {
-
     const string = 'report an issue';
     const key = Instabug.strings.reportBug;
     Instabug.setString(key, string);
 
-    expect(setString.calledOnceWithExactly(string, key)).toBe(true);
-
+    expect(NativeInstabug.setString).toBeCalledTimes(1);
+    expect(NativeInstabug.setString).toBeCalledWith(string, key);
   });
 
   it('should call the native method identifyUser', () => {
-
-
     const email = 'foo@instabug.com';
     const name = 'Instabug';
     Instabug.identifyUser(email, name);
 
-    expect(identifyUser.calledOnceWithExactly(email, name)).toBe(true);
-
+    expect(NativeInstabug.identifyUser).toBeCalledTimes(1);
+    expect(NativeInstabug.identifyUser).toBeCalledWith(email, name);
   });
 
   it('should call the native method logOut', () => {
-
     Instabug.logOut();
 
-    expect(logOut.calledOnce).toBe(true);
-
+    expect(NativeInstabug.logOut).toBeCalledTimes(1);
   });
 
   it('should call the native method logUserEvent', () => {
-
     const event = 'click';
     Instabug.logUserEvent(event);
 
-    expect(logUserEvent.calledOnceWithExactly(event)).toBe(true);
-
+    expect(NativeInstabug.logUserEvent).toBeCalledTimes(1);
+    expect(NativeInstabug.logUserEvent).toBeCalledWith(event);
   });
 
   it('should call the native method logVerbose', () => {
-
     const message = 'log';
     Instabug.logVerbose(message);
 
-    expect(logVerbose.calledOnce).toBe(true);
-
+    expect(NativeInstabug.logVerbose).toBeCalledTimes(1);
   });
 
   it('should call the native method logDebug', () => {
-
     const message = 'log';
     Instabug.logDebug(message);
 
-    expect(logDebug.calledOnce).toBe(true);
-
+    expect(NativeInstabug.logDebug).toBeCalledTimes(1);
   });
 
   it('should call the native method logInfo', () => {
-
     const message = 'log';
     Instabug.logInfo(message);
 
-    expect(logInfo.calledOnce).toBe(true);
-
+    expect(NativeInstabug.logInfo).toBeCalledTimes(1);
   });
 
   it('should call the native method logWarn', () => {
-
     const message = 'log';
     Instabug.logWarn(message);
 
-    expect(logWarn.calledOnce).toBe(true);
-
+    expect(NativeInstabug.logWarn).toBeCalledTimes(1);
   });
 
   it('should call the native method logError', () => {
-
     const message = 'log';
     Instabug.logError(message);
 
-    expect(logError.calledOnce).toBe(true);
-
+    expect(NativeInstabug.logError).toBeCalledTimes(1);
   });
 
   it('should call the native method clearLogs', () => {
-
     Instabug.clearLogs();
 
-    expect(clearLogs.calledOnce).toBe(true);
-
+    expect(NativeInstabug.clearLogs).toBeCalledTimes(1);
   });
 
   it('should call the native method setReproStepsMode', () => {
-
     const mode = Instabug.reproStepsMode.enabled;
     Instabug.setReproStepsMode(mode);
 
-    expect(setReproStepsMode.calledOnceWithExactly(mode)).toBe(true);
-
+    expect(NativeInstabug.setReproStepsMode).toBeCalledTimes(1);
+    expect(NativeInstabug.setReproStepsMode).toBeCalledWith(mode);
   });
 
   it('should call the native method setSdkDebugLogsLevel on iOS', () => {
     const debugLevel = Instabug.sdkDebugLogsLevel.sdkDebugLogsLevelVerbose;
-    
+
     Platform.OS = 'ios';
     Instabug.setSdkDebugLogsLevel(debugLevel);
 
-    expect(setSdkDebugLogsLevel.calledOnceWithExactly(debugLevel)).toBe(true);
+    expect(NativeInstabug.setSdkDebugLogsLevel).toBeCalledTimes(1);
+    expect(NativeInstabug.setSdkDebugLogsLevel).toBeCalledWith(debugLevel);
   });
 
   it('should not call the native method setSdkDebugLogsLevel on Android', () => {
     const debugLevel = Instabug.sdkDebugLogsLevel.sdkDebugLogsLevelVerbose;
-    
+
     Platform.OS = 'android';
     Instabug.setSdkDebugLogsLevel(debugLevel);
 
-    expect(setSdkDebugLogsLevel.notCalled).toBe(true);
+    expect(NativeInstabug.setSdkDebugLogsLevel).not.toBeCalled();
   });
 
   it('should call the native method setUserAttribute', () => {
-
     const key = 'age';
     const value = '24';
     Instabug.setUserAttribute(key, value);
 
-    expect(setUserAttribute.calledOnceWithExactly(key, value)).toBe(true);
-
+    expect(NativeInstabug.setUserAttribute).toBeCalledTimes(1);
+    expect(NativeInstabug.setUserAttribute).toBeCalledWith(key, value);
   });
 
-  it('should call native method getUserAttribute', (done) => {
-
-    const callback = (value) => {
+  it('should call native method getUserAttribute', done => {
+    const callback = value => {
       expect(value).toBeDefined();
       done();
-    }
+    };
     const key = 'age';
     Instabug.getUserAttribute(key, callback);
-    expect(getUserAttribute.calledOnceWithExactly(key, callback)).toBe(true);
-
+    expect(NativeInstabug.getUserAttribute).toBeCalledTimes(1);
+    expect(NativeInstabug.getUserAttribute).toBeCalledWith(key, callback);
   });
 
   it('should call the native method removeUserAttribute', () => {
-
     const key = 'age';
     Instabug.removeUserAttribute(key);
 
-    expect(removeUserAttribute.calledOnceWithExactly(key)).toBe(true);
-
+    expect(NativeInstabug.removeUserAttribute).toBeCalledTimes(1);
+    expect(NativeInstabug.removeUserAttribute).toBeCalledWith(key);
   });
 
-  it('should call native method getAllUserAttributes', (done) => {
-
-    const callback = (value) => {
+  it('should call native method getAllUserAttributes', done => {
+    const callback = value => {
       expect(value).toBeDefined();
       done();
-    }
+    };
     Instabug.getAllUserAttributes(callback);
-    expect(getAllUserAttributes.calledOnceWithExactly(callback)).toBe(true);
-
+    expect(NativeInstabug.getAllUserAttributes).toBeCalledTimes(1);
+    expect(NativeInstabug.getAllUserAttributes).toBeCalledWith(callback);
   });
 
   it('should call the native method clearAllUserAttributes', () => {
-
     Instabug.clearAllUserAttributes();
 
-    expect(clearAllUserAttributes.calledOnce).toBe(true);
-
+    expect(NativeInstabug.clearAllUserAttributes).toBeCalledTimes(1);
   });
 
   it('should call the native method setDebugEnabled', () => {
-
     Platform.OS = 'android';
     Instabug.setDebugEnabled(true);
 
-    expect(setDebugEnabled.calledOnceWithExactly(true)).toBe(true);
-
+    expect(NativeInstabug.setDebugEnabled).toBeCalledTimes(1);
+    expect(NativeInstabug.setDebugEnabled).toBeCalledWith(true);
   });
 
   it('should not call the native method setDebugEnabled when platform is ios', () => {
-
     Platform.OS = 'ios';
     Instabug.setDebugEnabled(true);
 
-    expect(setDebugEnabled.notCalled).toBe(true);
-
+    expect(NativeInstabug.setDebugEnabled).not.toBeCalled();
   });
 
   it('should call the native method enable', () => {
-
     Platform.OS = 'android';
     Instabug.enable();
 
-    expect(enable.calledOnce).toBe(true);
-
+    expect(NativeInstabug.enable).toBeCalledTimes(1);
   });
 
   it('should not call the native method enable when platform is ios', () => {
-
     Platform.OS = 'ios';
     Instabug.enable();
 
-    expect(enable.notCalled).toBe(true);
-
+    expect(NativeInstabug.enable).not.toBeCalled();
   });
 
   it('should call the native method disable', () => {
-
     Platform.OS = 'android';
     Instabug.disable();
 
-    expect(disable.calledOnce).toBe(true);
-
+    expect(NativeInstabug.disable).toBeCalledTimes(1);
   });
 
   it('should not call the native method disable when platform is ios', () => {
-
     Platform.OS = 'ios';
     Instabug.disable();
 
-    expect(disable.notCalled).toBe(true);
-
+    expect(NativeInstabug.disable).not.toBeCalled();
   });
 
-  it('should call the native method isRunningLive', (done) => {
-
+  it('should call the native method isRunningLive', done => {
     Platform.OS = 'ios';
-    const callback = (isRunningLive) => {
+    const callback = isRunningLive => {
       expect(isRunningLive).toBeDefined();
       done();
-    }
+    };
     Instabug.isRunningLive(callback);
 
-    expect(isRunningLive.calledOnceWithExactly(callback)).toBe(true);
-
+    expect(NativeInstabug.isRunningLive).toBeCalledTimes(1);
+    expect(NativeInstabug.isRunningLive).toBeCalledWith(callback);
   });
 
   it('should not call the native method isRunningLive when platform is android', () => {
-
     Platform.OS = 'android';
     Instabug.isRunningLive(jest.fn());
 
-    expect(isRunningLive.notCalled).toBe(true);
-
+    expect(NativeInstabug.isRunningLive).not.toBeCalled();
   });
 
   it('should call the native method showWelcomeMessageWithMode', () => {
-
     const mode = Instabug.welcomeMessageMode.beta;
     Instabug.showWelcomeMessage(mode);
 
-    expect(showWelcomeMessageWithMode.calledOnceWithExactly(mode)).toBe(true);
-
+    expect(NativeInstabug.showWelcomeMessageWithMode).toBeCalledTimes(1);
+    expect(NativeInstabug.showWelcomeMessageWithMode).toBeCalledWith(mode);
   });
 
   it('should call the native method setWelcomeMessageMode', () => {
-
     const mode = Instabug.welcomeMessageMode.beta;
     Instabug.setWelcomeMessageMode(mode);
 
-    expect(setWelcomeMessageMode.calledOnceWithExactly(mode)).toBe(true);
-
+    expect(NativeInstabug.setWelcomeMessageMode).toBeCalledTimes(1);
+    expect(NativeInstabug.setWelcomeMessageMode).toBeCalledWith(mode);
   });
 
   it('should call the native method setFileAttachment with filePath when platform is ios', () => {
-
     Platform.OS = 'ios';
     const path = '~/path';
     Instabug.addFileAttachment(path);
 
-    expect(setFileAttachment.calledOnceWithExactly(path)).toBe(true);
-
+    expect(NativeInstabug.setFileAttachment).toBeCalledTimes(1);
+    expect(NativeInstabug.setFileAttachment).toBeCalledWith(path);
   });
 
   it('should call the native method setFileAttachment with filePath and fileName when platform is android', () => {
-
     Platform.OS = 'android';
     const path = '~/path';
     const name = 'file';
     Instabug.addFileAttachment(path, name);
 
-    expect(setFileAttachment.calledOnceWithExactly(path, name)).toBe(true);
-
+    expect(NativeInstabug.setFileAttachment).toBeCalledTimes(1);
+    expect(NativeInstabug.setFileAttachment).toBeCalledWith(path, name);
   });
 
   it('should call the native method addPrivateView', () => {
-
-    <Text ref={(c) => this.textView = c} />
+    <Text ref={c => (this.textView = c)} />;
     Instabug.addPrivateView(this.textView);
 
-    expect(addPrivateView.calledOnceWithExactly(findNodeHandle(this.textView))).toBe(true);
+    expect(NativeInstabug.addPrivateView).toBeCalledTimes(1);
+    expect(NativeInstabug.addPrivateView).toBeCalledWith(findNodeHandle(this.textView));
   });
 
   it('should call the native method removePrivateView', () => {
-
-    <Text ref={(c) => this.textView = c} />
+    <Text ref={c => (this.textView = c)} />;
     Instabug.removePrivateView(this.textView);
 
-    expect(removePrivateView.calledOnceWithExactly(findNodeHandle(this.textView))).toBe(true);
+    expect(NativeInstabug.removePrivateView).toBeCalledTimes(1);
+    expect(NativeInstabug.removePrivateView).toBeCalledWith(findNodeHandle(this.textView));
   });
 
   it('should call the native method show', () => {
-
     Instabug.show();
 
-    expect(show.calledOnce).toBe(true);
-
+    expect(NativeInstabug.show).toBeCalledTimes(1);
   });
 
   it('should set _isOnReportHandlerSet to true on calling onReportSubmitHandler', () => {
-
     Instabug.onReportSubmitHandler(jest.fn());
     InstabugUtils.isOnReportHandlerSet.mockImplementation(() => true);
     const isReportHandlerSet = InstabugUtils.isOnReportHandlerSet();
 
     expect(isReportHandlerSet).toBe(true);
-
   });
 
   it('should call the native method setPreSendingHandler with a function', () => {
-
-    const callback = jest.fn()
+    const callback = jest.fn();
     Instabug.onReportSubmitHandler(callback);
 
-    expect(setPreSendingHandler.calledOnceWithExactly(callback)).toBe(true);
+    expect(NativeInstabug.setPreSendingHandler).toBeCalledTimes(1);
+    expect(NativeInstabug.setPreSendingHandler).toBeCalledWith(callback);
   });
 
-
-  it('should invoke callback on emitting the event IBGpreSendingHandler', (done) => {
-
+  it('should invoke callback on emitting the event IBGpreSendingHandler', done => {
     const report = {
       tags: ['tag1', 'tag2'],
       consoleLogs: ['consoleLog'],
       instabugLogs: ['instabugLog'],
       userAttributes: [{ age: '24' }],
-      fileAttachments: ['path']
+      fileAttachments: ['path'],
     };
-    const callback = (rep) => {
+    const callback = rep => {
       expect(rep).toBeInstanceOf(Report);
       expect(rep.tags).toBe(report.tags);
       expect(rep.consoleLogs).toBe(report.consoleLogs);
@@ -561,27 +444,25 @@ describe('Instabug Module', () => {
       expect(rep.userAttributes).toBe(report.userAttributes);
       expect(rep.fileAttachments).toBe(report.fileAttachments);
       done();
-    }
+    };
     Instabug.onReportSubmitHandler(callback);
     IBGEventEmitter.emit(IBGConstants.PRESENDING_HANDLER, report);
 
     expect(IBGEventEmitter.getListeners(IBGConstants.PRESENDING_HANDLER).length).toEqual(1);
-
   });
 
-  it('should invoke callback on emitting the event IBGSendHandledJSCrash', async (done) => {
-
+  it('should invoke callback on emitting the event IBGSendHandledJSCrash', async done => {
     Platform.OS = 'android';
     const report = {
       tags: ['tag1', 'tag2'],
       consoleLogs: ['consoleLog'],
       instabugLogs: ['instabugLog'],
       userAttributes: [{ age: '24' }],
-      fileAttachments: ['path']
+      fileAttachments: ['path'],
     };
     NativeModules.Instabug.getReport.mockResolvedValue(report);
     const jsonObject = { stack: 'error' };
-    const callback = (rep) => {
+    const callback = rep => {
       expect(rep).toBeInstanceOf(Report);
       expect(rep.tags).toBe(report.tags);
       expect(rep.consoleLogs).toBe(report.consoleLogs);
@@ -589,37 +470,34 @@ describe('Instabug Module', () => {
       expect(rep.userAttributes).toBe(report.userAttributes);
       expect(rep.fileAttachments).toBe(report.fileAttachments);
       done();
-    }
+    };
     Instabug.onReportSubmitHandler(callback);
     IBGEventEmitter.emit(IBGConstants.SEND_HANDLED_CRASH, jsonObject);
 
     expect(IBGEventEmitter.getListeners(IBGConstants.SEND_HANDLED_CRASH).length).toEqual(1);
-    await expect(sendHandledJSCrash.calledOnceWithExactly(jsonObject)).toBe(true);
-
+    await expect(NativeInstabug.sendHandledJSCrash).toBeCalledTimes(1);
+    await expect(NativeInstabug.sendHandledJSCrash).toBeCalledWith(jsonObject);
   });
 
   it('should not invoke callback on emitting the event IBGSendHandledJSCrash when Platform is iOS', () => {
-
     Platform.OS = 'ios';
     Instabug.onReportSubmitHandler(jest.fn());
     IBGEventEmitter.emit(IBGConstants.SEND_HANDLED_CRASH, {});
     expect(IBGEventEmitter.getListeners(IBGConstants.SEND_HANDLED_CRASH).length).toEqual(0);
-
   });
 
-  it('should invoke callback on emitting the event IBGSendUnhandledJSCrash', async (done) => {
-
+  it('should invoke callback on emitting the event IBGSendUnhandledJSCrash', async done => {
     Platform.OS = 'android';
     const report = {
       tags: ['tag1', 'tag2'],
       consoleLogs: ['consoleLog'],
       instabugLogs: ['instabugLog'],
       userAttributes: [{ age: '24' }],
-      fileAttachments: ['path']
+      fileAttachments: ['path'],
     };
     NativeModules.Instabug.getReport.mockResolvedValue(report);
     const jsonObject = { stack: 'error' };
-    const callback = (rep) => {
+    const callback = rep => {
       expect(rep).toBeInstanceOf(Report);
       expect(rep.tags).toBe(report.tags);
       expect(rep.consoleLogs).toBe(report.consoleLogs);
@@ -627,48 +505,47 @@ describe('Instabug Module', () => {
       expect(rep.userAttributes).toBe(report.userAttributes);
       expect(rep.fileAttachments).toBe(report.fileAttachments);
       done();
-    }
+    };
     Instabug.onReportSubmitHandler(callback);
     IBGEventEmitter.emit(IBGConstants.SEND_UNHANDLED_CRASH, jsonObject);
 
     expect(IBGEventEmitter.getListeners(IBGConstants.SEND_UNHANDLED_CRASH).length).toEqual(1);
-    await expect(sendJSCrash.calledOnceWithExactly(jsonObject)).toBe(true);
-
+    await expect(NativeInstabug.sendJSCrash).toBeCalledTimes(1);
+    await expect(NativeInstabug.sendJSCrash).toBeCalledWith(jsonObject);
   });
 
   it('should not invoke callback on emitting the event IBGSendUnhandledJSCrash when Platform is iOS', () => {
-
     Platform.OS = 'ios';
     Instabug.onReportSubmitHandler(jest.fn());
     IBGEventEmitter.emit(IBGConstants.SEND_UNHANDLED_CRASH, {});
     expect(IBGEventEmitter.getListeners(IBGConstants.SEND_UNHANDLED_CRASH).length).toEqual(0);
-
   });
 
   it('should invoke the native method callPrivateApi', () => {
-
     const apiName = 'name';
     const param = 'param';
     Instabug.callPrivateApi(apiName, param);
 
-    expect(callPrivateApi.calledOnceWithExactly(apiName, param)).toBe(true);
-
+    expect(NativeInstabug.callPrivateApi).toBeCalledTimes(1);
+    expect(NativeInstabug.callPrivateApi).toBeCalledWith(apiName, param);
   });
 
   it('should call native addExperiments method', () => {
     const experiments = ['exp1', 'exp2'];
     Instabug.addExperiments(experiments);
-    expect(addExperiments.calledOnceWithExactly(experiments)).toBeTruthy();
+    expect(NativeInstabug.addExperiments).toBeCalledTimes(1);
+    expect(NativeInstabug.addExperiments).toBeCalledWith(experiments);
   });
 
   it('should call native removeExperiments method', () => {
     const experiments = ['exp1', 'exp2'];
     Instabug.removeExperiments(experiments);
-    expect(removeExperiments.calledOnceWithExactly(experiments)).toBeTruthy();
+    expect(NativeInstabug.removeExperiments).toBeCalledTimes(1);
+    expect(NativeInstabug.removeExperiments).toBeCalledWith(experiments);
   });
 
   it('should call native clearAllExperiments method', () => {
     Instabug.clearAllExperiments();
-    expect(clearAllExperiments.calledOnce).toBeTruthy();
+    expect(NativeInstabug.clearAllExperiments).toBeCalledTimes(1);
   });
 });

--- a/test/jest/mockAPM.js
+++ b/test/jest/mockAPM.js
@@ -13,6 +13,7 @@ jest.mock("NativeModules", () => {
       endAppLaunch: jest.fn(),
       setNetworkEnabledIOS: jest.fn(),
       ibgSleep: jest.fn(),
+      networkLog: jest.fn(),
     },
     Instabug: {
       setNetworkLoggingEnabled: jest.fn(),

--- a/test/jest/mockFeatureRequests.js
+++ b/test/jest/mockFeatureRequests.js
@@ -3,6 +3,7 @@ jest.mock('NativeModules', () => {
       IBGFeatureRequests: {
         setEmailFieldRequiredForFeatureRequests: jest.fn(),
         show: jest.fn(),
+        showFeatureRequests: jest.fn(),
         setEnabled: jest.fn()
       },
       Instabug: {}

--- a/test/jest/mockInstabug.js
+++ b/test/jest/mockInstabug.js
@@ -52,6 +52,7 @@ jest.mock("react-native", () => {
     addExperiments: jest.fn(),
     removeExperiments: jest.fn(),
     clearAllExperiments: jest.fn(),
+    networkLog: jest.fn(),
   };
   RN.NativeModules.IBGBugReporting = {
     setFloatingButtonEdge: jest.fn(),

--- a/test/jest/mockInstabug.js
+++ b/test/jest/mockInstabug.js
@@ -45,6 +45,7 @@ jest.mock("react-native", () => {
     callPrivateApi: jest.fn(),
     addListener: jest.fn(),
     getReport: jest.fn(),
+    setCrashReportingEnabled: jest.fn(),
     sendHandledJSCrash: jest.fn(),
     sendJSCrash: jest.fn(),
     reportScreenChange: jest.fn(),

--- a/test/replies.spec.js
+++ b/test/replies.spec.js
@@ -6,44 +6,23 @@
 import 'react-native';
 import { NativeModules, Platform } from 'react-native';
 import './jest/mockReplies';
-import sinon from 'sinon';
 import Replies from '../src/modules/Replies';
 import IBGConstants from '../src/utils/InstabugConstants';
 import IBGEventEmitter from '../src/utils/IBGEventEmitter';
 
-describe('Replies Module', () => {
-  
-  const setRepliesEnabled = sinon.spy(NativeModules.IBGReplies, 'setEnabled');
-  const hasChats = sinon.spy(NativeModules.IBGReplies, 'hasChats');
-  const showReplies = sinon.spy(NativeModules.IBGReplies, 'show');
-  const setOnNewReplyReceivedCallback = sinon.spy(NativeModules.IBGReplies, 'setOnNewReplyReceivedHandler');
-  const getUnreadMessagesCount = sinon.spy(NativeModules.IBGReplies, 'getUnreadRepliesCount');
-  const setInAppNotificationEnabled = sinon.spy(NativeModules.IBGReplies, 'setInAppNotificationEnabled');
-  const setEnableInAppNotificationSound = sinon.spy(NativeModules.IBGReplies, 'setInAppNotificationSound');
-  const setPushNotificationsEnabled = sinon.spy(NativeModules.IBGReplies, 'setPushNotificationsEnabled');
-  const setPushNotificationRegistrationToken = sinon.spy(NativeModules.IBGReplies, 'setPushNotificationRegistrationToken');
-  const showNotification = sinon.spy(NativeModules.IBGReplies, 'showNotification');
-  const setNotificationIcon = sinon.spy(NativeModules.IBGReplies, 'setNotificationIcon');
-  const setPushNotificationChannelId = sinon.spy(NativeModules.IBGReplies, 'setPushNotificationChannelId');
-  const setSystemReplyNotificationSoundEnabled = sinon.spy(NativeModules.IBGReplies, 'setSystemReplyNotificationSoundEnabled');
+const { IBGReplies: NativeIBGReplies } = NativeModules;
 
+describe('Replies Module', () => {
   beforeEach(() => {
-    setOnNewReplyReceivedCallback.resetHistory();
-    setEnableInAppNotificationSound.resetHistory();
     IBGEventEmitter.removeAllListeners();
-    setPushNotificationsEnabled.resetHistory();
-    setPushNotificationRegistrationToken.resetHistory();
-    showNotification.resetHistory();
-    setNotificationIcon.resetHistory();
-    setPushNotificationChannelId.resetHistory();
-    setSystemReplyNotificationSoundEnabled.resetHistory();
   });
 
   it('should call the native method setRepliesEnabled', () => {
 
     Replies.setEnabled(true);
 
-    expect(setRepliesEnabled.calledOnceWithExactly(true)).toBe(true);
+    expect(NativeIBGReplies.setEnabled).toBeCalledTimes(1);
+    expect(NativeIBGReplies.setEnabled).toBeCalledWith(true);
 
   });
 
@@ -51,19 +30,18 @@ describe('Replies Module', () => {
 
     Replies.show();
 
-    expect(showReplies.calledOnce).toBe(true);
+    expect(NativeIBGReplies.show).toBeCalledTimes(1);
 
   });
 
-  it('should call the native method hasChats', (done) => {
+  it('should call the native method hasChats', () => {
 
-    const callback = (hasChats) => {
-        expect(hasChats).toBe(true);
-        done();
-    }
+    const callback = jest.fn();
     Replies.hasChats(callback);
 
-    expect(hasChats.calledOnceWithExactly(callback)).toBe(true);
+    expect(NativeIBGReplies.hasChats).toBeCalledTimes(1);
+    expect(NativeIBGReplies.hasChats).toBeCalledWith(callback);
+    expect(callback).toBeCalledWith(true);
 
   });
 
@@ -72,7 +50,8 @@ describe('Replies Module', () => {
     const callback = jest.fn()
     Replies.setOnNewReplyReceivedHandler(callback);
 
-    expect(setOnNewReplyReceivedCallback.calledOnceWithExactly(callback)).toBe(true);
+    expect(NativeIBGReplies.setOnNewReplyReceivedHandler).toBeCalledTimes(1);
+    expect(NativeIBGReplies.setOnNewReplyReceivedHandler).toBeCalledWith(callback);
 
   });
 
@@ -87,15 +66,14 @@ describe('Replies Module', () => {
 
   });
 
-  it('should call the native method getUnreadMessagesCount', (done) => {
+  it('should call the native method getUnreadRepliesCount', () => {
 
-    const callback = (messagesCount) => {
-        expect(messagesCount).toBe(2);
-        done();
-    }
+    const callback = jest.fn();
     Replies.getUnreadRepliesCount(callback);
-
-    expect(getUnreadMessagesCount.calledOnceWithExactly(callback)).toBe(true);
+    
+    expect(NativeIBGReplies.getUnreadRepliesCount).toBeCalledTimes(1);
+    expect(NativeIBGReplies.getUnreadRepliesCount).toBeCalledWith(callback);
+    expect(callback).toBeCalledWith(2);
 
   });
 
@@ -103,16 +81,18 @@ describe('Replies Module', () => {
 
     Replies.setInAppNotificationsEnabled(true);
 
-    expect(setInAppNotificationEnabled.calledOnceWithExactly(true)).toBe(true);
+    expect(NativeIBGReplies.setInAppNotificationEnabled).toBeCalledTimes(1);
+    expect(NativeIBGReplies.setInAppNotificationEnabled).toBeCalledWith(true);
 
   });
 
-  it('should call the native method setEnableInAppNotificationSound', () => {
+  it('should call the native method setInAppNotificationSound', () => {
 
     Platform.OS = 'android';
     Replies.setInAppNotificationSound(true);
 
-    expect(setEnableInAppNotificationSound.calledOnceWithExactly(true)).toBe(true);
+    expect(NativeIBGReplies.setInAppNotificationSound).toBeCalledTimes(1);
+    expect(NativeIBGReplies.setInAppNotificationSound).toBeCalledWith(true);
 
   });
 
@@ -121,7 +101,7 @@ describe('Replies Module', () => {
     Platform.OS = 'ios';
     Replies.setInAppNotificationSound(true);
 
-    expect(setEnableInAppNotificationSound.notCalled).toBe(true);
+    expect(NativeIBGReplies.setInAppNotificationSound).not.toBeCalled();
 
   });
 
@@ -130,7 +110,8 @@ describe('Replies Module', () => {
 
     Replies.setPushNotificationsEnabled(true);
 
-    expect(setPushNotificationsEnabled.calledOnceWithExactly(true)).toBe(true);
+    expect(NativeIBGReplies.setPushNotificationsEnabled).toBeCalledTimes(1);
+    expect(NativeIBGReplies.setPushNotificationsEnabled).toBeCalledWith(true);
 
   });
 
@@ -139,7 +120,8 @@ describe('Replies Module', () => {
     Platform.OS = 'android';
     Replies.setPushNotificationRegistrationTokenAndroid('123');
 
-    expect(setPushNotificationRegistrationToken.calledOnceWithExactly('123')).toBe(true);
+    expect(NativeIBGReplies.setPushNotificationRegistrationToken).toBeCalledTimes(1);
+    expect(NativeIBGReplies.setPushNotificationRegistrationToken).toBeCalledWith('123');
   });
 
 
@@ -147,7 +129,8 @@ describe('Replies Module', () => {
     Platform.OS = 'android';
     Replies.showNotificationAndroid('test');
 
-    expect(showNotification.calledOnceWithExactly('test')).toBe(true);
+    expect(NativeIBGReplies.showNotification).toBeCalledTimes(1);
+    expect(NativeIBGReplies.showNotification).toBeCalledWith('test');
   });
 
 
@@ -155,7 +138,7 @@ describe('Replies Module', () => {
     Platform.OS = 'ios';
     Replies.setPushNotificationRegistrationTokenAndroid(true);
 
-    expect(setPushNotificationRegistrationToken.notCalled).toBe(true);
+    expect(NativeIBGReplies.setPushNotificationRegistrationToken).not.toBeCalled();
   });
 
 
@@ -163,14 +146,15 @@ describe('Replies Module', () => {
     Platform.OS = 'android';
     Replies.setNotificationIconAndroid(123);
 
-    expect(setNotificationIcon.calledOnceWithExactly(123)).toBe(true);
+    expect(NativeIBGReplies.setNotificationIcon).toBeCalledTimes(1);
+    expect(NativeIBGReplies.setNotificationIcon).toBeCalledWith(123);
   });
 
   it('should not call the native method setNotificationIcon on iOS', () => {
     Platform.OS = 'ios';
     Replies.setNotificationIconAndroid(123);
 
-    expect(setNotificationIcon.notCalled).toBe(true);
+    expect(NativeIBGReplies.setNotificationIcon).not.toBeCalled();
   });
 
 
@@ -178,14 +162,15 @@ describe('Replies Module', () => {
     Platform.OS = 'android';
     Replies.setPushNotificationChannelIdAndroid('123');
 
-    expect(setPushNotificationChannelId.calledOnceWithExactly('123')).toBe(true);
+    expect(NativeIBGReplies.setPushNotificationChannelId).toBeCalledTimes(1);
+    expect(NativeIBGReplies.setPushNotificationChannelId).toBeCalledWith('123');
   });
 
   it('should not call the native method setPushNotificationChannelId on iOS', () => {
     Platform.OS = 'ios';
     Replies.setPushNotificationChannelIdAndroid('123');
 
-    expect(setPushNotificationChannelId.notCalled).toBe(true);
+    expect(NativeIBGReplies.setPushNotificationChannelId).not.toBeCalled();
   });
 
 
@@ -193,14 +178,15 @@ describe('Replies Module', () => {
     Platform.OS = 'android';
     Replies.setSystemReplyNotificationSoundEnabledAndroid(true);
 
-    expect(setSystemReplyNotificationSoundEnabled.calledOnceWithExactly(true)).toBe(true);
+    expect(NativeIBGReplies.setSystemReplyNotificationSoundEnabled).toBeCalledTimes(1);
+    expect(NativeIBGReplies.setSystemReplyNotificationSoundEnabled).toBeCalledWith(true);
   });
 
   it('should not call the native method setSystemReplyNotificationSoundEnabled on iOS', () => {
     Platform.OS = 'ios';
     Replies.setSystemReplyNotificationSoundEnabledAndroid(true);
 
-    expect(setSystemReplyNotificationSoundEnabled.notCalled).toBe(true);
+    expect(NativeIBGReplies.setSystemReplyNotificationSoundEnabled).not.toBeCalled();
   });
 
 });

--- a/test/report.spec.js
+++ b/test/report.spec.js
@@ -7,25 +7,13 @@ import 'react-native';
 import { NativeModules, Platform } from 'react-native';
 import './jest/mockReport';
 import Report from '../src/models/Report'
-import sinon from 'sinon';
+
+const { Instabug: NativeInstabug } = NativeModules;
 
 describe('Report Model', () => {
-  
-  const appendTagToReport = sinon.spy(NativeModules.Instabug, 'appendTagToReport');
-  const appendConsoleLogToReport = sinon.spy(NativeModules.Instabug, 'appendConsoleLogToReport');
-  const setUserAttributeToReport = sinon.spy(NativeModules.Instabug, 'setUserAttributeToReport');
-  const logDebugToReport = sinon.spy(NativeModules.Instabug, 'logDebugToReport');
-  const logVerboseToReport = sinon.spy(NativeModules.Instabug, 'logVerboseToReport');
-  const logWarnToReport = sinon.spy(NativeModules.Instabug, 'logWarnToReport');
-  const logErrorToReport = sinon.spy(NativeModules.Instabug, 'logErrorToReport');
-  const logInfoToReport = sinon.spy(NativeModules.Instabug, 'logInfoToReport');
-  const addFileAttachmentWithURLToReport = sinon.spy(NativeModules.Instabug, 'addFileAttachmentWithURLToReport');
-  const addFileAttachmentWithDataToReport = sinon.spy(NativeModules.Instabug, 'addFileAttachmentWithDataToReport');
   var report;
   
   beforeEach(() => {
-      addFileAttachmentWithDataToReport.resetHistory();
-      addFileAttachmentWithURLToReport.resetHistory();
     const reportData = {
         tags: ['tag1', 'tag2'],
         consoleLogs: ['consoleLog'],
@@ -44,7 +32,8 @@ describe('Report Model', () => {
     report.appendTag(tag);
 
     expect(report.tags).toEqual([...tagsBefore, tag]);
-    expect(appendTagToReport.calledOnceWithExactly(tag)).toBe(true);
+    expect(NativeInstabug.appendTagToReport).toBeCalledTimes(1);
+    expect(NativeInstabug.appendTagToReport).toBeCalledWith(tag);
 
   });
 
@@ -55,7 +44,8 @@ describe('Report Model', () => {
     report.appendConsoleLog(log);
 
     expect(report.consoleLogs).toEqual([...logsBefore, log]);
-    expect(appendConsoleLogToReport.calledOnceWithExactly(log)).toBe(true);
+    expect(NativeInstabug.appendConsoleLogToReport).toBeCalledTimes(1);
+    expect(NativeInstabug.appendConsoleLogToReport).toBeCalledWith(log);
 
   });
 
@@ -67,7 +57,8 @@ describe('Report Model', () => {
 
     expect(report.userAttributes).toHaveProperty(key);
     expect(report.userAttributes[key]).toEqual(value);
-    expect(setUserAttributeToReport.calledOnceWithExactly(key, value)).toBe(true);
+    expect(NativeInstabug.setUserAttributeToReport).toBeCalledTimes(1);
+    expect(NativeInstabug.setUserAttributeToReport).toBeCalledWith(key, value);
 
   });
 
@@ -78,7 +69,8 @@ describe('Report Model', () => {
     report.logDebug(message);
 
     expect(report.instabugLogs).toEqual([...logsBefore, { log: message, type: 'debug' }]);
-    expect(logDebugToReport.calledOnceWithExactly(message)).toBe(true);
+    expect(NativeInstabug.logDebugToReport).toBeCalledTimes(1);
+    expect(NativeInstabug.logDebugToReport).toBeCalledWith(message);
 
   });
 
@@ -89,7 +81,8 @@ describe('Report Model', () => {
     report.logVerbose(message);
 
     expect(report.instabugLogs).toEqual([...logsBefore, { log: message, type: 'verbose' }]);
-    expect(logVerboseToReport.calledOnceWithExactly(message)).toBe(true);
+    expect(NativeInstabug.logVerboseToReport).toBeCalledTimes(1);
+    expect(NativeInstabug.logVerboseToReport).toBeCalledWith(message);
 
   });
 
@@ -100,7 +93,8 @@ describe('Report Model', () => {
     report.logWarn(message);
 
     expect(report.instabugLogs).toEqual([...logsBefore, { log: message, type: 'warn' }]);
-    expect(logWarnToReport.calledOnceWithExactly(message)).toBe(true);
+    expect(NativeInstabug.logWarnToReport).toBeCalledTimes(1);
+    expect(NativeInstabug.logWarnToReport).toBeCalledWith(message);
 
   });
 
@@ -111,7 +105,8 @@ describe('Report Model', () => {
     report.logError(message);
 
     expect(report.instabugLogs).toEqual([...logsBefore, { log: message, type: 'error' }]);
-    expect(logErrorToReport.calledOnceWithExactly(message)).toBe(true);
+    expect(NativeInstabug.logErrorToReport).toBeCalledTimes(1);
+    expect(NativeInstabug.logErrorToReport).toBeCalledWith(message);
 
   });
 
@@ -122,7 +117,8 @@ describe('Report Model', () => {
     report.logInfo(message);
 
     expect(report.instabugLogs).toEqual([...logsBefore, { log: message, type: 'info' }]);
-    expect(logInfoToReport.calledOnceWithExactly(message)).toBe(true);
+    expect(NativeInstabug.logInfoToReport).toBeCalledTimes(1);
+    expect(NativeInstabug.logInfoToReport).toBeCalledWith(message);
 
   });
 
@@ -134,7 +130,8 @@ describe('Report Model', () => {
     report.addFileAttachmentWithUrl(file);
 
     expect(report.fileAttachments).toEqual([...filesBefore, { file: file, type: 'url' }]);
-    expect(addFileAttachmentWithURLToReport.calledOnceWithExactly(file)).toBe(true);
+    expect(NativeInstabug.addFileAttachmentWithURLToReport).toBeCalledTimes(1);
+    expect(NativeInstabug.addFileAttachmentWithURLToReport).toBeCalledWith(file);
 
   });
 
@@ -147,7 +144,8 @@ describe('Report Model', () => {
     report.addFileAttachmentWithUrl(file, fileName);
 
     expect(report.fileAttachments).toEqual([...filesBefore, { file: file, type: 'url' }]);
-    expect(addFileAttachmentWithURLToReport.calledOnceWithExactly(file, fileName)).toBe(true);
+    expect(NativeInstabug.addFileAttachmentWithURLToReport).toBeCalledTimes(1);
+    expect(NativeInstabug.addFileAttachmentWithURLToReport).toBeCalledWith(file, fileName);
 
   });
 
@@ -159,7 +157,8 @@ describe('Report Model', () => {
     report.addFileAttachmentWithData(file);
 
     expect(report.fileAttachments).toEqual([...filesBefore, { file: file, type: 'data' }]);
-    expect(addFileAttachmentWithDataToReport.calledOnceWithExactly(file)).toBe(true);
+    expect(NativeInstabug.addFileAttachmentWithDataToReport).toBeCalledTimes(1);
+    expect(NativeInstabug.addFileAttachmentWithDataToReport).toBeCalledWith(file);
 
   });
 
@@ -172,7 +171,8 @@ describe('Report Model', () => {
     report.addFileAttachmentWithData(file, fileName);
 
     expect(report.fileAttachments).toEqual([...filesBefore, { file: file, type: 'data' }]);
-    expect(addFileAttachmentWithDataToReport.calledOnceWithExactly(file, fileName)).toBe(true);
+    expect(NativeInstabug.addFileAttachmentWithDataToReport).toBeCalledTimes(1);
+    expect(NativeInstabug.addFileAttachmentWithDataToReport).toBeCalledWith(file, fileName);
 
   });
 

--- a/test/surveys.spec.js
+++ b/test/surveys.spec.js
@@ -7,86 +7,58 @@ import "react-native";
 import { NativeModules } from "react-native";
 import "./jest/mockSurveys";
 import Surveys from "../src/modules/Surveys";
-import sinon from "sinon";
 
 import IBGConstants from "../src/utils/InstabugConstants";
 import IBGEventEmitter from "../src/utils/IBGEventEmitter";
 
-describe("Surveys Module", () => {
-  const setSurveysEnabled = sinon.spy(NativeModules.IBGSurveys, "setEnabled");
-  const setAppStoreURL = sinon.spy(NativeModules.IBGSurveys, "setAppStoreURL");
-  const showSurveysIfAvailable = sinon.spy(
-    NativeModules.IBGSurveys,
-    "showSurveysIfAvailable"
-  );
-  const getAvailableSurveys = sinon.spy(
-    NativeModules.IBGSurveys,
-    "getAvailableSurveys"
-  );
-  const setAutoShowingSurveysEnabled = sinon.spy(
-    NativeModules.IBGSurveys,
-    "setAutoShowingEnabled"
-  );
-  const setWillShowSurveyHandler = sinon.spy(
-    NativeModules.IBGSurveys,
-    "setOnShowHandler"
-  );
-  const setDidDismissSurveyHandler = sinon.spy(
-    NativeModules.IBGSurveys,
-    "setOnDismissHandler"
-  );
-  const showSurveyWithToken = sinon.spy(NativeModules.IBGSurveys, "showSurvey");
-  const hasRespondedToSurveyWithToken = sinon.spy(
-    NativeModules.IBGSurveys,
-    "hasRespondedToSurvey"
-  );
-  const setShouldShowSurveysWelcomeScreen = sinon.spy(
-    NativeModules.IBGSurveys,
-    "setShouldShowWelcomeScreen"
-  );
+const { IBGSurveys: NativeIBGSurveys } = NativeModules;
 
+describe("Surveys Module", () => {
   beforeEach(() => {
-    setWillShowSurveyHandler.resetHistory();
-    setDidDismissSurveyHandler.resetHistory();
     IBGEventEmitter.removeAllListeners();
   });
 
   it("should call the native method setSurveysEnabled", () => {
     Surveys.setEnabled(true);
 
-    expect(setSurveysEnabled.calledOnceWithExactly(true)).toBe(true);
+    expect(NativeIBGSurveys.setEnabled).toBeCalledTimes(1);
+    expect(NativeIBGSurveys.setEnabled).toBeCalledWith(true);
   });
 
   it("should call the native method setAppStoreURL", () => {
     Surveys.setAppStoreURL("URL");
 
-    expect(setAppStoreURL.calledOnceWithExactly("URL")).toBe(true);
+    expect(NativeIBGSurveys.setAppStoreURL).toBeCalledTimes(1);
+    expect(NativeIBGSurveys.setAppStoreURL).toBeCalledWith("URL");
   });
 
   it("should call the native method showSurveysIfAvailable", () => {
     Surveys.showSurveyIfAvailable();
 
-    expect(showSurveysIfAvailable.calledOnce).toBe(true);
+    expect(NativeIBGSurveys.showSurveysIfAvailable).toBeCalledTimes(1);
   });
 
   it("should call the native method getAvailableSurveys", () => {
     const callback = jest.fn();
     Surveys.getAvailableSurveys(callback);
 
-    expect(getAvailableSurveys.calledOnceWithExactly(callback)).toBe(true);
+    expect(NativeIBGSurveys.getAvailableSurveys).toBeCalledTimes(1);
+    expect(NativeIBGSurveys.getAvailableSurveys).toBeCalledWith(callback);
   });
 
   it("should call the native method setAutoShowingSurveysEnabled", () => {
     Surveys.setAutoShowingEnabled(true);
 
-    expect(setAutoShowingSurveysEnabled.calledOnceWithExactly(true)).toBe(true);
+    expect(NativeIBGSurveys.setAutoShowingEnabled).toBeCalledTimes(1);
+    expect(NativeIBGSurveys.setAutoShowingEnabled).toBeCalledWith(true);
   });
 
   it("should call the native method setWillShowSurveyHandler with a function", () => {
     const callback = jest.fn();
     Surveys.setOnShowHandler(callback);
 
-    expect(setWillShowSurveyHandler.calledOnceWithExactly(callback)).toBe(true);
+    expect(NativeIBGSurveys.setOnShowHandler).toBeCalledTimes(1);
+    expect(NativeIBGSurveys.setOnShowHandler).toBeCalledWith(callback);
   });
 
   it("should invoke callback on emitting the event IBGWillShowSurvey", () => {
@@ -94,9 +66,7 @@ describe("Surveys Module", () => {
     Surveys.setOnShowHandler(callback);
     IBGEventEmitter.emit(IBGConstants.WILL_SHOW_SURVEY_HANDLER);
 
-    expect(
-      IBGEventEmitter.getListeners(IBGConstants.WILL_SHOW_SURVEY_HANDLER).length
-    ).toEqual(1);
+    expect(IBGEventEmitter.getListeners(IBGConstants.WILL_SHOW_SURVEY_HANDLER).length).toEqual(1);
     expect(callback).toHaveBeenCalled();
   });
 
@@ -104,9 +74,8 @@ describe("Surveys Module", () => {
     const callback = jest.fn();
     Surveys.setOnDismissHandler(callback);
 
-    expect(setDidDismissSurveyHandler.calledOnceWithExactly(callback)).toBe(
-      true
-    );
+    expect(NativeIBGSurveys.setOnDismissHandler).toBeCalledTimes(1);
+    expect(NativeIBGSurveys.setOnDismissHandler).toBeCalledWith(callback);
   });
 
   it("should invoke callback on emitting the event IBGDidDismissSurvey", () => {
@@ -114,10 +83,7 @@ describe("Surveys Module", () => {
     Surveys.setOnDismissHandler(callback);
     IBGEventEmitter.emit(IBGConstants.DID_DISMISS_SURVEY_HANDLER);
 
-    expect(
-      IBGEventEmitter.getListeners(IBGConstants.DID_DISMISS_SURVEY_HANDLER)
-        .length
-    ).toEqual(1);
+    expect(IBGEventEmitter.getListeners(IBGConstants.DID_DISMISS_SURVEY_HANDLER).length).toEqual(1);
     expect(callback).toHaveBeenCalled();
   });
 
@@ -125,27 +91,24 @@ describe("Surveys Module", () => {
     const surveyToken = "HEU128JD";
     Surveys.showSurvey(surveyToken);
 
-    expect(showSurveyWithToken.calledOnceWithExactly(surveyToken)).toBe(true);
+    expect(NativeIBGSurveys.showSurvey).toBeCalledTimes(1);
+    expect(NativeIBGSurveys.showSurvey).toBeCalledWith(surveyToken);
   });
 
-  it("should call the native method hasRespondedToSurveyWithToken", done => {
-    const callback = hasResponded => {
-      expect(hasResponded).toBe(true);
-      done();
-    };
+  it("should call the native method hasRespondedToSurveyWithToken", () => {
+    const callback = jest.fn();
     const surveyToken = "HEU128JD";
     Surveys.hasRespondedToSurvey(surveyToken, callback);
 
-    expect(
-      hasRespondedToSurveyWithToken.calledOnceWithExactly(surveyToken, callback)
-    ).toBe(true);
+    expect(NativeIBGSurveys.hasRespondedToSurvey).toBeCalledTimes(1);
+    expect(NativeIBGSurveys.hasRespondedToSurvey).toBeCalledWith(surveyToken, callback);
+    expect(callback).toBeCalledWith(true);
   });
 
   it("should call the native method setShouldShowSurveysWelcomeScreen", () => {
     Surveys.setShouldShowWelcomeScreen(true);
 
-    expect(setShouldShowSurveysWelcomeScreen.calledOnceWithExactly(true)).toBe(
-      true
-    );
+    expect(NativeIBGSurveys.setShouldShowWelcomeScreen).toBeCalledTimes(1);
+    expect(NativeIBGSurveys.setShouldShowWelcomeScreen).toBeCalledWith(true);
   });
 });


### PR DESCRIPTION
## Description of Change

All the mocks in our SDK were written twice, once in Jest and once Sinon.
Since Jest is our main test runner and it provides powerful mocking mechanisms, we ditched Sinon mocks (except for XHR mocks) in favor of Jest mocks, this makes our code less redundant.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
