### PR TITLE
[MOB-10611] Add new APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Unreleased
 
 - Adds first-class TypeScript support.
+- Adds BugReporting.setDisclaimerText API
+- Adds BugReporting.setCommentMinimumCharacterCount API
+- Deprecates Instabug.enable and Instabug.disable APIs in favour of a new API Instabug.setEnabled, which works on both platforms
 - Fixes a compilation error on Android projects without buildToolsVersion property set.
 
 ## 11.3.0 (2022-10-11)

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugBugReportingModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugBugReportingModule.java
@@ -380,4 +380,31 @@ public class RNInstabugBugReportingModule extends ReactContextBaseJavaModule {
         });
     }
 
+    /**
+    * Sets a minimum number of characters as a requirement for the comments field in the different report types.
+    * @param limit int number of characters.
+    * @param reportTypes (Optional) Array of reportType. If it's not passed, the limit will apply to all report types.
+    */
+    @ReactMethod
+    public void setCommentMinimumCharacterCount(final int limit, final ReadableArray reportTypes){
+        MainThreadHandler.runOnMainThread(new Runnable() {
+            @SuppressLint("WrongConstant")
+            @Override
+            public void run() {
+                try {
+                    final ArrayList<String> keys = ArrayUtil.parseReadableArrayOfStrings(reportTypes);
+                    final ArrayList<Integer> types = ArgsRegistry.reportTypes.getAll(keys);
+
+                    final int[] typesInts = new int[types.size()];
+                    for (int i = 0; i < types.size(); i++) {
+                        typesInts[i] = types.get(i);
+                    }
+
+                    BugReporting.setCommentMinimumCharacterCount(limit, typesInts);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        });
+    }
 }

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugBugReportingModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugBugReportingModule.java
@@ -366,5 +366,18 @@ public class RNInstabugBugReportingModule extends ReactContextBaseJavaModule {
         });
     }
 
+    /**
+    * Adds a disclaimer text within the bug reporting form, which can include hyperlinked text.
+    * @param text String text.
+    */
+    @ReactMethod
+    public void setDisclaimerText(final String text){
+        MainThreadHandler.runOnMainThread(new Runnable() {
+            @Override
+            public void run() {
+                BugReporting.setDisclaimerText(text);
+            }
+        });
+    }
 
 }

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
@@ -105,6 +105,27 @@ public class RNInstabugReactnativeModule extends ReactContextBaseJavaModule {
     public String getName() {
         return "Instabug";
     }
+    
+    /** 
+     * Enables or disables Instabug functionality.
+     * @param isEnabled A boolean to enable/disable Instabug.
+     */
+    @ReactMethod
+    public void setEnabled(final boolean isEnabled) {
+        MainThreadHandler.runOnMainThread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    if(isEnabled)
+                        Instabug.enable();
+                    else
+                        Instabug.disable();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        });
+    } 
 
   /**
    * Starts the SDK.

--- a/android/src/test/java/com/instabug/reactlibrary/RNInstabugBugReportingModuleTest.java
+++ b/android/src/test/java/com/instabug/reactlibrary/RNInstabugBugReportingModuleTest.java
@@ -335,4 +335,18 @@ public class RNInstabugBugReportingModuleTest {
         BugReporting.show(reportTypeArgs.get(reportTypeKeys[0]));
     }
 
+    @Test
+    public void givenArgs$setDisclaimerText_whenQuery_shouldCallNativeApiWithArgs() {
+        // given
+        String text = "This is a disclaimer text!";
+
+        // when
+        bugReportingModule.setDisclaimerText(text);
+
+        // then
+        verify(BugReporting.class, VerificationModeFactory.times(1));
+
+        BugReporting.setDisclaimerText(text);
+    }
+
 }

--- a/android/src/test/java/com/instabug/reactlibrary/RNInstabugBugReportingModuleTest.java
+++ b/android/src/test/java/com/instabug/reactlibrary/RNInstabugBugReportingModuleTest.java
@@ -349,4 +349,22 @@ public class RNInstabugBugReportingModuleTest {
         BugReporting.setDisclaimerText(text);
     }
 
+    @Test
+    public void givenArgs$setCommentMinimumCharacterCount_whenQuery_thenShouldCallNativeApiWithArgs() {
+        // given
+        final int count = 20;
+        final Map<String, Integer> args = ArgsRegistry.reportTypes;
+        final String[] keysArray = args.keySet().toArray(new String[0]);
+        JavaOnlyArray actualArray = new JavaOnlyArray();
+        actualArray.pushString(keysArray[0]);
+
+        // when
+        bugReportingModule.setCommentMinimumCharacterCount(count, actualArray);
+
+        // then
+        verify(BugReporting.class, VerificationModeFactory.times(1));
+        int type1 = args.get(keysArray[0]);
+        
+        BugReporting.setCommentMinimumCharacterCount(count, type1);
+    }
 }

--- a/android/src/test/java/com/instabug/reactlibrary/RNInstabugReactnativeModuleTest.java
+++ b/android/src/test/java/com/instabug/reactlibrary/RNInstabugReactnativeModuleTest.java
@@ -93,6 +93,29 @@ public class RNInstabugReactnativeModuleTest {
 
     /********Instabug*********/
 
