### PR TITLE
[MOB-12204] Upgrade macOS Resource Class to Gen2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,7 @@ jobs:
   e2e_ios:
     macos:
       xcode: 13.4.1
-    resource_class: large
+    resource_class: macos.x86.medium.gen2
     environment:
       INSTABUG_SOURCEMAPS_UPLOAD_DISABLE: true
     steps:


### PR DESCRIPTION
## Description of the change

Migrate `e2e_ios` job's deprecated macOS large resource class machine to the new `macos.x86.medium.gen2`.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
