### PR TITLE
[MOB-12053] Use `node` CI Orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,28 +3,9 @@ version: 2.1
 orbs:
   android: circleci/android@2.0
   advanced-checkout: vsco/advanced-checkout@1.0.0
+  node: circleci/node@5.1.0
 
 commands:
-  install_node_modules:
-    parameters:
-      working_directory:
-        type: string
-        default: .
-    steps:
-      - restore_cache:
-          name: Restore Yarn Cache
-          keys:
-            - v0.2-node-modules-{{ checksum "<< parameters.working_directory >>/yarn.lock" }}
-      - run:
-          name: Install Node Modules
-          working_directory: << parameters.working_directory >>
-          command: yarn install --frozen-lockfile --cache-folder /tmp/.cache/yarn
-      - save_cache:
-          name: Save Yarn Cache
-          key: v0.2-node-modules-{{ checksum "<< parameters.working_directory >>/yarn.lock" }}
-          paths:
-            - /tmp/.cache/yarn
-
   install_pods:
     parameters:
       working_directory:
@@ -53,11 +34,12 @@ jobs:
       - run: bundle exec danger
 
   lint:
-    docker:
-      - image: cimg/node:16.17.1
+    executor:
+      name: node/default
     steps:
       - advanced-checkout/shallow-checkout
-      - install_node_modules
+      - node/install-packages:
+          pkg-manager: yarn
       - run:
           name: Check Format
           command: yarn format
@@ -66,11 +48,12 @@ jobs:
           command: yarn lint:ci
 
   test_module:
-    docker:
-      - image: cimg/node:16.17.1
+    executor:
+      name: node/default
     steps:
       - advanced-checkout/shallow-checkout
-      - install_node_modules
+      - node/install-packages:
+          pkg-manager: yarn
       - run:
           name: Run Tests
           command: yarn test
@@ -82,10 +65,9 @@ jobs:
     working_directory: ~/project/example
     steps:
       - advanced-checkout/shallow-checkout
-      - run:
-          name: Install Yarn
-          command: npm install -g yarn
-      - install_node_modules
+      - node/install-yarn
+      - node/install-packages:
+          pkg-manager: yarn
       - android/run-tests:
           working-directory: android
           test-command: ./gradlew test -PinstabugUploadEnable=false
@@ -110,9 +92,11 @@ jobs:
       xcode: 13.4.1
     steps:
       - advanced-checkout/shallow-checkout
-      - install_node_modules
-      - install_node_modules:
-          working_directory: example
+      - node/install-packages:
+          pkg-manager: yarn
+      - node/install-packages:
+          pkg-manager: yarn
+          app-dir: example
       - install_pods:
           working_directory: example/ios
       - run: git --no-pager diff
@@ -126,7 +110,8 @@ jobs:
       INSTABUG_SOURCEMAPS_UPLOAD_DISABLE: true
     steps:
       - advanced-checkout/shallow-checkout
-      - install_node_modules
+      - node/install-packages:
+          pkg-manager: yarn
       - install_pods:
           working_directory: ios
       - run:
@@ -160,17 +145,23 @@ jobs:
       INSTABUG_SOURCEMAPS_UPLOAD_DISABLE: true
     steps:
       - advanced-checkout/shallow-checkout
+      - node/install-packages:
+          pkg-manager: yarn
+      - node/install-packages:
+          pkg-manager: yarn
+          app-dir: example
+      - install_pods:
+          working_directory: example/ios
       - run:
           name: Install Detox CLI
           command: npm install -g detox-cli
       - run:
           name: Install Detox Utils
           command: brew tap wix/brew && brew install applesimutils
-      - install_node_modules
-      - install_node_modules:
+      - run:
+          name: Rebuild Detox.framework Cache
           working_directory: example
-      - install_pods:
-          working_directory: example/ios
+          command: detox clean-framework-cache && detox build-framework-cache
       - run:
           name: Detox - Build Release App
           working_directory: example
@@ -187,15 +178,15 @@ jobs:
       resource-class: large
     steps:
       - advanced-checkout/shallow-checkout
-      - run:
-          name: Install Yarn
-          command: npm install -g yarn
+      - node/install-yarn
+      - node/install-packages:
+          pkg-manager: yarn
+      - node/install-packages:
+          pkg-manager: yarn
+          app-dir: example
       - run:
           name: Install Detox CLI
           command: npm install -g detox-cli
-      - install_node_modules
-      - install_node_modules:
-          working_directory: example
       - android/create-avd:
           avd-name: Nexus_6P_API_27
           install: true
@@ -220,10 +211,21 @@ jobs:
     steps:
       - advanced-checkout/shallow-checkout
       - run: git clone git@github.com:Instabug/Escape.git
