### PR TITLE
[MOB-11562] Fix Original Error Handler Not Called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Fixes global error handler not being called.
 - Deprecates Instabug.start in favour of Instabug.init that takes a configuration object for SDK initialization.
 - Deprecates Instabug.setDebugEnabled, Instabug.setSdkDebugLogsLevel, and APM.setLogLevel in favour of debugLogsLevel property, which can be passed to InstabugConfig while initializing the SDK using Instabug.init.
 - Deprecates the enums: sdkDebugLogsLevel and logLevel in favour of a new enum LogLevel.


### PR DESCRIPTION
## Description of the change

The original global error handler was initialized in the global scope, so it used to have the default value set by React Native. When users try to set a global error handler themselves, the handler will be ignored, due to the early initialization of `originalHandler`.

This PR fixes this issue by getting the global error handler within `Instabug.init` scope. Allowing the users to set global error handlers before initializing Instabug. Setting handlers after Instabug's initialization would still not be possible.

```js
// This handler will be called before Instabug's global error handler
ErrorUtils.setGlobalHandler((err, isFatal) => {
  console.error("Something bad happened");
});

Instabug.init({ ... });
```

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
