### PR TITLE
[MOB-11440] Add `debugLogsLevel` to `InstabugConfig`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
 - Deprecates Instabug.start in favour of Instabug.init that takes a configuration object for SDK initialization.
+- Deprecates Instabug.setDebugEnabled, Instabug.setSdkDebugLogsLevel, and APM.setLogLevel in favour of debugLogsLevel property, which can be passed to InstabugConfig while initializing the SDK using Instabug.init.
+- Deprecates the enums: sdkDebugLogsLevel and logLevel in favour of a new enum LogLevel.
 
 ## 11.6.0 (2022-12-29)
 

--- a/android/src/main/java/com/instabug/reactlibrary/ArgsRegistry.java
+++ b/android/src/main/java/com/instabug/reactlibrary/ArgsRegistry.java
@@ -57,6 +57,7 @@ final class ArgsRegistry {
             putAll(actionTypes);
             putAll(extendedBugReportStates);
             putAll(reproStates);
+            putAll(sdkLogLevels);
             putAll(promptOptions);
             putAll(locales);
             putAll(placeholders);
@@ -143,6 +144,13 @@ final class ArgsRegistry {
         put("reproStepsEnabledWithNoScreenshots", State.ENABLED_WITH_NO_SCREENSHOTS);
         put("reproStepsEnabled", State.ENABLED);
         put("reproStepsDisabled", State.DISABLED);
+    }};
+
+    static final ArgsMap<Integer> sdkLogLevels = new ArgsMap<Integer>() {{
+        put("sdkDebugLogsLevelNone", com.instabug.library.LogLevel.NONE);
+        put("sdkDebugLogsLevelError", com.instabug.library.LogLevel.ERROR);
+        put("sdkDebugLogsLevelDebug", com.instabug.library.LogLevel.DEBUG);
+        put("sdkDebugLogsLevelVerbose", com.instabug.library.LogLevel.VERBOSE);
     }};
 
     @Deprecated

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
@@ -39,6 +39,7 @@ import com.instabug.library.Instabug;
 import com.instabug.library.InstabugState;
 import com.instabug.library.OnSdkDismissCallback;
 import com.instabug.library.Platform;
+import com.instabug.library.LogLevel;
 import com.instabug.library.extendedbugreport.ExtendedBugReport;
 import com.instabug.library.internal.module.InstabugLocale;
 import com.instabug.library.invocation.InstabugInvocationEvent;
