### PR TITLE
[INSD-8104] Declare local vars final

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * Uses Cocoapods for Instabug iOS SDK
+* Fixes a compile error on projects with Java version prior to 8.
 
 ## 11.2.0 (2022-09-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 * Uses Cocoapods for Instabug iOS SDK
-* Fixes a compile error on projects with Java version prior to 8.
+* Fixes a compilation error on projects with Java version prior to 8.
 
 ## 11.2.0 (2022-09-19)
 

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugBugReportingModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugBugReportingModule.java
@@ -180,7 +180,7 @@ public class RNInstabugBugReportingModule extends ReactContextBaseJavaModule {
      * @see InstabugInvocationEvent
      */
     @ReactMethod
-    public void setInvocationEvents(ReadableArray invocationEventValues) {
+    public void setInvocationEvents(final ReadableArray invocationEventValues) {
         MainThreadHandler.runOnMainThread(new Runnable() {
             @Override
             public void run() {
@@ -324,7 +324,7 @@ public class RNInstabugBugReportingModule extends ReactContextBaseJavaModule {
      * @see BugReporting.ReportType
      */
     @ReactMethod
-    public void setReportTypes(ReadableArray types) {
+    public void setReportTypes(final ReadableArray types) {
         MainThreadHandler.runOnMainThread(new Runnable() {
             @SuppressLint("WrongConstant")
             @Override

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
@@ -553,7 +553,7 @@ public class RNInstabugReactnativeModule extends ReactContextBaseJavaModule {
      * @see InstabugInvocationEvent
      */
     @ReactMethod
-    public void setInvocationEvents(ReadableArray invocationEventValues) {
+    public void setInvocationEvents(final ReadableArray invocationEventValues) {
         MainThreadHandler.runOnMainThread(new Runnable() {
             @Override
             public void run() {


### PR DESCRIPTION
## Description of the change
### Problem:
Users face a compile error on Android stating that `local variables accessed from within inner class need to be declared final`. This is only encountered on projects with Java version prior to 8. 

**Starting Java 8**, this requirement was relaxed to final or _effectively final_. A variable whose value is never changed after it is initialized is effectively final. Hence, users on Java 8 or higher do not face this issue. 

### Solution:
Declare these local variables _explicitly_ `final` so that the app builds successfully on different Java versions. 
## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request 