+
+    @Test
+    public void givenTrue$setEnabled_whenQuery_thenShouldCallNativeApi() {
+        // given
+
+        // when
+        rnModule.setEnabled(true);
+        // then
+        verify(Instabug.class, times(1));
+        Instabug.enable();
+    }
+
+    @Test
+    public void givenFalse$setEnabled_whenQuery_thenShouldCallNativeApi() {
+        // given
+
+        // when
+        rnModule.setEnabled(false);
+        // then
+        verify(Instabug.class, times(1));
+        Instabug.disable();
+    }
+
     @Test
     public void givenBoolean$setDebugEnabled_whenQuery_thenShouldCallNativeApi() {
         // when

--- a/example/ios/InstabugSampleTests/InstabugBugReportingTests.m
+++ b/example/ios/InstabugSampleTests/InstabugBugReportingTests.m
@@ -177,5 +177,14 @@
   XCTAssertTrue(IBGBugReporting.shouldCaptureViewHierarchy);
 }
 
+- (void) testSetDisclaimerText {
+  id mock = OCMClassMock([IBGBugReporting class]);
+  NSString *text = @"This is a disclaimer text!";
+
+  OCMStub([mock setDisclaimerText:text]);
+  [self.instabugBridge setDisclaimerText:text];
+  OCMVerify([mock setDisclaimerText:text]);
+}
+
 @end
 

--- a/example/ios/InstabugSampleTests/InstabugBugReportingTests.m
+++ b/example/ios/InstabugSampleTests/InstabugBugReportingTests.m
@@ -186,5 +186,18 @@
   OCMVerify([mock setDisclaimerText:text]);
 }
 
+- (void) testSetCommentMinimumCharacterCount {
+  id mock = OCMClassMock([IBGBugReporting class]);
+  NSNumber *limit = [NSNumber numberWithInt:20];
+  NSArray *reportTypesArr = [NSArray arrayWithObjects: @(IBGReportTypeBug), nil];
+  IBGBugReportingReportType reportTypes = 0;
+  for (NSNumber *reportType in reportTypesArr) {
+    reportTypes |= [reportType intValue];
+  }
+  OCMStub([mock setCommentMinimumCharacterCountForReportTypes:reportTypes withLimit:limit.intValue]);
+  [self.instabugBridge setCommentMinimumCharacterCount:limit reportTypes:reportTypesArr];
+  OCMVerify([mock setCommentMinimumCharacterCountForReportTypes:reportTypes withLimit:limit.intValue]);
+}
+
 @end
 

--- a/example/ios/InstabugSampleTests/InstabugSampleTests.m
+++ b/example/ios/InstabugSampleTests/InstabugSampleTests.m
@@ -52,6 +52,15 @@
  +------------------------------------------------------------------------+
  */
 
