### PR TITLE
[MOB-12026] Fix TS Compile Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fixes a TS compilation error due to a broken entry point path.
+
 ## 11.9.0 (2023-02-20)
 
 - Bumps Instabug Android SDK to v11.9.0.

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,11 +12,11 @@ module.exports = {
   modulePathIgnorePatterns: ['example'],
   transform: {
     '^.+\\.jsx$': 'babel-jest',
-    '^.+\\.tsx?$': [
-      'ts-jest',
-      {
-        tsconfig: 'tsconfig.json',
-      },
-    ],
+    '^.+\\.tsx?$': 'ts-jest',
+  },
+  globals: {
+    'ts-jest': {
+      tsConfig: 'tsconfig.test.json',
+    },
   },
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src/**/*", "test/**/*"],
+  "include": ["src/**/*"],
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["test/**/*"]
+}


### PR DESCRIPTION
## Description of the change
**Problem**
A TS compile error started to arise on `v11.9.0` due to the `dist` dir having a different structure than the entry points provided in `package.json`. In particular, adding the `test` dir in `tsconfig.json` `include` property is the root cause of the change. This was done during the unit tests migration to TS to resolve an error related to the declaration file for module `xhr2`, which is inside the `test` dir. 

**Solution**
Remove the `test` dir from being included and add a separate `tsconfig.test.json` for the tests configuration, which would preserve the old `dist` structure and provide the required files for the tests to run. 

Note:
Changelog formatting according to the new guidelines will be done entirely in a separate PR.  

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request
