### PR TITLE
[MOB-11609] Deprecate `Instabug.isRunningLive` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Deprecates Instabug.start in favour of Instabug.init that takes a configuration object for SDK initialization.
 - Deprecates Instabug.setDebugEnabled, Instabug.setSdkDebugLogsLevel, and APM.setLogLevel in favour of debugLogsLevel property, which can be passed to InstabugConfig while initializing the SDK using Instabug.init.
 - Deprecates the enums: sdkDebugLogsLevel and logLevel in favour of a new enum LogLevel.
+- Deprecates Instabug.isRunningLive API.
 
 ## 11.6.0 (2022-12-29)
 

--- a/src/modules/Instabug.ts
+++ b/src/modules/Instabug.ts
@@ -444,6 +444,9 @@ export const disable = () => {
 };
 
 /**
+ * @deprecated This API will be removed in a future release.
+ * You can manage and check your app running environment using environment variables.
+ *
  * Checks whether app is development/Beta testing OR live
  * Note: This API is iOS only
  * It returns in the callback false if in development or beta testing on Test Flight, and


### PR DESCRIPTION
## Description of the change

This API works only on iOS with no equivalent on Android, which makes it confusing to users. We should deprecate it and recommend managing and checking app running environment using environment variables instead.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request