+- (void)testSetEnabled {
+  id mock = OCMClassMock([Instabug class]);
+  BOOL isEnabled = true;
+  
+  OCMStub([mock setEnabled:isEnabled]);
+  [self.instabugBridge setEnabled:isEnabled];
+  OCMVerify([mock setEnabled:isEnabled]);
+}
+
 - (void)testStart {
   id<InstabugCPTestProtocol> mock = OCMClassMock([Instabug class]);
   IBGInvocationEvent floatingButtonInvocationEvent = IBGInvocationEventFloatingButton;

--- a/ios/RNInstabug/InstabugBugReportingBridge.h
+++ b/ios/RNInstabug/InstabugBugReportingBridge.h
@@ -49,4 +49,6 @@
 
 - (void)setDisclaimerText:(NSString *)text;
 
+- (void)setCommentMinimumCharacterCount:(NSNumber *)limit reportTypes:(NSArray *)reportTypes;
+
 @end

--- a/ios/RNInstabug/InstabugBugReportingBridge.h
+++ b/ios/RNInstabug/InstabugBugReportingBridge.h
@@ -47,4 +47,6 @@
 
 - (void)setViewHierarchyEnabled:(BOOL)viewHirearchyEnabled;
 
+- (void)setDisclaimerText:(NSString *)text;
+
 @end

--- a/ios/RNInstabug/InstabugBugReportingBridge.m
+++ b/ios/RNInstabug/InstabugBugReportingBridge.m
@@ -201,6 +201,10 @@ RCT_EXPORT_METHOD(setShakingThresholdForiPad:(double)iPadShakingThreshold) {
     IBGBugReporting.shakingThresholdForiPad = iPadShakingThreshold;
 }
 
+RCT_EXPORT_METHOD(setDisclaimerText:(NSString*)text) {
+   [IBGBugReporting setDisclaimerText:text];
+}
+
 
 @synthesize description;
 

--- a/ios/RNInstabug/InstabugBugReportingBridge.m
+++ b/ios/RNInstabug/InstabugBugReportingBridge.m
@@ -205,6 +205,20 @@ RCT_EXPORT_METHOD(setDisclaimerText:(NSString*)text) {
    [IBGBugReporting setDisclaimerText:text];
 }
 
+RCT_EXPORT_METHOD(setCommentMinimumCharacterCount:(nonnull NSNumber *)limit reportTypes:(NSArray *)reportTypes) {
+    IBGBugReportingReportType parsedReportTypes = 0;
+
+    if (![reportTypes count]) {
+        parsedReportTypes = @(IBGBugReportingReportTypeBug).integerValue | @(IBGBugReportingReportTypeFeedback).integerValue | @(IBGBugReportingReportTypeQuestion).integerValue;
+    }
+    else {
+        for (NSNumber *reportType in reportTypes) {
+            parsedReportTypes |= [reportType intValue];
+        }
+    }
+
+   [IBGBugReporting setCommentMinimumCharacterCountForReportTypes:parsedReportTypes withLimit:limit.intValue];
+}
 
 @synthesize description;
 

--- a/ios/RNInstabug/InstabugReactBridge.h
+++ b/ios/RNInstabug/InstabugReactBridge.h
@@ -25,6 +25,8 @@
  +------------------------------------------------------------------------+
  */
 
+- (void)setEnabled:(BOOL)isEnabled;
+
 - (void)start:(NSString *)token invocationEvents:(NSArray *)invocationEventsArray;
 
 - (void)setUserData:(NSString *)userData;

--- a/ios/RNInstabug/InstabugReactBridge.m
+++ b/ios/RNInstabug/InstabugReactBridge.m
@@ -36,6 +36,11 @@ RCT_EXPORT_MODULE(Instabug)
     return dispatch_get_main_queue();
 }
 
+
+RCT_EXPORT_METHOD(setEnabled:(BOOL)isEnabled) {
+    Instabug.enabled = isEnabled;
+}
+
 RCT_EXPORT_METHOD(start:(NSString *)token invocationEvents:(NSArray*)invocationEventsArray) {
      SEL setPrivateApiSEL = NSSelectorFromString(@"setCurrentPlatform:");
     if ([[Instabug class] respondsToSelector:setPrivateApiSEL]) {

--- a/src/modules/BugReporting.ts
+++ b/src/modules/BugReporting.ts
@@ -223,3 +223,11 @@ export const setEnabledAttachmentTypes = (
     screenRecording,
   );
 };
+
+/**
+ * Adds a disclaimer text within the bug reporting form, which can include hyperlinked text.
+ * @param text String text.
+ */
+export const setDisclaimerText = (text: string) => {
+  NativeBugReporting.setDisclaimerText(text);
+};

--- a/src/modules/BugReporting.ts
+++ b/src/modules/BugReporting.ts
@@ -231,3 +231,12 @@ export const setEnabledAttachmentTypes = (
 export const setDisclaimerText = (text: string) => {
   NativeBugReporting.setDisclaimerText(text);
 };
+
+/**
+ * Sets a minimum number of characters as a requirement for the comments field in the different report types.
+ * @param limit int number of characters.
+ * @param reportTypes (Optional) Array of reportType. If it's not passed, the limit will apply to all report types.
+ */
+export const setCommentMinimumCharacterCount = (limit: number, reportTypes?: reportType[]) => {
+  NativeBugReporting.setCommentMinimumCharacterCount(limit, reportTypes ?? []);
+};

--- a/src/modules/Instabug.ts
+++ b/src/modules/Instabug.ts
@@ -47,6 +47,14 @@ export {
 };
 
 /**
+ * Enables or disables Instabug functionality.
+ * @param isEnabled A boolean to enable/disable Instabug.
+ */
+export const setEnabled = (isEnabled: boolean) => {
+  NativeInstabug.setEnabled(isEnabled);
+};
+
+/**
  * Starts the SDK.
  * This is the main SDK method that does all the magic. This is the only
  * method that SHOULD be called.

--- a/src/modules/Instabug.ts
+++ b/src/modules/Instabug.ts
@@ -398,6 +398,8 @@ export const setDebugEnabled = (isEnabled: boolean) => {
 };
 
 /**
+ * @deprecated Use {@link setEnabled} instead. This will work on both Android and iOS.
+ *
  * Enables all Instabug functionality
  * It works on android only
  */
@@ -408,6 +410,8 @@ export const enable = () => {
 };
 
 /**
+ * @deprecated Use {@link setEnabled} instead. This will work on both Android and iOS.
+ *
  * Disables all Instabug functionality
  * It works on android only
  */

--- a/tests/mocks/mockBugReporting.js
+++ b/tests/mocks/mockBugReporting.js
@@ -20,5 +20,6 @@ export default {
     setDidSelectPromptOptionHandler: jest.fn(),
     setVideoRecordingFloatingButtonPosition: jest.fn(),
     setDisclaimerText: jest.fn(),
+    setCommentMinimumCharacterCount: jest.fn(),
   },
 };

--- a/tests/mocks/mockBugReporting.js
+++ b/tests/mocks/mockBugReporting.js
@@ -19,5 +19,6 @@ export default {
     setEnabledAttachmentTypes: jest.fn(),
     setDidSelectPromptOptionHandler: jest.fn(),
     setVideoRecordingFloatingButtonPosition: jest.fn(),
+    setDisclaimerText: jest.fn(),
   },
 };

