### PR TITLE
[MOB-10423] Fix `Invalid revision` error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Adds first-class TypeScript support.
+- Fixes a compilation error on Android projects without buildToolsVersion property set.
 
 ## 11.3.0 (2022-10-11)
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
 InstabugReactNative_compileSdkVersion=30
-InstabugReactNative_buildToolsVersion='30.0.2'
+InstabugReactNative_buildToolsVersion=30.0.2
 InstabugReactNative_targetSdkVersion=31
 InstabugReactNative_minSdkVersion=16


### PR DESCRIPTION
## Description of the change

- Removes the single quotes around `buildToolsVersion` value in `gradle.properties`, which causes `Invalid revision: '30.0.2'` error when building the project in Android Studio.  

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request
