### PR TITLE
[MOB-10372] Enable Disabled `InstabugUtils` Test

### DIFF
--- a/tests/utils/InstabugUtils.spec.js
+++ b/tests/utils/InstabugUtils.spec.js
@@ -1,6 +1,9 @@
 import '../mocks/mockXhrNetworkInterceptor';
 import { NativeModules, Platform } from 'react-native';
 import Instabug from '../../src';
+import InstabugUtils from '../../src/utils/InstabugUtils';
+import IBGEventEmitter from '../../src/utils/IBGEventEmitter';
+import IBGConstants from '../../src/utils/InstabugConstants';
 
 const { Instabug: NativeInstabug } = NativeModules;
 
@@ -26,20 +29,21 @@ describe('Test global error handler', () => {
     expect(NativeInstabug.sendJSCrash).toHaveBeenCalledWith(expected);
   });
 
-  // it('should emit event IBGSendUnhandledJSCrash when platform is android and onReportSubmitHandler is set', (done) => {
-  //     Platform.OS = 'android';
-  //     Instabug._isOnReportHandlerSet = jest.fn(() => true);
-  //     const handler = global.ErrorUtils.getGlobalHandler();
-  //     IBGEventEmitter.addListener(Instabug, IBGConstants.SEND_UNHANDLED_CRASH, (actual) => {
-  //         const expected = {
-  //             message: 'TypeError - This is a type error.',
-  //             os: 'android',
-  //             platform: 'react_native',
-  //             exception: []
-  //         };
-  //         expect(actual).toEqual(expected);
-  //         done();
-  //     });
-  //     handler({ name: 'TypeError', message: 'This is a type error.' }, false);
-  // });
+  it('should emit event IBGSendUnhandledJSCrash when platform is android and onReportSubmitHandler is set', () => {
+    Platform.OS = 'android';
+    InstabugUtils.setOnReportHandler(true);
+    const handler = global.ErrorUtils.getGlobalHandler();
+    const callback = jest.fn();
+    IBGEventEmitter.addListener(Instabug, IBGConstants.SEND_UNHANDLED_CRASH, callback);
+    handler({ name: 'TypeError', message: 'This is a type error.' }, false);
+
+    expect(callback).toHaveBeenCalledWith({
+      message: 'TypeError - This is a type error.',
+      e_message: 'This is a type error.',
+      e_name: 'TypeError',
+      os: 'android',
+      platform: 'react_native',
+      exception: [],
+    });
+  });
 });


### PR DESCRIPTION
## Description of the change

Enables and fixes the "should emit event IBGSendUnhandledJSCrash when platform is android and onReportSubmitHandler is set" `InstabugUtils` disabled test.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