--- a/tests/mocks/mockInstabug.js
+++ b/tests/mocks/mockInstabug.js
@@ -1,5 +1,6 @@
 export default {
   Instabug: {
+    setEnabled: jest.fn(),
     start: jest.fn(),
     setUserData: jest.fn(),
     setTrackUserSteps: jest.fn(),

--- a/tests/modules/BugReporting.spec.js
+++ b/tests/modules/BugReporting.spec.js
@@ -241,4 +241,12 @@ describe('Testing BugReporting Module', () => {
     expect(NativeBugReporting.setVideoRecordingFloatingButtonPosition).toBeCalledTimes(1);
     expect(NativeBugReporting.setVideoRecordingFloatingButtonPosition).toBeCalledWith(position);
   });
+
+  it('should call the native method setDisclaimerText', () => {
+    const text = 'This is a disclaimer text!';
+    BugReporting.setDisclaimerText(text);
+
+    expect(NativeBugReporting.setDisclaimerText).toBeCalledTimes(1);
+    expect(NativeBugReporting.setDisclaimerText).toBeCalledWith(text);
+  });
 });

--- a/tests/modules/BugReporting.spec.js
+++ b/tests/modules/BugReporting.spec.js
@@ -249,4 +249,14 @@ describe('Testing BugReporting Module', () => {
     expect(NativeBugReporting.setDisclaimerText).toBeCalledTimes(1);
     expect(NativeBugReporting.setDisclaimerText).toBeCalledWith(text);
   });
+
+  it('should call the native method setCommentMinimumCharacterCount', () => {
+    const count = 20;
+    const reportTypes = [BugReporting.reportType.bug];
+
+    BugReporting.setCommentMinimumCharacterCount(count, reportTypes);
+
+    expect(NativeBugReporting.setCommentMinimumCharacterCount).toBeCalledTimes(1);
+    expect(NativeBugReporting.setCommentMinimumCharacterCount).toBeCalledWith(count, reportTypes);
+  });
 });

--- a/tests/modules/Instabug.spec.js
+++ b/tests/modules/Instabug.spec.js
@@ -15,6 +15,13 @@ import InstabugUtils from '../../src/utils/InstabugUtils';
 const { Instabug: NativeInstabug, IBGCrashReporting: NativeCrashReporting } = NativeModules;
 
 describe('Instabug Module', () => {
+  it('should call the native method setEnabled', () => {
+    Instabug.setEnabled(true);
+
+    expect(NativeInstabug.setEnabled).toBeCalledTimes(1);
+    expect(NativeInstabug.setEnabled).toBeCalledWith(true);
+  });
+
   it('reportScreenChange should call the native method reportScreenChange', () => {
     const screenName = 'some-screen';
     Instabug.reportScreenChange(screenName);


### PR DESCRIPTION
## Description of the change

1. Adds `BugReporting.setDisclaimerText` API
2. Adds `BugReporting.setCommentMinimumCharacterCount` API
3. Deprecates `Instabug.enable` and `Instabug.disable` APIs in favour of a new API `Instabug.setEnabled`, which works on both platforms
4. Adds unit tests for the new APIs

**Usage Examples:** 🚀 

1. 

```
BugReporting.setDisclaimerText(
      "Instabug can help developers produce more quality code. [Learn more](https://www.instabug.com)"); 
```
2. 
`BugReporting.setCommentMinimumCharacterCount(20);`

Another usage:
```
BugReporting.setCommentMinimumCharacterCount(20, [
      BugReporting.reportType.bug,
      BugReporting.reportType.feedback,
    ]);
```
3. `Instabug.setEnabled(true);` OR `Instabug.setEnabled(false);`

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request
