### PR TITLE
Disable Sourcemap Upload Scripts on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
           command: yarn
       - android/run-tests:
           working-directory: ./example/android
-          test-command: ./gradlew test
+          test-command: ./gradlew test -PinstabugUploadEnable=false
 
   validate_shell_files:
     machine:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,8 +53,11 @@ task upload_sourcemap(type: Exec) {
 }
 
 tasks.whenTaskAdded { task ->
-    if (task.name == 'preReleaseBuild' &&
-        (rootProject.hasProperty("instabugUploadEnable") ? rootProject.instabugUploadEnable : true)) {
+    def isEnabled = rootProject.hasProperty('instabugUploadEnable')
+            ? new Boolean(rootProject.property('instabugUploadEnable'))
+            : true
+    
+    if (task.name == 'preReleaseBuild' && isEnabled) {
         task.dependsOn upload_sourcemap 
     }
 }

--- a/example/.detoxrc.json
+++ b/example/.detoxrc.json
@@ -22,7 +22,7 @@
     },
     "android.emu.release": {
       "binaryPath": "android/app/build/outputs/apk/release/app-release.apk",
-      "build": "cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release && cd ..",
+      "build": "cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release -PinstabugUploadEnable=false && cd ..",
       "type": "android.emulator",
       "name": "Nexus_6P_API_27"
     }


### PR DESCRIPTION
## Description of the change

Disable the `upload_sourcemaps` Gradle Task from running by passing the property `instabugUploadEnable` via command line. This task used to run unsuccessfully in both Unit and E2E tests on Android as follows:

```text
> Task :instabug-reactnative:upload_sourcemap
./upload_sourcemap.sh: 7: [[: not found
Instabug: Looking for Token...
versionCode could not be found, please upload the sourcemap files manually
``` 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
