### PR TITLE
[MOB-12414] Disable Android Sourcemaps Upload with Env Var

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,13 +80,15 @@ jobs:
       name: android/android-machine
       tag: '2022.03.1'
     working_directory: ~/project/examples/default
+    environment:
+      INSTABUG_SOURCEMAPS_UPLOAD_DISABLE: true
     steps:
       - advanced-checkout/shallow-checkout
       - node/install-yarn
       - install_node_modules
       - android/run-tests:
           working-directory: android
-          test-command: ./gradlew test -PinstabugUploadEnable=false
+          test-command: ./gradlew test
       - persist_to_workspace:
           root: ~/project/android/build/reports/jacoco/jacocoTestReport
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,6 +192,8 @@ jobs:
       name: android/android-machine
       tag: 2022.03.1
       resource-class: large
+    environment:
+      INSTABUG_SOURCEMAPS_UPLOAD_DISABLE: true
     steps:
       - advanced-checkout/shallow-checkout
       - node/install-yarn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/Instabug/Instabug-React-Native/compare/v11.10.0...dev)
 
+### Deprecated
+
+- Deprecate `instabugUploadEnable` gradle property to disable Android sourcemaps auto upload in favor of `INSTABUG_SOURCEMAPS_UPLOAD_DISABLE` env variable ([#983](https://github.com/Instabug/Instabug-React-Native/pull/983)).
+
 ### Fixed
 
 - Fix an issue with unhandled JavaScript crashes being reported as native Android crashes ([#980](https://github.com/Instabug/Instabug-React-Native/pull/980)).

--- a/README.md
+++ b/README.md
@@ -72,13 +72,7 @@ For your app crashes to show up with a fully symbolicated stack trace, we will a
 If your app token is defined as a constant, you can set an environment variable `INSTABUG_APP_TOKEN` to be used instead.
 We also automatically read your `versionName` and `versionCode` to upload your sourcemap file. alternatively, can also set the environment variables `INSTABUG_APP_VERSION_NAME` and `INSTABUG_APP_VERSION_CODE` to be used instead.
 
-To disable the automatic upload in android, you can set the following property your build.gradle:
-
-```dart
-ext {
-    instabugUploadEnable = false;
-}
-```
+To disable the automatic upload, you can set the environment variable `INSTABUG_SOURCEMAPS_UPLOAD_DISABLE` to TRUE.
 
 ## Network Logging
 

--- a/android/sourcemaps.gradle
+++ b/android/sourcemaps.gradle
@@ -14,22 +14,7 @@ gradle.projectsEvaluated {
 task uploadSourcemaps() {
     group 'instabug'
     description 'Uploads sourcemaps file to Instabug server'
-    enabled = {
-        def envValue = System.getenv('INSTABUG_SOURCEMAPS_UPLOAD_DISABLE')?.toBoolean()
-        def defaultValue = true
-       
-        if(rootProject.hasProperty('instabugUploadEnable')){
-            project.logger.warn "The property instabugUploadEnable is deprecated and will be removed in an upcoming version. \n" +
-            "You can use INSTABUG_SOURCEMAPS_UPLOAD_DISABLE environment variable instead."
-            defaultValue = rootProject.property('instabugUploadEnable')
-        }
-        if(envValue != null){
-            return !envValue 
-        }
-        else {
-            return defaultValue
-        }
-    }()
+    enabled = isUploadSourcemapsEnabled()
 
     doLast {
         try {
@@ -70,6 +55,19 @@ task uploadSourcemaps() {
                     "Reason: ${exception.message}"
         }
     }
+}
+
+boolean isUploadSourcemapsEnabled() {
+    def envValue = System.getenv('INSTABUG_SOURCEMAPS_UPLOAD_DISABLE')?.toBoolean()
+    def defaultValue = true
+       
+    if (rootProject.hasProperty('instabugUploadEnable')) {
+        project.logger.warn "The property instabugUploadEnable is deprecated and will be removed in an upcoming version. \n" +
+        "You can use INSTABUG_SOURCEMAPS_UPLOAD_DISABLE environment variable instead."
+        defaultValue = rootProject.property('instabugUploadEnable')
+    }
+
+    return (envValue != null) ? !envValue : defaultValue
 }
 
 String resolveVar(String name, String envKey, String defaultValue) {

--- a/android/sourcemaps.gradle
+++ b/android/sourcemaps.gradle
@@ -14,9 +14,22 @@ gradle.projectsEvaluated {
 task uploadSourcemaps() {
     group 'instabug'
     description 'Uploads sourcemaps file to Instabug server'
-    enabled rootProject.hasProperty('instabugUploadEnable')
-            ? new Boolean(rootProject.property('instabugUploadEnable'))
-            : true
+    enabled = {
+        def envValue = System.getenv('INSTABUG_SOURCEMAPS_UPLOAD_DISABLE')?.toBoolean()
+        def defaultValue = true
+       
+        if(rootProject.hasProperty('instabugUploadEnable')){
+            project.logger.warn "The property instabugUploadEnable is deprecated and will be removed in an upcoming version. \n" +
+            "You can use INSTABUG_SOURCEMAPS_UPLOAD_DISABLE environment variable instead."
+            defaultValue = rootProject.property('instabugUploadEnable')
+        }
+        if(envValue != null){
+            return !envValue 
+        }
+        else {
+            return defaultValue
+        }
+    }()
 
     doLast {
         try {

--- a/examples/default/.detoxrc.json
+++ b/examples/default/.detoxrc.json
@@ -22,7 +22,7 @@
     },
     "android.emu.release": {
       "binaryPath": "android/app/build/outputs/apk/release/app-release.apk",
-      "build": "cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release -PinstabugUploadEnable=false && cd ..",
+      "build": "cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release && cd ..",
       "type": "android.emulator",
       "name": "Nexus_6P_API_27"
     }


### PR DESCRIPTION
## Description of the change

- Deprecate `instabugUploadEnable` gradle property to disable Android Sourcemaps auto upload in favor of `INSTABUG_SOURCEMAPS_UPLOAD_DISABLE` env variable. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request
