### PR TITLE
[MOB-10387] Fix `e2e_ios` CI Flakiness

### DIFF
--- a/example/e2e/reportBug.e2e.js
+++ b/example/e2e/reportBug.e2e.js
@@ -3,10 +3,8 @@ import mockData from './utils/mockData';
 
 beforeEach(async () => {
   await device.launchApp();
-});
-
-beforeEach(async () => {
   await device.reloadReactNative();
+  await device.setURLBlacklist(['https://api.instabug.com']);
 });
 
 it('reports a bug', async () => {

--- a/example/e2e/reportBug.e2e.js
+++ b/example/e2e/reportBug.e2e.js
@@ -8,7 +8,10 @@ beforeEach(async () => {
 });
 
 it('reports a bug', async () => {
-  await getElement('floatingButton').tap();
+  const floatingButton = getElement('floatingButton');
+  await waitFor(floatingButton).toBeVisible().withTimeout(30000);
+  await floatingButton.tap();
+
   await getElement('reportBugMenuItem').tap();
 
   await getElement('emailField').typeText(mockData.email);


### PR DESCRIPTION
## Description of the change

Fixes `e2e_ios` job flakiness by waiting for Instabug's floating button before pressing it and blacklisting Instabug's API from Detox network synchronization (to make it assert for the "Thank You" pop-up immediately after the bug is reported).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request
