### PR TITLE
[MOB-10612] Support `setSdkDebugLogsLevel` on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Deprecates Instabug.setDebugEnabled and APM.setLogLevel APIs in favour of Instabug.setSdkDebugLogsLevel, which controls the verbosity of SDK logs on both platforms
+
 ## 11.5.0 (2022-11-28)
 
 - Bumps Instabug Android SDK to v11.6.0

--- a/android/src/main/java/com/instabug/reactlibrary/ArgsRegistry.java
+++ b/android/src/main/java/com/instabug/reactlibrary/ArgsRegistry.java
@@ -57,6 +57,7 @@ final class ArgsRegistry {
             putAll(actionTypes);
             putAll(extendedBugReportStates);
             putAll(reproStates);
+            putAll(sdkLogLevels);
             putAll(promptOptions);
             putAll(locales);
             putAll(placeholders);
@@ -143,6 +144,13 @@ final class ArgsRegistry {
         put("reproStepsEnabledWithNoScreenshots", State.ENABLED_WITH_NO_SCREENSHOTS);
         put("reproStepsEnabled", State.ENABLED);
         put("reproStepsDisabled", State.DISABLED);
+    }};
+
+    static final ArgsMap<Integer> sdkLogLevels = new ArgsMap<Integer>() {{
+        put("sdkDebugLogsLevelNone", com.instabug.library.LogLevel.NONE);
+        put("sdkDebugLogsLevelError", com.instabug.library.LogLevel.ERROR);
+        put("sdkDebugLogsLevelDebug", com.instabug.library.LogLevel.DEBUG);
+        put("sdkDebugLogsLevelVerbose", com.instabug.library.LogLevel.VERBOSE);
     }};
 
     @Deprecated

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
@@ -39,6 +39,7 @@ import com.instabug.library.Instabug;
 import com.instabug.library.InstabugState;
 import com.instabug.library.OnSdkDismissCallback;
 import com.instabug.library.Platform;
+import com.instabug.library.LogLevel;
 import com.instabug.library.extendedbugreport.ExtendedBugReport;
 import com.instabug.library.internal.module.InstabugLocale;
 import com.instabug.library.invocation.InstabugInvocationEvent;
@@ -563,8 +564,21 @@ public class RNInstabugReactnativeModule extends ReactContextBaseJavaModule {
         });
     }
 
