### PR TITLE
[MOB-12241] Bump iOS SDK to `v11.10.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - Bump Instabug Android SDK to v11.11.0 ([#963](https://github.com/Instabug/Instabug-React-Native/pull/963)). [See release notes](https://github.com/Instabug/Instabug-Android/releases/tag/v11.11.0).
+- Bump Instabug iOS SDK to v11.10.1 ([#964](https://github.com/Instabug/Instabug-Flutter/pull/964)). [See release notes](https://github.com/Instabug/Instabug-iOS/releases/tag/11.10.1).
 - Return a `Promise` from the below APIs ([#948](https://github.com/Instabug/Instabug-React-Native/pull/948)):
 
   - `Instabug.getTags`

--- a/examples/default/ios/Podfile.lock
+++ b/examples/default/ios/Podfile.lock
@@ -72,7 +72,7 @@ PODS:
     - FlipperKit/FlipperKitNetworkPlugin
   - fmt (6.2.1)
   - glog (0.3.5)
-  - Instabug (11.9.0)
+  - Instabug (11.10.1)
   - libevent (2.1.12)
   - OCMock (3.9.1)
   - OpenSSL-Universal (1.1.180)
@@ -342,7 +342,7 @@ PODS:
     - React-logger (= 0.66.0)
     - React-perflogger (= 0.66.0)
   - RNInstabug (11.9.1):
-    - Instabug (= 11.9.0)
+    - Instabug (= 11.10.1)
     - React-Core
   - RNScreens (3.20.0):
     - React-Core
@@ -524,7 +524,7 @@ SPEC CHECKSUMS:
   FlipperKit: d8d346844eca5d9120c17d441a2f38596e8ed2b9
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 5337263514dd6f09803962437687240c5dc39aa4
-  Instabug: 1d21096fdadbc1f26cd2fc2322ff8e060a611237
+  Instabug: 8b0fcb6dd1bb91ae30a80176431d3e7f57ec3c4f
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OCMock: 9491e4bec59e0b267d52a9184ff5605995e74be8
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
@@ -553,7 +553,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: 53b92d54b923283638cb0186da7a5c2d2b70a49b
   React-runtimeexecutor: 4bb657a97aa74568d9ed634c8bd478299bb8a3a6
   ReactCommon: eb059748e842a1a86025ebbd4ac9d99e74492f88
-  RNInstabug: c24a8e0b0c4d411e0e8b088028ea1b2dd8fac823
+  RNInstabug: 8848bc44e7c160a816fe6b8b421d46115d0f645b
   RNScreens: 218801c16a2782546d30bd2026bb625c0302d70f
   RNSVG: 551acb6562324b1d52a4e0758f7ca0ec234e278f
   RNVectorIcons: fcc2f6cb32f5735b586e66d14103a74ce6ad61f8

--- a/ios/native.rb
+++ b/ios/native.rb
@@ -1,4 +1,4 @@
-$instabug = { :version => '11.9.0' }
+$instabug = { :version => '11.10.1' }
 
 def use_instabug! (spec = nil)
   version = $instabug[:version]


### PR DESCRIPTION
## Description of the change

- Bump iOS SDK to v11.10.1

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request
