### PR TITLE
[MOB-11946] Delegate Native SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Bumps Instabug Android SDK to v11.8.0
 - Bumps Instabug iOS SDK to v11.7.0
 - Adds monorepo support for source maps scripts
+- Adds gradle and ruby files to integrate native SDKs within exiting native apps. See [#919](https://github.com/Instabug/Instabug-React-Native/pull/919) for more info.
 - Fixes global error handler not being called.
 - Deprecates all module-enums (e.g. `Instabug.invocationEvent`) in favour of standalone-enums (e.g. `InvocationEvent`). See [#914](https://github.com/Instabug/Instabug-React-Native/pull/914) for more info and detailed list of Enums.
 - Deprecates Instabug.start in favour of Instabug.init that takes a configuration object for SDK initialization.

--- a/RNInstabug.podspec
+++ b/RNInstabug.podspec
@@ -1,4 +1,6 @@
 require 'json'
+require_relative './ios/native'
+
 package = JSON.parse(File.read('package.json'))
 
 Pod::Spec.new do |s|
@@ -14,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm}"
 
   s.dependency 'React-Core'
-  s.dependency 'Instabug', '11.7.0'
+  use_instabug!(s)
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 
 apply from: './jacoco.gradle'
+apply from: './native.gradle'
 
 String getExtOrDefault(String name) {
     if (rootProject.ext.has(name)) {
@@ -34,8 +35,6 @@ android {
 dependencies {
     implementation "androidx.multidex:multidex:2.0.1"
     implementation 'com.facebook.react:react-native:+'
-
-    api 'com.instabug.library:instabug:11.8.0'
 
     testImplementation "org.mockito:mockito-inline:3.4.0"
     testImplementation "org.mockito:mockito-android:3.4.0"

--- a/android/native.gradle
+++ b/android/native.gradle
@@ -1,0 +1,7 @@
+project.ext.instabug = [
+    version: '11.8.0'
+]
+
+dependencies {
+    api "com.instabug.library:instabug:${project.ext.instabug.version}"
+}

--- a/ios/native.rb
+++ b/ios/native.rb
@@ -1,0 +1,13 @@
+$instabug = { :version => '11.7.0' }
+
+def use_instabug! (spec = nil)
+  version = $instabug[:version]
+
+  if (!spec)
+    pod 'Instabug', version
+  else
+    spec.dependency 'Instabug', version
+  end
+
+  $instabug
+end


### PR DESCRIPTION
## Description of the change

Allow native apps that have recently integrated React Native within their apps to use Instabug native SDKs via the `instabug-reactnative` npm package as follows:

### Android (`app/build.gradle`)

```gradle
apply from: "../../node_modules/instabug-reactnative/android/native.gradle"
```

### iOS (`Podfile`)

```ruby
require_relative '../node_modules/instabug-reactnative/ios/native'

target 'CoolApp' do
  use_instabug!
  // ...
end
```

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
