### PR TITLE
[MOB-11894] Export Native Android SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Deprecates Instabug.setDebugEnabled, Instabug.setSdkDebugLogsLevel, and APM.setLogLevel in favour of debugLogsLevel property, which can be passed to InstabugConfig while initializing the SDK using Instabug.init.
 - Deprecates the enums: sdkDebugLogsLevel and logLevel in favour of a new enum LogLevel.
 - Deprecates Instabug.isRunningLive API.
+- Exports native Android SDK
 
 ## 11.6.0 (2022-12-29)
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,7 +34,8 @@ android {
 dependencies {
     implementation "androidx.multidex:multidex:2.0.1"
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.instabug.library:instabug:11.7.0'
+
+    api 'com.instabug.library:instabug:11.7.0'
 
     testImplementation "org.mockito:mockito-inline:3.4.0"
     testImplementation "org.mockito:mockito-android:3.4.0"


### PR DESCRIPTION
## Description of the change

Allow users to use Instabug Android SDK within their Java/Kotlin files.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
