### PR TITLE
[MOB-12219] Bump `advanced-checkout` orb to `v1.1.0`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   android: circleci/android@2.0
-  advanced-checkout: vsco/advanced-checkout@1.0.0
+  advanced-checkout: vsco/advanced-checkout@1.1.0
   node: circleci/node@5.1.0
 
 commands:
@@ -61,7 +61,7 @@ jobs:
   test_android:
     executor:
       name: android/android-machine
-      tag: '2022.03.1'
+      tag: "2022.03.1"
     working_directory: ~/project/examples/default
     steps:
       - advanced-checkout/shallow-checkout
@@ -207,7 +207,7 @@ jobs:
   publish:
     macos:
       xcode: 13.4.1
-    working_directory: '~'
+    working_directory: "~"
     steps:
       - advanced-checkout/shallow-checkout
       - run: git clone git@github.com:Instabug/Escape.git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
   test_android:
     executor:
       name: android/android-machine
-      tag: "2022.03.1"
+      tag: '2022.03.1'
     working_directory: ~/project/examples/default
     steps:
       - advanced-checkout/shallow-checkout
@@ -207,7 +207,7 @@ jobs:
   publish:
     macos:
       xcode: 13.4.1
-    working_directory: "~"
+    working_directory: '~'
     steps:
       - advanced-checkout/shallow-checkout
       - run: git clone git@github.com:Instabug/Escape.git


### PR DESCRIPTION
## Description of the change

- Fixes the issue addressed [here](https://github.blog/2023-03-23-we-updated-our-rsa-ssh-host-key/).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request
