### PR TITLE
[MOB-11085] Integrate Danger Coverage Plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,17 @@ orbs:
   node: circleci/node@5.1.0
 
 commands:
+  install_node_modules:
+    parameters:
+      app-dir:
+        type: string
+        default: .
+    steps:
+      - node/install-packages:
+          pkg-manager: yarn
+          # Network concurrency is set to 1 for installation from GitHub to work.
+          override-ci-command: yarn install --frozen-lockfile --network-concurrency 1
+          app-dir: << parameters.app-dir >>
   install_pods:
     parameters:
       working_directory:
@@ -30,8 +41,7 @@ jobs:
       name: node/default
     steps:
       - advanced-checkout/shallow-checkout
-      - node/install-packages:
-          pkg-manager: yarn
+      - install_node_modules
       - attach_workspace:
           at: coverage
       - run:
@@ -43,8 +53,7 @@ jobs:
       name: node/default
     steps:
       - advanced-checkout/shallow-checkout
-      - node/install-packages:
-          pkg-manager: yarn
+      - install_node_modules
       - run:
           name: Check Format
           command: yarn format
@@ -57,8 +66,7 @@ jobs:
       name: node/default
     steps:
       - advanced-checkout/shallow-checkout
-      - node/install-packages:
-          pkg-manager: yarn
+      - install_node_modules
       - run:
           name: Run Tests
           command: yarn test
@@ -75,8 +83,7 @@ jobs:
     steps:
       - advanced-checkout/shallow-checkout
       - node/install-yarn
-      - node/install-packages:
-          pkg-manager: yarn
+      - install_node_modules
       - android/run-tests:
           working-directory: android
           test-command: ./gradlew test -PinstabugUploadEnable=false
@@ -105,8 +112,7 @@ jobs:
       xcode: 13.4.1
     steps:
       - advanced-checkout/shallow-checkout
-      - node/install-packages:
-          pkg-manager: yarn
+      - install_node_modules
       - node/install-packages:
           pkg-manager: yarn
           app-dir: examples/default
@@ -123,8 +129,7 @@ jobs:
       INSTABUG_SOURCEMAPS_UPLOAD_DISABLE: true
     steps:
       - advanced-checkout/shallow-checkout
-      - node/install-packages:
-          pkg-manager: yarn
+      - install_node_modules
       - install_pods:
           working_directory: ios
       - run:
@@ -155,8 +160,7 @@ jobs:
       INSTABUG_SOURCEMAPS_UPLOAD_DISABLE: true
     steps:
       - advanced-checkout/shallow-checkout
-      - node/install-packages:
-          pkg-manager: yarn
+      - install_node_modules
       - node/install-packages:
           pkg-manager: yarn
           app-dir: examples/default
@@ -189,8 +193,7 @@ jobs:
     steps:
       - advanced-checkout/shallow-checkout
       - node/install-yarn
-      - node/install-packages:
-          pkg-manager: yarn
+      - install_node_modules
       - node/install-packages:
           pkg-manager: yarn
           app-dir: examples/default
@@ -227,8 +230,7 @@ jobs:
       - run:
           working_directory: Escape/.build/release
           command: cp -f Escape /usr/local/bin/escape
-      - node/install-packages:
-          pkg-manager: yarn
+      - install_node_modules:
           app-dir: project
       - run:
           working_directory: project

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,8 @@ jobs:
       - advanced-checkout/shallow-checkout
       - node/install-packages:
           pkg-manager: yarn
+      - attach_workspace:
+          at: coverage
       - run:
           name: Run Danger
           command: yarn danger ci
@@ -60,6 +62,10 @@ jobs:
       - run:
           name: Run Tests
           command: yarn test
+      - persist_to_workspace:
+          root: coverage
+          paths:
+            - lcov.info
 
   test_android:
     executor:
@@ -74,6 +80,10 @@ jobs:
       - android/run-tests:
           working-directory: android
           test-command: ./gradlew test -PinstabugUploadEnable=false
+      - persist_to_workspace:
+          root: ~/project/android/build/reports/jacoco/jacocoTestReport
+          paths:
+            - jacocoTestReport.xml
 
   validate_shell_files:
     machine:
