### PR TITLE
[MOB-11942] Fix Bug Reporting's Did Select Prompt Option Handler

### DIFF
--- a/ios/RNInstabug/InstabugBugReportingBridge.m
+++ b/ios/RNInstabug/InstabugBugReportingBridge.m
@@ -89,7 +89,7 @@ RCT_EXPORT_METHOD(setOnSDKDismissedHandler:(RCTResponseSenderBlock)callBack) {
     }
 }
 
-RCT_EXPORT_METHOD(didSelectPromptOptionHandler:(RCTResponseSenderBlock)callBack) {
+RCT_EXPORT_METHOD(setDidSelectPromptOptionHandler:(RCTResponseSenderBlock)callBack) {
     if (callBack != nil) {
         
         IBGBugReporting.didSelectPromptOptionHandler = ^(IBGPromptOption promptOption) {


### PR DESCRIPTION
## Description of the change

Changes the name of the native bug reporting `setDidSelectPromptOptionHandler` to match the one used on the JavaScript side.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request
