### PR TITLE
[MOB-12425] Properly Disable Network Interception with Patched XHR

### DIFF
--- a/src/utils/XhrNetworkInterceptor.ts
+++ b/src/utils/XhrNetworkInterceptor.ts
@@ -24,9 +24,9 @@ export interface NetworkData {
 }
 
 const XMLHttpRequest = global.XMLHttpRequest;
-const originalXHROpen = XMLHttpRequest.prototype.open;
-const originalXHRSend = XMLHttpRequest.prototype.send;
-const originalXHRSetRequestHeader = XMLHttpRequest.prototype.setRequestHeader;
+let originalXHROpen = XMLHttpRequest.prototype.open;
+let originalXHRSend = XMLHttpRequest.prototype.send;
+let originalXHRSetRequestHeader = XMLHttpRequest.prototype.setRequestHeader;
 
 let onProgressCallback: ProgressCallback | null;
 let onDoneCallback: NetworkDataCallback | null;
@@ -63,6 +63,15 @@ export default {
     onProgressCallback = callback;
   },
   enableInterception() {
+    // Prevents infinite calls to XMLHttpRequest.open when enabling interception multiple times
+    if (isInterceptorEnabled) {
+      return;
+    }
+
+    originalXHROpen = XMLHttpRequest.prototype.open;
+    originalXHRSend = XMLHttpRequest.prototype.send;
+    originalXHRSetRequestHeader = XMLHttpRequest.prototype.setRequestHeader;
+
     XMLHttpRequest.prototype.open = function (method, url, ...args) {
       _reset();
       network.url = url;

--- a/test/utils/XhrNetworkInterceptor.spec.ts
+++ b/test/utils/XhrNetworkInterceptor.spec.ts
@@ -29,7 +29,7 @@ describe('Network Interceptor', () => {
     FakeRequest.send();
   });
 
-  it('should call patched XMLHttpRequest methods', () => {
+  it('should keep patched XMLHttpRequest methods', () => {
     Interceptor.disableInterception();
 
     // Patch XMLHttpRequest.open

--- a/test/utils/XhrNetworkInterceptor.spec.ts
+++ b/test/utils/XhrNetworkInterceptor.spec.ts
@@ -29,6 +29,29 @@ describe('Network Interceptor', () => {
     FakeRequest.send();
   });
 
+  it('should call patched XMLHttpRequest methods', () => {
+    Interceptor.disableInterception();
+
+    // Patch XMLHttpRequest.open
+    const originalXHROpen = XMLHttpRequest.prototype.open;
+    const patchedCode = jest.fn();
+    XMLHttpRequest.prototype.open = function (...args: Parameters<XMLHttpRequest['open']>) {
+      patchedCode();
+      originalXHROpen.apply(this, args);
+    };
+
+    // Enable and disable network interception to see if disabling network interception
+    // keeps the patched XMLHttpRequest methods
+    Interceptor.enableInterception();
+    Interceptor.disableInterception();
+
+    FakeRequest.open(method, url);
+
+    expect(patchedCode).toHaveBeenCalledTimes(1);
+
+    XMLHttpRequest.prototype.open = originalXHROpen;
+  });
+
   it('should set network object on calling setRequestHeader', (done) => {
     const requestHeaders = { 'content-type': 'application/json', token: '9u4hiudhi3bf' };
 


### PR DESCRIPTION
## Description of the change

The current implementation of the network interceptor grabs the original `XMLHttpRequest` methods that we alter from the beginning (once you import `instabug-reactnative`) so that when the user wants to disable network interception/logging using `NetworkLogger.setEnabled(false)` it reassigns these methods back to their original version.
The fact that we grab original XHR methods on import means that any changes done by the user after this import will get ignored even after disabling network logging.

This PR modifies the XHR interceptor to get the original `XMLHttpRequest` methods when enabling it and not globally on import. This will enable users to patch XHR when network interception is disabled (which includes before `Instabug.init` and `NetworkLogger.setEnabled(true)` and after `NetworkLogger.setEnabled(false)`).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes #981

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request
