### PR TITLE
[MOB-12305] Fix Sourcemaps Upload Script with Android Product Flavors

### DIFF
--- a/android/sourcemaps.gradle
+++ b/android/sourcemaps.gradle
@@ -12,14 +12,14 @@ gradle.projectsEvaluated {
         def prefixes = ['bundle', 'createBundle']
         def start = name.startsWith(prefixes[0]) ? prefixes[0].length() : prefixes[1].length()
         def end = name.length() - suffix.length()
-        def variant = name.substring(start, end).uncapitalize()
+        def flavor = name.substring(start, end).uncapitalize()
 
-        task.finalizedBy createUploadSourcemapsTask(variant)
+        task.finalizedBy createUploadSourcemapsTask(flavor)
     }
 }
 
-Task createUploadSourcemapsTask(String variant) {
-    def name = 'uploadSourcemaps' + variant.capitalize()
+Task createUploadSourcemapsTask(String flavor) {
+    def name = 'uploadSourcemaps' + flavor.capitalize()
     def provider = tasks.register(name) {
         group 'instabug'
         description 'Uploads sourcemaps file to Instabug server'
@@ -29,8 +29,8 @@ Task createUploadSourcemapsTask(String variant) {
             try {
                 def appProject = project(':app')
                 def appDir = appProject.projectDir
-                def variantPath = variant + variant.empty ? '' : '/'
-                def sourceMapDest = "build/generated/sourcemaps/react/${variantPath}release/index.android.bundle.map"
+                def flavorPath = flavor + flavor.empty ? '' : '/'
+                def sourceMapDest = "build/generated/sourcemaps/react/${flavorPath}release/index.android.bundle.map"
                 def sourceMapFile = new File(appDir, sourceMapDest)
 
                 if (!sourceMapFile.exists()) {

--- a/android/sourcemaps.gradle
+++ b/android/sourcemaps.gradle
@@ -29,7 +29,7 @@ Task createUploadSourcemapsTask(String flavor) {
             try {
                 def appProject = project(':app')
                 def appDir = appProject.projectDir
-                def flavorPath = flavor + flavor.empty ? '' : '/'
+                def flavorPath = flavor + (flavor.empty ? '' : '/')
                 def sourceMapDest = "build/generated/sourcemaps/react/${flavorPath}release/index.android.bundle.map"
                 def sourceMapFile = new File(appDir, sourceMapDest)
 

--- a/android/sourcemaps.gradle
+++ b/android/sourcemaps.gradle
@@ -4,11 +4,13 @@ def appProject = project(":app")
 
 gradle.projectsEvaluated {
     // Works for both `bundleReleaseJsAndAssets` and `createBundleReleaseJsAndAssets` and product flavors
-    def bundleTask = appProject.tasks.find {
+    def bundleTasks = appProject.tasks.findAll {
         task -> task.name.endsWith('ReleaseJsAndAssets')
     }
 
-    bundleTask.finalizedBy uploadSourcemaps
+    bundleTasks.forEach { task ->
+        task.finalizedBy uploadSourcemaps
+    }
 }
 
 task uploadSourcemaps() {

--- a/android/sourcemaps.gradle
+++ b/android/sourcemaps.gradle
@@ -1,68 +1,80 @@
 import org.apache.tools.ant.taskdefs.condition.Os
 
-def appProject = project(":app")
-
 gradle.projectsEvaluated {
     // Works for both `bundleReleaseJsAndAssets` and `createBundleReleaseJsAndAssets` and product flavors
-    def bundleTasks = appProject.tasks.findAll {
-        task -> task.name.endsWith('ReleaseJsAndAssets')
+    def suffix = 'ReleaseJsAndAssets'
+    def bundleTasks = project(':app').tasks.findAll {
+        task -> task.name.endsWith(suffix)
     }
 
     bundleTasks.forEach { task ->
-        task.finalizedBy uploadSourcemaps
+        def name = task.name
+        def prefixes = ['bundle', 'createBundle']
+        def start = name.startsWith(prefixes[0]) ? prefixes[0].length() : prefixes[1].length()
+        def end = name.length() - suffix.length()
+        def variant = name.substring(start, end).uncapitalize()
+
+        task.finalizedBy createUploadSourcemapsTask(variant)
     }
 }
 
-task uploadSourcemaps() {
-    group 'instabug'
-    description 'Uploads sourcemaps file to Instabug server'
-    enabled = isUploadSourcemapsEnabled()
+Task createUploadSourcemapsTask(String variant) {
+    def name = 'uploadSourcemaps' + variant.capitalize()
+    def provider = tasks.register(name) {
+        group 'instabug'
+        description 'Uploads sourcemaps file to Instabug server'
+        enabled = isUploadSourcemapsEnabled()
 
-    doLast {
-        try {
-            def appDir = appProject.projectDir
-            def sourceMapDest = 'build/generated/sourcemaps/react/release/index.android.bundle.map'
-            def sourceMapFile = new File(appDir, sourceMapDest)
+        doLast {
+            try {
+                def appProject = project(':app')
+                def appDir = appProject.projectDir
+                def variantPath = variant + variant.empty ? '' : '/'
+                def sourceMapDest = "build/generated/sourcemaps/react/${variantPath}release/index.android.bundle.map"
+                def sourceMapFile = new File(appDir, sourceMapDest)
 
-            if (!sourceMapFile.exists()) {
-                throw new InvalidUserDataException("Unable to find source map file at: ${sourceMapFile.absolutePath}")
+                if (!sourceMapFile.exists()) {
+                    throw new InvalidUserDataException("Unable to find source map file at: ${sourceMapFile.absolutePath}")
+                }
+
+                def jsProjectDir = rootDir.parentFile
+                def instabugDir = new File(['node', '-p', 'require.resolve("instabug-reactnative/package.json")'].execute(null, rootDir).text.trim()).getParentFile()
+
+                def tokenShellFile = new File(instabugDir, 'scripts/find-token.sh')
+                def inferredToken = executeShellScript(tokenShellFile, jsProjectDir)
+                def appToken = resolveVar('App Token', 'INSTABUG_APP_TOKEN', inferredToken)
+
+                def projectConfig = appProject.android.defaultConfig
+                def versionName = resolveVar('Version Name', 'INSTABUG_VERSION_NAME', "${projectConfig.versionName}")
+                def versionCode = resolveVar('Version Code', 'INSTABUG_VERSION_CODE', "${projectConfig.versionCode}")
+
+                exec {
+                    def osCompatibility = Os.isFamily(Os.FAMILY_WINDOWS) ? ['cmd', '/c'] : []
+                    def args = [
+                            'npx', 'instabug', 'upload-sourcemaps',
+                            '--platform', 'android',
+                            '--file', sourceMapFile.absolutePath,
+                            '--token', appToken,
+                            '--name', versionName,
+                            '--code', versionCode
+                    ]
+
+                    commandLine(*osCompatibility, *args)
+                }
+            } catch (exception) {
+                project.logger.error "Failed to upload source map file.\n" +
+                        "Reason: ${exception.message}"
             }
-
-            def jsProjectDir = rootDir.parentFile
-            def instabugDir = new File(['node', '-p', 'require.resolve("instabug-reactnative/package.json")'].execute(null, rootDir).text.trim()).getParentFile()
-
-            def tokenShellFile = new File(instabugDir, 'scripts/find-token.sh')
-            def inferredToken = executeShellScript(tokenShellFile, jsProjectDir)
-            def appToken = resolveVar('App Token', 'INSTABUG_APP_TOKEN', inferredToken)
-
-            def projectConfig = appProject.android.defaultConfig
-            def versionName = resolveVar('Version Name', 'INSTABUG_VERSION_NAME', "${projectConfig.versionName}")
-            def versionCode = resolveVar('Version Code', 'INSTABUG_VERSION_CODE', "${projectConfig.versionCode}")
-
-            exec {
-                def osCompatibility = Os.isFamily(Os.FAMILY_WINDOWS) ? ['cmd', '/c'] : []
-                def args = [
-                        'npx', 'instabug', 'upload-sourcemaps',
-                        '--platform', 'android',
-                        '--file', sourceMapFile.absolutePath,
-                        '--token', appToken,
-                        '--name', versionName,
-                        '--code', versionCode
-                ]
-
-                commandLine(*osCompatibility, *args)
-            }
-        } catch (exception) {
-            project.logger.error "Failed to upload source map file.\n" +
-                    "Reason: ${exception.message}"
         }
     }
+
+    return provider.get()
 }
 
 boolean isUploadSourcemapsEnabled() {
     def envValue = System.getenv('INSTABUG_SOURCEMAPS_UPLOAD_DISABLE')?.toBoolean()
     def defaultValue = true
-       
+
     if (rootProject.hasProperty('instabugUploadEnable')) {
         project.logger.warn "The property instabugUploadEnable is deprecated and will be removed in an upcoming version. \n" +
         "You can use INSTABUG_SOURCEMAPS_UPLOAD_DISABLE environment variable instead."


### PR DESCRIPTION
## Description of the change

### Problem

There is a problem with the new Android sourcemaps upload script (see #974) which we tried to fix in #975 but [the fix wasn't complete](https://github.com/Instabug/Instabug-React-Native/issues/974#issuecomment-1538382655). This PR aims at fixing all remaining issues related to this problem.

The current problems are:
1. The `uploadSourcemaps` task is attached to only one of the `[create]Bundle[Flavor]ReleaseJsAndAssets` where there are multiple ones when using product flavors (e.g. `bundleDemoReleaseJsAndAssets` and `bundleFullReleaseJsAndAssets`, both happen on release but for different flavors).
2. The sourcemaps path is different for different flavors. When using product flavors, sourcemaps are located at `build/generated/sourcemaps/react/flavor/release/index.android.bundle.map`, and at `build/generated/sourcemaps/react/release/index.android.bundle.map` without flavors.

### Solution

This PR includes solutions for the two problems mentioned above.

1. We can use `findAll` instead of `find` to find all the tasks that end with `ReleaseJsAndAssets` and attach the `uploadSourcemaps` task to all of them.
2. We need to pass the flavor to `uploadSourcemaps` so I changed the creation of the task to use `tasks.register` inside a function that generates a task for each flavor. New tasks are named `uploadSourcemaps[Flavor]` (e.g. `uploadSourcemaps`, `uploadSourcemapsDemo`), then the task looks for the correct sourcemaps path with the given flavor.

### Testing

I tested this change with and without product flavors as described below.

#### Without Product Flavors

After updating the `sourcemaps.gradle` script, I ran `./gradlew assembleRelease` inside `examples/default/android` and searched for `uploadSourcemaps` to see that the task has completed successfully and outputted
```
Successfully uploaded Source maps for version: 1.0 (1)
{ status: 'ok' }
```

#### With Product Flavors

I added two flavors to the example app by adding the below snippet to `examples/default/android/app/build.gradle` after `buildTypes`

```groovy
    buildTypes {
       // ...
    }

    // Add the below code
    flavorDimensions "version"
    productFlavors {
        demo {
            dimension "version"
            applicationIdSuffix ".demo"
            versionNameSuffix "-demo"
        }
        full {
            dimension "version"
            applicationIdSuffix ".full"
            versionNameSuffix "-full"
        }
    }
```

Then I ran `./gradlew assembleDemoRelease` and `./gradlew assembleFullRelease` and checked the output as I did without flavors.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes #974 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request