@@ -133,19 +134,21 @@ public class RNInstabugReactnativeModule extends ReactContextBaseJavaModule {
      * @param invocationEventValues The events that invoke the SDK's UI.
      */
     @ReactMethod
-    public void init(final String token, final ReadableArray invocationEventValues) {
+    public void init(final String token, final ReadableArray invocationEventValues, final String logLevel) {
         MainThreadHandler.runOnMainThread(new Runnable() {
             @Override
             public void run() {
                 try {
                     final ArrayList<String> keys = ArrayUtil.parseReadableArrayOfStrings(invocationEventValues);
                     final ArrayList<InstabugInvocationEvent> parsedInvocationEvents = ArgsRegistry.invocationEvents.getAll(keys);
+                    final int parsedLogLevel = ArgsRegistry.sdkLogLevels.getOrDefault(logLevel, LogLevel.ERROR);
 
                     setCurrentPlatform();
                     setBaseUrlForDeprecationLogs();
 
                     new Instabug.Builder(getCurrentActivity().getApplication(), token)
                             .setInvocationEvents(parsedInvocationEvents.toArray(new InstabugInvocationEvent[0]))
+                            .setSdkDebugLogsLevel(parsedLogLevel)
                             .build();
 
                     // Temporarily disabling APM hot launches

--- a/example/ios/InstabugSampleTests/InstabugSampleTests.m
+++ b/example/ios/InstabugSampleTests/InstabugSampleTests.m
@@ -66,10 +66,12 @@
   IBGInvocationEvent floatingButtonInvocationEvent = IBGInvocationEventFloatingButton;
   NSString *appToken = @"app_token";
   NSArray *invocationEvents = [NSArray arrayWithObjects:[NSNumber numberWithInteger:floatingButtonInvocationEvent], nil];
+  IBGSDKDebugLogsLevel sdkDebugLogsLevel = IBGSDKDebugLogsLevelDebug;
+  
   XCTestExpectation *expectation = [self expectationWithDescription:@"Testing [Instabug init]"];
   
   OCMStub([mock startWithToken:appToken invocationEvents:floatingButtonInvocationEvent]);
-  [self.instabugBridge init:appToken invocationEvents:invocationEvents];
+  [self.instabugBridge init:appToken invocationEvents:invocationEvents debugLogsLevel:sdkDebugLogsLevel];
 
   [[NSRunLoop mainRunLoop] performBlock:^{
     OCMVerify([mock startWithToken:appToken invocationEvents:floatingButtonInvocationEvent]);

--- a/ios/RNInstabug/InstabugReactBridge.h
+++ b/ios/RNInstabug/InstabugReactBridge.h
@@ -27,7 +27,7 @@
 
 - (void)setEnabled:(BOOL)isEnabled;
 
-- (void)init:(NSString *)token invocationEvents:(NSArray *)invocationEventsArray;
+- (void)init:(NSString *)token invocationEvents:(NSArray *)invocationEventsArray debugLogsLevel:(IBGSDKDebugLogsLevel)sdkDebugLogsLevel;
 
 - (void)setUserData:(NSString *)userData;
 

--- a/ios/RNInstabug/InstabugReactBridge.m
+++ b/ios/RNInstabug/InstabugReactBridge.m
@@ -41,7 +41,7 @@ RCT_EXPORT_METHOD(setEnabled:(BOOL)isEnabled) {
     Instabug.enabled = isEnabled;
 }
 
-RCT_EXPORT_METHOD(init:(NSString *)token invocationEvents:(NSArray*)invocationEventsArray) {
+RCT_EXPORT_METHOD(init:(NSString *)token invocationEvents:(NSArray*)invocationEventsArray debugLogsLevel:(IBGSDKDebugLogsLevel)sdkDebugLogsLevel) {
     SEL setPrivateApiSEL = NSSelectorFromString(@"setCurrentPlatform:");
     if ([[Instabug class] respondsToSelector:setPrivateApiSEL]) {
         NSInteger *platform = IBGPlatformReactNative;
@@ -57,7 +57,8 @@ RCT_EXPORT_METHOD(init:(NSString *)token invocationEvents:(NSArray*)invocationEv
         invocationEvents |= [boxedValue intValue];
     }
     [Instabug startWithToken:token invocationEvents:invocationEvents];
-    
+    [Instabug setSdkDebugLogsLevel:sdkDebugLogsLevel];
+
     RCTAddLogFunction(InstabugReactLogFunction);
     RCTSetLogThreshold(RCTLogLevelInfo);
     

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export {
   Replies,
   Surveys,
 };
+export * from './utils/Enums';
 
 export type { InstabugConfig };
 export type { Survey };

--- a/src/models/InstabugConfig.ts
+++ b/src/models/InstabugConfig.ts
@@ -1,6 +1,8 @@
 import type { invocationEvent } from '../utils/ArgsRegistry';
+import type { LogLevel } from '../utils/Enums';
 
 export interface InstabugConfig {
   token: string;
   invocationEvents: invocationEvent[];
+  debugLogsLevel?: LogLevel;
 }

--- a/src/models/InstabugConfig.ts
+++ b/src/models/InstabugConfig.ts
@@ -2,7 +2,16 @@ import type { invocationEvent } from '../utils/ArgsRegistry';
 import type { LogLevel } from '../utils/Enums';
 
 export interface InstabugConfig {
+  /**
+   * The token that identifies the app. You can find it on your dashboard.
+   */
   token: string;
+  /**
+   * An array of events that invoke the SDK's UI.
+   */
   invocationEvents: invocationEvent[];
+  /**
+   * An optional LogLevel to indicate the verbosity of SDK logs. Default is Error.
+   */
   debugLogsLevel?: LogLevel;
 }

--- a/src/modules/APM.ts
+++ b/src/modules/APM.ts
@@ -7,6 +7,8 @@ import { logLevel } from '../utils/ArgsRegistry';
 export { logLevel };
 
 /**
+ * @deprecated Pass a LogLevel to debugLogsLevel in Instabug.init instead.
+ *
  * Sets the printed logs priority. Filter to one of the following levels:
  *
  * - `logLevelNone` disables all APM SDK console logs.

--- a/src/modules/Instabug.ts
+++ b/src/modules/Instabug.ts
@@ -144,6 +144,8 @@ export const setSessionProfilerEnabled = (isEnabled: boolean) => {
 };
 
 /**
+ * @deprecated Pass a {@link LogLevel} to debugLogsLevel in {@link init} instead. This will work on both Android and iOS.
+ *
  * This API sets the verbosity level of logs used to debug The SDK. The default value in debug
  * mode is sdkDebugLogsLevelVerbose and in production is sdkDebugLogsLevelError.
  * @param level The verbosity level of logs.
@@ -407,6 +409,8 @@ export const clearAllUserAttributes = () => {
 };
 
 /**
+ * @deprecated Pass a {@link LogLevel} to debugLogsLevel in {@link init} instead. This will work on both Android and iOS.
+ *
  * Enable/Disable debug logs from Instabug SDK
  * Default state: disabled
  *

--- a/src/modules/Instabug.ts
+++ b/src/modules/Instabug.ts
@@ -22,6 +22,7 @@ import {
   strings,
   welcomeMessageMode,
 } from '../utils/ArgsRegistry';
+import { LogLevel } from '../utils/Enums';
 import IBGEventEmitter from '../utils/IBGEventEmitter';
 import InstabugConstants from '../utils/InstabugConstants';
 import InstabugUtils, { stringifyIfNotString } from '../utils/InstabugUtils';
@@ -73,14 +74,20 @@ export const start = (token: string, invocationEvents: invocationEvent[]) => {
  * This is the main SDK method that does all the magic. This is the only
  * method that SHOULD be called.
  * Should be called in constructor of the AppRegistry component
- * @param token The token that identifies the app. You can find it on your dashboard.
- * @param invocationEvents The events that invoke the SDK's UI.
+ * @param config InstabugConfig object that includes:
+ * token: The token that identifies the app. You can find it on your dashboard.
+ * invocationEvents: The events that invoke the SDK's UI.
+ * debugLogsLevel: (Optional) A LogLevel to indicate the verbosity of SDK logs. Default is Error.
  */
 export const init = (config: InstabugConfig) => {
   InstabugUtils.captureJsErrors();
   NetworkLogger.setEnabled(true);
 
-  NativeInstabug.init(config.token, config.invocationEvents);
+  NativeInstabug.init(
+    config.token,
+    config.invocationEvents,
+    config.debugLogsLevel ?? LogLevel.Error,
+  );
 
   _isFirstScreen = true;
   _currentScreen = firstScreen;

--- a/src/modules/Instabug.ts
+++ b/src/modules/Instabug.ts
@@ -74,10 +74,7 @@ export const start = (token: string, invocationEvents: invocationEvent[]) => {
  * This is the main SDK method that does all the magic. This is the only
  * method that SHOULD be called.
  * Should be called in constructor of the AppRegistry component
- * @param config InstabugConfig object that includes:
- * token: The token that identifies the app. You can find it on your dashboard.
- * invocationEvents: The events that invoke the SDK's UI.
- * debugLogsLevel: (Optional) A LogLevel to indicate the verbosity of SDK logs. Default is Error.
+ * @param config SDK configurations. See {@link InstabugConfig} for more info.
  */
 export const init = (config: InstabugConfig) => {
   InstabugUtils.captureJsErrors();

--- a/src/utils/ArgsRegistry.ts
+++ b/src/utils/ArgsRegistry.ts
@@ -1,7 +1,7 @@
 import { NativeInstabug } from '../native';
 
 /**
- * @deprecated Pass a LogLevel to debugLogsLevel in Instabug.init instead.
+ * @deprecated Pass a `LogLevel` to `debugLogsLevel` in `Instabug.init` instead.
  *
  * Verbosity level of the SDK debug logs. This has nothing to do with IBGLog,
  * and only affect the logs used to debug the SDK itself.
@@ -14,7 +14,7 @@ export enum sdkDebugLogsLevel {
 }
 
 /**
- * @deprecated Pass a LogLevel to debugLogsLevel in Instabug.init instead.
+ * @deprecated Pass a `LogLevel` to `debugLogsLevel` in `Instabug.init` instead.
  *
  * APM Log Level.
  */

--- a/src/utils/ArgsRegistry.ts
+++ b/src/utils/ArgsRegistry.ts
@@ -1,6 +1,8 @@
 import { NativeInstabug } from '../native';
 
 /**
+ * @deprecated Pass a LogLevel to debugLogsLevel in Instabug.init instead.
+ *
  * Verbosity level of the SDK debug logs. This has nothing to do with IBGLog,
  * and only affect the logs used to debug the SDK itself.
  */
@@ -12,6 +14,8 @@ export enum sdkDebugLogsLevel {
 }
 
 /**
+ * @deprecated Pass a LogLevel to debugLogsLevel in Instabug.init instead.
+ *
  * APM Log Level.
  */
 export enum logLevel {

--- a/src/utils/Enums.ts
+++ b/src/utils/Enums.ts
@@ -1,0 +1,8 @@
+import { NativeInstabug } from '../native';
+
+export enum LogLevel {
+  Verbose = NativeInstabug.sdkDebugLogsLevelVerbose,
+  Debug = NativeInstabug.sdkDebugLogsLevelDebug,
+  Error = NativeInstabug.sdkDebugLogsLevelError,
+  None = NativeInstabug.sdkDebugLogsLevelNone,
+}

--- a/tests/modules/Instabug.spec.js
+++ b/tests/modules/Instabug.spec.js
@@ -8,6 +8,7 @@ import waitForExpect from 'wait-for-expect';
 
 import Report from '../../src/models/Report';
 import * as Instabug from '../../src/modules/Instabug';
+import { LogLevel } from '../../src/utils/Enums';
 import IBGEventEmitter from '../../src/utils/IBGEventEmitter';
 import IBGConstants from '../../src/utils/InstabugConstants';
 import InstabugUtils from '../../src/utils/InstabugUtils';
@@ -140,6 +141,7 @@ describe('Instabug Module', () => {
     const instabugConfig = {
       token: 'some-token',
       invocationEvents: [Instabug.invocationEvent.floatingButton, Instabug.invocationEvent.shake],
+      debugLogsLevel: LogLevel.Debug,
     };
     Instabug.init(instabugConfig);
 
@@ -147,6 +149,7 @@ describe('Instabug Module', () => {
     expect(NativeInstabug.init).toBeCalledWith(
       instabugConfig.token,
       instabugConfig.invocationEvents,
+      instabugConfig.debugLogsLevel,
     );
   });
 


### PR DESCRIPTION
## Description of the change

- Add `debugLogsLevel` optional property to `InstabugConfig` and its native mappings.
- Add `LogLevel` enum
- Deprecate the APIs:
1. `Instabug.setDebugEnabled`
2. `Instabug.setSdkDebugLogsLevel`
3. `APM.setLogLevel`
- Deprecate the enums `sdkDebugLogsLevel` and `logLevel`



## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request
