### PR TITLE
[INSD-8643] Add `reportError` and deprecate `reportJSException`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Deprecates CrashReporting.reportJSException in favour of a new strongly typed API: CrashReporting.reportError
 - Fixes Survey interface export causing a build error with certain babel versions
 
 ## 11.5.0 (2022-11-28)

--- a/example/src/screens/HomeScreen.js
+++ b/example/src/screens/HomeScreen.js
@@ -27,8 +27,10 @@ export function HomeScreen() {
     try {
       throw new Error('Handled Exception From Instabug Test App');
     } catch (err) {
-      CrashReporting.reportJSException(err);
-      Alert.alert('Crash report Sent!');
+      if (err instanceof Error) {
+        CrashReporting.reportError(err);
+        Alert.alert('Crash report Sent!');
+      }
     }
   };
 

--- a/src/modules/CrashReporting.ts
+++ b/src/modules/CrashReporting.ts
@@ -1,5 +1,4 @@
 import { Platform } from 'react-native';
-import type { ExtendedError } from 'react-native/Libraries/Core/Devtools/parseErrorStack';
 
 import { NativeCrashReporting } from '../native';
 import IBGEventEmitter from '../utils/IBGEventEmitter';
@@ -19,25 +18,27 @@ export const setEnabled = (isEnabled: boolean) => {
  * Send handled JS error object
  * @param error Error object to be sent to Instabug's servers
  */
-export const reportJSException = (error: ExtendedError) => {
-  const jsStackTrace = InstabugUtils.getStackTrace(error);
+export const reportJSException = (error: any) => {
+  if (error instanceof Error) {
+    const jsStackTrace = InstabugUtils.getStackTrace(error);
 
-  const jsonObject = {
-    message: error.name + ' - ' + error.message,
-    e_message: error.message,
-    e_name: error.name,
-    os: Platform.OS,
-    platform: 'react_native',
-    exception: jsStackTrace,
-  };
+    const jsonObject = {
+      message: error.name + ' - ' + error.message,
+      e_message: error.message,
+      e_name: error.name,
+      os: Platform.OS,
+      platform: 'react_native',
+      exception: jsStackTrace,
+    };
 
-  if (InstabugUtils.isOnReportHandlerSet() && Platform.OS === 'android') {
-    IBGEventEmitter.emit(InstabugConstants.SEND_HANDLED_CRASH, jsonObject);
-  } else {
-    if (Platform.OS === 'android') {
-      NativeCrashReporting.sendHandledJSCrash(JSON.stringify(jsonObject));
+    if (InstabugUtils.isOnReportHandlerSet() && Platform.OS === 'android') {
+      IBGEventEmitter.emit(InstabugConstants.SEND_HANDLED_CRASH, jsonObject);
     } else {
-      NativeCrashReporting.sendHandledJSCrash(jsonObject);
+      if (Platform.OS === 'android') {
+        NativeCrashReporting.sendHandledJSCrash(JSON.stringify(jsonObject));
+      } else {
+        NativeCrashReporting.sendHandledJSCrash(jsonObject);
+      }
     }
   }
 };

--- a/tests/modules/CrashReporting.spec.js
+++ b/tests/modules/CrashReporting.spec.js
@@ -20,7 +20,7 @@ describe('CrashReporting Module', () => {
   it('should call the native method sendHandledJSCrash when platform is ios', () => {
     Platform.OS = 'ios';
     const errorObject = { name: 'TypeError', message: 'Invalid type' };
-    CrashReporting.reportJSException(errorObject);
+    CrashReporting.reportError(errorObject);
 
     const expectedObject = {
       message: 'TypeError - Invalid type',
@@ -38,7 +38,7 @@ describe('CrashReporting Module', () => {
   it('should call the native method sendHandledJSCrash when platform is android', () => {
     Platform.OS = 'android';
     const errorObject = { name: 'TypeError', message: 'Invalid type' };
-    CrashReporting.reportJSException(errorObject);
+    CrashReporting.reportError(errorObject);
 
     const expectedObject = {
       message: 'TypeError - Invalid type',
@@ -75,7 +75,7 @@ describe('CrashReporting Module', () => {
       crashHandler,
     );
 
-    CrashReporting.reportJSException(errorObject);
+    CrashReporting.reportError(errorObject);
     expect(crashHandler).toBeCalledTimes(1);
     expect(crashHandler).toBeCalledWith(expectedObject);
   });


### PR DESCRIPTION
## Description of the change

**Problem:**
Enforcing a strong type for `reportJSException` would require code changes from the users as the `catch` block parameter has to be of type `any` / `unknown`.

**Solution:**
1. Instead of the users having to handle the `error` type checking before calling the API, we accept `any` type and handle the type checking internally not to cause breaking changes with the current API.
2. Introduce a new strongly typed API `reportError` and deprecate `reportJSException`

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request
