### PR TITLE
[INSD-8643] Fix `Survey` interface export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fixes Survey interface export causing a build error with certain babel versions
+
 ## 11.5.0 (2022-11-28)
 
 - Bumps Instabug Android SDK to v11.6.0

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,6 @@ import * as Surveys from './modules/Surveys';
 export {
   Report,
   Trace,
-  Survey,
   APM,
   BugReporting,
   CrashReporting,
@@ -24,5 +23,7 @@ export {
   Replies,
   Surveys,
 };
+
+export type { Survey };
 
 export default Instabug;


### PR DESCRIPTION
## Description of the change

**Problem:**
In `index.js`, we import `Survey` interface with `import type` while re-export it as `export { Survey };` which causes a build error with certain babel versions. 

**Solution:**
Re-export `Survey` interface as `export type { Survey };`

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request
