### PR TITLE
[MOB-12305] Fix Sourcemaps Upload Script with Android Product Flavors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fix an issue with the Android sourcemaps upload script, causing the build to fail on older versions of Gradle ([#970](https://github.com/Instabug/Instabug-React-Native/pull/970)), closes [#969](https://github.com/Instabug/Instabug-React-Native/issues/969).
+- Fix an issue with the Android sourcemaps upload script, causing the build to fail when using product flavors ([#975](https://github.com/Instabug/Instabug-React-Native/pull/975)), closes [#974](https://github.com/Instabug/Instabug-React-Native/issues/974).
 
 ## [11.10.0](https://github.com/Instabug/Instabug-React-Native/compare/v11.9.1...11.10.0) (April 20, 2023)
 

--- a/android/sourcemaps.gradle
+++ b/android/sourcemaps.gradle
@@ -5,10 +5,7 @@ def appProject = project(":app")
 gradle.projectsEvaluated {
     // Works for both `bundleReleaseJsAndAssets` and `createBundleReleaseJsAndAssets` and product flavors
     def bundleTask = appProject.tasks.find {
-        def task = it.name
-        def hasPrefix = task.startsWith('bundle') || task.startsWith('createBundle')
-        def hasSuffix = task.endsWith('ReleaseJsAndAssets')
-        return hasPrefix && hasSuffix
+        task -> task.name.endsWith('ReleaseJsAndAssets')
     }
 
     bundleTask.finalizedBy uploadSourcemaps

--- a/android/sourcemaps.gradle
+++ b/android/sourcemaps.gradle
@@ -3,9 +3,12 @@ import org.apache.tools.ant.taskdefs.condition.Os
 def appProject = project(":app")
 
 gradle.projectsEvaluated {
-    // Works for both `bundleReleaseJsAndAssets` and `createBundleReleaseJsAndAssets`
+    // Works for both `bundleReleaseJsAndAssets` and `createBundleReleaseJsAndAssets` and product flavors
     def bundleTask = appProject.tasks.find {
-        task -> task.name.toLowerCase().endsWith('bundlereleasejsandassets')
+        def task = it.name
+        def hasPrefix = task.startsWith('bundle') || task.startsWith('createBundle')
+        def hasSuffix = task.endsWith('ReleaseJsAndAssets')
+        return hasPrefix && hasSuffix
     }
 
     bundleTask.finalizedBy uploadSourcemaps


### PR DESCRIPTION
## Description of the change

### Problem

The new Android sourcemaps upload script can’t detect the `[create]Bundle[Flavor]ReleaseJsAndAssets` when the user is using the Android product flavors feature.

### Solution

Check for a suffix of `ReleaseJsAndAssets` instead of looking for a suffix of `bundleReleaseJsAndAssets` (ignoring the casing.)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes #974 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request
