### PR TITLE
[MOB-11436] Deprecate `callPrivateApi`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Bumps Instabug Android SDK to v11.7.0
 - Bumps Instabug iOS SDK to v11.6.0
+- Deprecates the legacy API `callPrivateApi`
 
 ## 11.5.1 (2022-12-14)
 

--- a/src/modules/Instabug.ts
+++ b/src/modules/Instabug.ts
@@ -561,6 +561,9 @@ export const onReportSubmitHandler = (handler?: (report: Report) => void) => {
   NativeInstabug.setPreSendingHandler(handler);
 };
 
+/**
+ * @deprecated Legacy API that will be removed in future releases.
+ */
 export const callPrivateApi = (apiName: string, param: any[]) => {
   NativeInstabug.callPrivateApi(apiName, param);
 };


### PR DESCRIPTION
## Description of the change

> Description goes here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
