### PR TITLE
[MOB-10617] Add missing iOS permissions to sample app

### DIFF
--- a/example/ios/InstabugSample/Info.plist
+++ b/example/ios/InstabugSample/Info.plist
@@ -55,5 +55,9 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Instabug needs access to your microphone so you can attach voice notes.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Instabug needs access to your photo library so you can attach images.</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Description of the change
- Adds missing mic and photo library permissions to `Info.plist` file to be able to attach screen recordings and gallery photos  to bug reports. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request
