### PR TITLE
[MOB-12247] Fix Sourcemaps Script with Old Gradle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased](https://github.com/Instabug/Instabug-React-Native/compare/v11.10.0...dev)
+
+### Fixed
+
+- Fix the Android sourcemaps upload script in older versions of Gradle ([#970](https://github.com/Instabug/Instabug-React-Native/pull/970)), closes [#969](https://github.com/Instabug/Instabug-React-Native/issues/969).
+
 ## [11.10.0](https://github.com/Instabug/Instabug-React-Native/compare/v11.9.1...11.10.0) (April 20, 2023)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fix the Android sourcemaps upload script in older versions of Gradle ([#970](https://github.com/Instabug/Instabug-React-Native/pull/970)), closes [#969](https://github.com/Instabug/Instabug-React-Native/issues/969).
+- Fix an issue with the Android sourcemaps upload script, causing the build to fail on older versions of Gradle ([#970](https://github.com/Instabug/Instabug-React-Native/pull/970)), closes [#969](https://github.com/Instabug/Instabug-React-Native/issues/969).
 
 ## [11.10.0](https://github.com/Instabug/Instabug-React-Native/compare/v11.9.1...11.10.0) (April 20, 2023)
 

--- a/android/sourcemaps.gradle
+++ b/android/sourcemaps.gradle
@@ -5,7 +5,7 @@ def appProject = project(":app")
 gradle.projectsEvaluated {
     // Works for both `bundleReleaseJsAndAssets` and `createBundleReleaseJsAndAssets`
     def bundleTask = appProject.tasks.find {
-        task -> task.name.endsWithIgnoreCase('bundleReleaseJsAndAssets')
+        task -> task.name.toLowerCase().endsWith('bundlereleasejsandassets')
     }
 
     bundleTask.finalizedBy uploadSourcemaps


### PR DESCRIPTION
## Description of the change

### Problem

The current sourcemaps upload script uses a Groovy method called endsWithIgnoreCase which is supported in Groovy 3 used by Gradle 7, while older versions of Gradle use older versions of Groovy (e.g. Gradle 6.9 uses Groovy 2.5.12) which don’t include this method. Hence, the build fails with the error:

```
FAILURE: Build failed with an exception.

* Where:
Script '[redacted]/node_modules/instabug-reactnative/android/sourcemaps.gradle' line: 8

* What went wrong:
No signature of method: java.lang.String.endsWithIgnoreCase() is applicable for argument types: (String) values: [bundleReleaseJsAndAssets]
```

### Solution

We can replace the usage of endsWithIgnoreCase with another well-supported approach like .toLowerCase().endsWith (tested with React Native 0.66.1, Gradle 6.9, Groovy 2.5.12).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes #969

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