-
-
+    @ReactMethod
+    public void setSdkDebugLogsLevel(final String logLevel) {
+        MainThreadHandler.runOnMainThread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    final int sdkLogLevel = ArgsRegistry.sdkLogLevels
+                            .getOrDefault(logLevel, LogLevel.ERROR);
+                    Instabug.setSdkDebugLogsLevel(sdkLogLevel);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        });
+    }
 
     /**
      * Appends a log message to Instabug internal log

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
@@ -544,26 +544,6 @@ public class RNInstabugReactnativeModule extends ReactContextBaseJavaModule {
         });
     }
 
-    /**
-     * Enable/Disable debug logs from Instabug SDK
-     * Default state: disabled
-     *
-     * @param isDebugEnabled whether debug logs should be printed or not into LogCat
-     */
-    @ReactMethod
-    public void setDebugEnabled(final boolean isDebugEnabled) {
-        MainThreadHandler.runOnMainThread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    Instabug.setDebugEnabled(isDebugEnabled);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            }
-        });
-    }
-
     @ReactMethod
     public void setSdkDebugLogsLevel(final String logLevel) {
         MainThreadHandler.runOnMainThread(new Runnable() {

--- a/android/src/test/java/com/instabug/reactlibrary/RNInstabugReactnativeModuleTest.java
+++ b/android/src/test/java/com/instabug/reactlibrary/RNInstabugReactnativeModuleTest.java
@@ -126,6 +126,25 @@ public class RNInstabugReactnativeModuleTest {
     }
 
     @Test
+    public void givenArg$setSdkDebugLogsLevel_whenQuery_thenShouldCallNativeApi() {
+        // given
+        Map<String, Integer> sdkLogLevelArg = ArgsRegistry.sdkLogLevels;
+        final String[] keysArray = sdkLogLevelArg.keySet().toArray(new String[0]);
+
+        // when
+        for (String key: keysArray) {
+            rnModule.setSdkDebugLogsLevel(key);
+        }
+
+        // then
+        verify(Instabug.class,times(1));
+        for (String key : keysArray) {
+            int sdkLogLevel = sdkLogLevelArg.get(key);
+            Instabug.setSdkDebugLogsLevel(sdkLogLevel);
+        }
+    }
+
+    @Test
     public void givenArgs$setUserAttribute_whenQuery_thenShouldCallNativeApi() {
         // given
 

--- a/android/src/test/java/com/instabug/reactlibrary/RNInstabugReactnativeModuleTest.java
+++ b/android/src/test/java/com/instabug/reactlibrary/RNInstabugReactnativeModuleTest.java
@@ -117,15 +117,6 @@ public class RNInstabugReactnativeModuleTest {
     }
 
     @Test
-    public void givenBoolean$setDebugEnabled_whenQuery_thenShouldCallNativeApi() {
-        // when
-        rnModule.setDebugEnabled(true);
-        // then
-        verify(Instabug.class,times(1));
-        Instabug.setDebugEnabled(true);
-    }
-
-    @Test
     public void givenArg$setSdkDebugLogsLevel_whenQuery_thenShouldCallNativeApi() {
         // given
         Map<String, Integer> sdkLogLevelArg = ArgsRegistry.sdkLogLevels;

--- a/src/modules/APM.ts
+++ b/src/modules/APM.ts
@@ -7,6 +7,8 @@ import { logLevel } from '../utils/ArgsRegistry';
 export { logLevel };
 
 /**
+ * @deprecated Use {@link setSdkDebugLogsLevel} instead.
+ *
  * Sets the printed logs priority. Filter to one of the following levels:
  *
  * - `logLevelNone` disables all APM SDK console logs.

--- a/src/modules/Instabug.ts
+++ b/src/modules/Instabug.ts
@@ -123,14 +123,11 @@ export const setSessionProfilerEnabled = (isEnabled: boolean) => {
 };
 
 /**
- * This API sets the verbosity level of logs used to debug The SDK. The default value in debug
- * mode is sdkDebugLogsLevelVerbose and in production is sdkDebugLogsLevelError.
+ * This API sets the verbosity level of logs used to debug The SDK. The default value is sdkDebugLogsLevelError.
  * @param level The verbosity level of logs.
  */
 export const setSdkDebugLogsLevel = (level: sdkDebugLogsLevel) => {
-  if (Platform.OS === 'ios') {
-    NativeInstabug.setSdkDebugLogsLevel(level);
-  }
+  NativeInstabug.setSdkDebugLogsLevel(level);
 };
 
 /**

--- a/src/modules/Instabug.ts
+++ b/src/modules/Instabug.ts
@@ -383,6 +383,8 @@ export const clearAllUserAttributes = () => {
 };
 
 /**
+ * @deprecated Use {@link setSdkDebugLogsLevel} instead. This will work on both Android and iOS.
+ *
  * Enable/Disable debug logs from Instabug SDK
  * Default state: disabled
  *
@@ -390,7 +392,11 @@ export const clearAllUserAttributes = () => {
  */
 export const setDebugEnabled = (isEnabled: boolean) => {
   if (Platform.OS === 'android') {
-    NativeInstabug.setDebugEnabled(isEnabled);
+    if (isEnabled) {
+      setSdkDebugLogsLevel(sdkDebugLogsLevel.sdkDebugLogsLevelVerbose);
+    } else {
+      setSdkDebugLogsLevel(sdkDebugLogsLevel.sdkDebugLogsLevelNone);
+    }
   }
 };
 

--- a/tests/modules/Instabug.spec.js
+++ b/tests/modules/Instabug.spec.js
@@ -361,23 +361,13 @@ describe('Instabug Module', () => {
     expect(NativeInstabug.setReproStepsMode).toBeCalledWith(mode);
   });
 
-  it('should call the native method setSdkDebugLogsLevel on iOS', () => {
+  it('should call the native method setSdkDebugLogsLevel', () => {
     const debugLevel = Instabug.sdkDebugLogsLevel.sdkDebugLogsLevelVerbose;
 
-    Platform.OS = 'ios';
     Instabug.setSdkDebugLogsLevel(debugLevel);
 
     expect(NativeInstabug.setSdkDebugLogsLevel).toBeCalledTimes(1);
     expect(NativeInstabug.setSdkDebugLogsLevel).toBeCalledWith(debugLevel);
-  });
-
-  it('should not call the native method setSdkDebugLogsLevel on Android', () => {
-    const debugLevel = Instabug.sdkDebugLogsLevel.sdkDebugLogsLevelVerbose;
-
-    Platform.OS = 'android';
-    Instabug.setSdkDebugLogsLevel(debugLevel);
-
-    expect(NativeInstabug.setSdkDebugLogsLevel).not.toBeCalled();
   });
 
   it.each([

--- a/tests/modules/Instabug.spec.js
+++ b/tests/modules/Instabug.spec.js
@@ -434,19 +434,20 @@ describe('Instabug Module', () => {
     expect(NativeInstabug.clearAllUserAttributes).toBeCalledTimes(1);
   });
 
-  it('should call the native method setDebugEnabled', () => {
+  it('should call the native method setSdkDebugLogsLevel when setDebugEnabled is called on Android', () => {
     Platform.OS = 'android';
     Instabug.setDebugEnabled(true);
+    const debugLevel = Instabug.sdkDebugLogsLevel.sdkDebugLogsLevelVerbose;
 
-    expect(NativeInstabug.setDebugEnabled).toBeCalledTimes(1);
-    expect(NativeInstabug.setDebugEnabled).toBeCalledWith(true);
+    expect(NativeInstabug.setSdkDebugLogsLevel).toBeCalledTimes(1);
+    expect(NativeInstabug.setSdkDebugLogsLevel).toBeCalledWith(debugLevel);
   });
 
-  it('should not call the native method setDebugEnabled when platform is ios', () => {
+  it('should not call the native method setSdkDebugLogsLevel when when setDebugEnabled is called on ios', () => {
     Platform.OS = 'ios';
     Instabug.setDebugEnabled(true);
 
-    expect(NativeInstabug.setDebugEnabled).not.toBeCalled();
+    expect(NativeInstabug.setSdkDebugLogsLevel).not.toBeCalled();
   });
 
   it('should call the native method enable', () => {


### PR DESCRIPTION
## Description of the change
We had two different native APIs for SDK logs, which were mapped accordingly in RN. Since this is now unified natively, this PR does the following:

1. Adds `setSdkDebugLogsLevel` implementation on Android, along with the needed changes and tests.
2. Deprecates `setDebugEnabled` and updates its implementation to use the new API when called on Android, in addition to the related unit tests.
3. Removes `setDebugEnabled` from the native bridge as well as its test. 

Note:
This is based on an internal snapshot, so the Android tests are expected to fail until we bump to the Android release, including this API.

To-Do:
- Rebase the PR after bumping the Android version

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request
