### PR TITLE
[INSD-9579] Fix Unhandled JavaScript Crashes on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fix an issue with unhandled JavaScript crashes being reported as native Android crashes ([#980](https://github.com/Instabug/Instabug-React-Native/pull/980)).
 - Fix an issue with the Android sourcemaps upload script, causing the build to fail on older versions of Gradle ([#970](https://github.com/Instabug/Instabug-React-Native/pull/970)), closes [#969](https://github.com/Instabug/Instabug-React-Native/issues/969).
 - Fix an issue with the Android sourcemaps upload script, causing the build to fail when using product flavors ([#975](https://github.com/Instabug/Instabug-React-Native/pull/975)), closes [#974](https://github.com/Instabug/Instabug-React-Native/issues/974).
 

--- a/src/utils/InstabugUtils.ts
+++ b/src/utils/InstabugUtils.ts
@@ -88,10 +88,19 @@ export const captureJsErrors = () => {
   };
 
   ErrorUtils.setGlobalHandler((err, isFatal) => {
-    if (!process.env.JEST_WORKER_ID) {
+    instabugErrorHandler(err, isFatal);
+
+    if (process.env.JEST_WORKER_ID) {
+      return;
+    }
+
+    if (Platform.OS === 'android') {
+      setTimeout(() => {
+        originalErrorHandler(err, isFatal);
+      }, 500);
+    } else {
       originalErrorHandler(err, isFatal);
     }
-    instabugErrorHandler(err, isFatal);
   });
 };
 


### PR DESCRIPTION
## Description of the change

Fix an issue with unhandled JavaScript crashes not being reported correctly on Android when we removed the `setTimeout` around the original global error handler call.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
