### PR TITLE
Update sourcemaps.gradle to fix #976

### DIFF
--- a/android/sourcemaps.gradle
+++ b/android/sourcemaps.gradle
@@ -42,7 +42,7 @@ task uploadSourcemaps() {
             exec {
                 def osCompatibility = Os.isFamily(Os.FAMILY_WINDOWS) ? ['cmd', '/c'] : []
                 def args = [
-                        'npx', 'instabug', 'upload-sourcemaps',
+                        'node', instabugDir.absolutePath + '/bin/index.js', 'upload-sourcemaps',
                         '--platform', 'android',
                         '--file', sourceMapFile.absolutePath,
                         '--token', appToken,


### PR DESCRIPTION
## Description of the change

Use full path to bin file instead of npx 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

https://github.com/Instabug/Instabug-React-Native/issues/976

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