@@ -131,14 +141,11 @@ jobs:
       - run:
           name: Convert xcresult into JSON report
           working_directory: ios/coverage
-          command: xcrun xccov view --report --json result.xcresult > report.json
-      - run:
-          name: Clone xccov2lcov
-          command: git clone git@github.com:trax-retail/xccov2lcov.git
-      - run:
-          name: Convert xccov into lcov report
-          working_directory: xccov2lcov
-          command: swift run xccov2lcov ../ios/coverage/report.json > ../ios/coverage/coverage.txt
+          command: xcrun xccov view --report --json result.xcresult > xcode.json
+      - persist_to_workspace:
+          root: ios/coverage
+          paths:
+            - xcode.json
 
   e2e_ios:
     macos:
@@ -233,7 +240,11 @@ jobs:
 workflows:
   publish:
     jobs:
-      - danger
+      - danger:
+          requires:
+            - test_module
+            - test_android
+            - test_ios
       - lint
       - test_module
       - test_android

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -1,3 +1,4 @@
+import collectCoverage, { ReportType } from '@instabug/danger-plugin-coverage';
 import { danger, fail, schedule, warn } from 'danger';
 
 const hasSourceChanges = danger.git.modified_files.some((file) => file.startsWith('src/'));
@@ -20,3 +21,21 @@ async function hasDescription() {
 }
 
 schedule(hasDescription());
+
+collectCoverage([
+  {
+    label: 'JavaScript',
+    type: ReportType.LCOV,
+    filePath: 'coverage/lcov.info',
+  },
+  {
+    label: 'Android',
+    type: ReportType.JACOCO,
+    filePath: 'coverage/jacocoTestReport.xml',
+  },
+  {
+    label: 'iOS',
+    type: ReportType.XCODE,
+    filePath: 'coverage/xcode.json',
+  },
+]);

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -27,15 +27,18 @@ collectCoverage([
     label: 'JavaScript',
     type: ReportType.LCOV,
     filePath: 'coverage/lcov.info',
+    threshold: 90,
   },
   {
     label: 'Android',
     type: ReportType.JACOCO,
     filePath: 'coverage/jacocoTestReport.xml',
+    threshold: 40,
   },
   {
     label: 'iOS',
     type: ReportType.XCODE,
     filePath: 'coverage/xcode.json',
+    threshold: 30,
   },
 ]);

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@apollo/client": "^3.7.0",
+    "@instabug/danger-plugin-coverage": "Instabug/danger-plugin-coverage",
     "@react-native-community/eslint-config": "^3.1.0",
     "@react-navigation/native": "^5.9.8",
     "@rollup/plugin-commonjs": "^24.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1110,6 +1110,12 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
+"@instabug/danger-plugin-coverage@Instabug/danger-plugin-coverage":
+  version "0.0.0-development"
+  resolved "git+ssh://git@github.com/Instabug/danger-plugin-coverage.git#049ba8c9b8df188d729dba437c474ac5b1a0cf00"
+  dependencies:
+    fast-xml-parser "^4.2.0"
+
 "@jest/console@^24.7.1", "@jest/console@^24.9.0":
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.9.0.tgz#79b1bc06fb74a8cfb01cbdedf945584b1b9707f0"
@@ -3826,6 +3832,13 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
+
+fast-xml-parser@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.2.0.tgz#6db2ba33b95b8b4af93f94fe024d4b4d02a50855"
+  integrity sha512-+zVQv4aVTO+o8oRUyRL7PjgeVo1J6oP8Cw2+a8UTZQcj5V0yUK5T63gTN0ldgiHDPghUjKc4OpT6SwMTwnOQug==
+  dependencies:
+    strnum "^1.0.5"
 
 fastq@^1.6.0:
   version "1.13.0"
@@ -7954,6 +7967,11 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+strnum@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.0.5.tgz#5c4e829fe15ad4ff0d20c3db5ac97b73c9b072db"
+  integrity sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==
 
 sudo-prompt@^9.0.0:
   version "9.2.1"


### PR DESCRIPTION
## Description of the change

Integrates the repo with the new Danger code coverage plugin for visibility on code coverage on PRs.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