-      - run: cd Escape && swift build -c release
-      - run: cd Escape/.build/release && cp -f Escape /usr/local/bin/escape
-      - run: cd project && yarn && yarn build
-      - run: cd project && Escape react-native publish
+      - run:
+          working_directory: Escape
+          command: swift build -c release
+      - run:
+          working_directory: Escape/.build/release
+          command: cp -f Escape /usr/local/bin/escape
+      - node/install-packages:
+          pkg-manager: yarn
+          app-dir: project
+      - run:
+          working_directory: project
+          command: yarn build
+      - run:
+          working_directory: project
+          command: Escape react-native publish
 
 workflows:
   publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,26 @@ orbs:
   advanced-checkout: vsco/advanced-checkout@1.0.0
 
 commands:
+  install_node_modules:
+    parameters:
+      working_directory:
+        type: string
+        default: .
+    steps:
+      - restore_cache:
+          name: Restore Yarn Cache
+          keys:
+            - v0.2-node-modules-{{ checksum "<< parameters.working_directory >>/yarn.lock" }}
+      - run:
+          name: Install Node Modules
+          working_directory: << parameters.working_directory >>
+          command: yarn install --frozen-lockfile --cache-folder /tmp/.cache/yarn
+      - save_cache:
+          name: Save Yarn Cache
+          key: v0.2-node-modules-{{ checksum "<< parameters.working_directory >>/yarn.lock" }}
+          paths:
+            - /tmp/.cache/yarn
+
   install_pods:
     parameters:
       working_directory:
@@ -37,9 +57,7 @@ jobs:
       - image: cimg/node:16.17.1
     steps:
       - advanced-checkout/shallow-checkout
-      - run:
-          name: Install Node Packages
-          command: yarn
+      - install_node_modules
       - run:
           name: Check Format
           command: yarn format
@@ -52,9 +70,7 @@ jobs:
       - image: cimg/node:16.17.1
     steps:
       - advanced-checkout/shallow-checkout
-      - run:
-          name: Install Node Packages
-          command: yarn
+      - install_node_modules
       - run:
           name: Run Tests
           command: yarn test
@@ -63,17 +79,15 @@ jobs:
     executor:
       name: android/android-machine
       tag: '2022.03.1'
+    working_directory: ~/project/example
     steps:
       - advanced-checkout/shallow-checkout
       - run:
           name: Install Yarn
           command: npm install -g yarn
-      - run:
-          name: Install Node Packages
-          working_directory: example
-          command: yarn
+      - install_node_modules
       - android/run-tests:
-          working-directory: ./example/android
+          working-directory: android
           test-command: ./gradlew test -PinstabugUploadEnable=false
 
   validate_shell_files:
@@ -96,8 +110,9 @@ jobs:
       xcode: 13.4.1
     steps:
       - advanced-checkout/shallow-checkout
-      - run: yarn
-      - run: cd example && yarn
+      - install_node_modules
+      - install_node_modules:
+          working_directory: example
       - install_pods:
           working_directory: example/ios
       - run: git --no-pager diff
@@ -111,9 +126,7 @@ jobs:
       INSTABUG_SOURCEMAPS_UPLOAD_DISABLE: true
     steps:
       - advanced-checkout/shallow-checkout
-      - run:
-          name: Install node_modules
-          command: yarn
+      - install_node_modules
       - install_pods:
           working_directory: ios
       - run:
@@ -153,13 +166,9 @@ jobs:
       - run:
           name: Install Detox Utils
           command: brew tap wix/brew && brew install applesimutils
-      - run:
-          name: Install Node Packages
-          command: yarn
-      - run:
-          name: Install Example's Node Packages
+      - install_node_modules
+      - install_node_modules:
           working_directory: example
-          command: yarn
       - install_pods:
           working_directory: example/ios
       - run:
@@ -184,13 +193,9 @@ jobs:
       - run:
           name: Install Detox CLI
           command: npm install -g detox-cli
-      - run:
-          name: Install Node Packages
-          command: yarn
-      - run:
-          name: Install Example's Node Packages
+      - install_node_modules
+      - install_node_modules:
           working_directory: example
-          command: yarn
       - android/create-avd:
           avd-name: Nexus_6P_API_27
           install: true


### PR DESCRIPTION
## Description of the change

By using the `node` orb, we benefit from the following:
  1. Default machine executors.
  2. Caching `node_modules`.

| Before | After |
|:---:|:---:|
| ![before](https://user-images.githubusercontent.com/99807625/225598663-473c2d96-c680-4207-9fe5-235394dbdbd4.png) | ![after](https://user-images.githubusercontent.com/99807625/225603066-94ab0eb0-62be-41ea-b904-936ce9811795.png) |


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
