### PR TITLE
[MOB-12027] Re-export `NetworkData` Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Fixes a TS compilation error due to a broken entry point path.
+- Re-exports `NetworkData` type to be imported from `instabug-reactnative`.
 
 ## 11.9.0 (2023-02-20)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import * as CrashReporting from './modules/CrashReporting';
 import * as FeatureRequests from './modules/FeatureRequests';
 import * as Instabug from './modules/Instabug';
 import * as NetworkLogger from './modules/NetworkLogger';
+import type { NetworkData } from './modules/NetworkLogger';
 import * as Replies from './modules/Replies';
 import type { Survey } from './modules/Surveys';
 import * as Surveys from './modules/Surveys';
@@ -27,5 +28,6 @@ export {
 };
 export type { InstabugConfig };
 export type { Survey };
+export type { NetworkData };
 
 export default Instabug;

--- a/src/modules/NetworkLogger.ts
+++ b/src/modules/NetworkLogger.ts
@@ -7,6 +7,8 @@ import IBGEventEmitter from '../utils/IBGEventEmitter';
 import InstabugConstants from '../utils/InstabugConstants';
 import xhr, { NetworkData, ProgressCallback } from '../utils/XhrNetworkInterceptor';
 
+export type { NetworkData };
+
 let _networkDataObfuscationHandlerSet = false;
 let _requestFilterExpression = 'false';
 


### PR DESCRIPTION
## Description of the change

Re-exports `NetworkData` type to be imported from `instabug-reactnative`.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request
