### PR TITLE
[MOB-10648] Add Overridable String Keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - Bumps Instabug Android SDK to v11.7.0
 - Bumps Instabug iOS SDK to v11.6.0
+- Adds new string keys: insufficientContentMessage and insufficientContentTitle
+- Adds missing mapping for some existing keys if relevant to the other platform
+- Removes the string key: video
 
 ## 11.5.1 (2022-12-14)
 

--- a/android/src/main/java/com/instabug/reactlibrary/ArgsRegistry.java
+++ b/android/src/main/java/com/instabug/reactlibrary/ArgsRegistry.java
@@ -236,5 +236,12 @@ final class ArgsRegistry {
         put("reproStepsListDescription", Key.REPRO_STEPS_LIST_DESCRIPTION);
         put("reproStepsListEmptyStateDescription", Key.REPRO_STEPS_LIST_EMPTY_STATE_DESCRIPTION);
         put("reproStepsListItemTitle", Key.REPRO_STEPS_LIST_ITEM_NUMBERING_TITLE);
+        put("okButtonTitle", Key.BUG_ATTACHMENT_DIALOG_OK_BUTTON);
+        put("audio", Key.CHATS_TYPE_AUDIO);
+        put("image", Key.CHATS_TYPE_IMAGE);
+        put("screenRecording", Key.CHATS_TYPE_VIDEO);
+        put("messagesNotificationAndOthers", Key.CHATS_MULTIPLE_MESSAGE_NOTIFICATION);
+        put("team", Key.CHATS_TEAM_STRING_NAME);
+        put("insufficientContentMessage", Key.COMMENT_FIELD_INSUFFICIENT_CONTENT);
     }};
 }

--- a/android/src/main/java/com/instabug/reactlibrary/ArgsRegistry.java
+++ b/android/src/main/java/com/instabug/reactlibrary/ArgsRegistry.java
@@ -201,7 +201,6 @@ final class ArgsRegistry {
         put("recordingMessageToHoldText", Key.VOICE_MESSAGE_PRESS_AND_HOLD_TO_RECORD);
         put("recordingMessageToReleaseText", Key.VOICE_MESSAGE_RELEASE_TO_ATTACH);
         put("thankYouText", Key.SUCCESS_DIALOG_HEADER);
-        put("video", Key.VIDEO_PLAYER_TITLE);
         put("videoPressRecord", Key.VIDEO_RECORDING_FAB_BUBBLE_HINT);
         put("conversationTextFieldHint", Key.CONVERSATION_TEXT_FIELD_HINT);
         put("thankYouAlertText", Key.REPORT_SUCCESSFULLY_SENT);

--- a/ios/RNInstabug/ArgsRegistry.m
+++ b/ios/RNInstabug/ArgsRegistry.m
@@ -252,7 +252,10 @@
         @"reproStepsListHeader": kIBGReproStepsListTitle,
         @"reproStepsListDescription": kIBGReproStepsListHeader,
         @"reproStepsListEmptyStateDescription": kIBGReproStepsListEmptyStateLabel,
-        @"reproStepsListItemTitle": kIBGReproStepsListItemName
+        @"reproStepsListItemTitle": kIBGReproStepsListItemName,
+        @"conversationTextFieldHint": kIBGChatReplyFieldPlaceholderStringName,
+        @"insufficientContentTitle" : kIBGInsufficientContentTitleStringName,
+        @"insufficientContentMessage" : kIBGInsufficientContentMessageStringName,
     };
 }
 

--- a/src/utils/ArgsRegistry.ts
+++ b/src/utils/ArgsRegistry.ts
@@ -231,4 +231,7 @@ export enum strings {
   reproStepsListDescription = NativeInstabug.reproStepsListDescription,
   reproStepsListEmptyStateDescription = NativeInstabug.reproStepsListEmptyStateDescription,
   reproStepsListItemTitle = NativeInstabug.reproStepsListItemTitle,
+  screenRecording = NativeInstabug.screenRecording,
+  insufficientContentMessage = NativeInstabug.insufficientContentMessage,
+  insufficientContentTitle = NativeInstabug.insufficientContentTitle,
 }

--- a/src/utils/ArgsRegistry.ts
+++ b/src/utils/ArgsRegistry.ts
@@ -197,7 +197,6 @@ export enum strings {
   cancelButtonText = NativeInstabug.cancelButtonTitle,
   thankYouText = NativeInstabug.thankYouText,
   audio = NativeInstabug.audio,
-  video = NativeInstabug.video,
   image = NativeInstabug.image,
   team = NativeInstabug.team,
   messagesNotification = NativeInstabug.messagesNotification,


### PR DESCRIPTION
## Description of the change

1. Add these string keys: `screenRecording`, `insufficientContentMessage`, and `insufficientContentTitle` with their mapping on both platforms (if relevant).
2. For already-existing keys on one platform, we add the corresponding mapping on the other platform (if relevant) for consistency and unification. 

Note:
This is based on an internal snapshot, so the Android tests are expected to fail until we bump to the Android release, including the new keys.

To-Do:

Rebase the PR after bumping the Android version

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request
