### PR TITLE
[MOB-12434] Bump Android SDK to `v11.12.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/Instabug/Instabug-React-Native/compare/v11.10.0...dev)
 
+### Changed
+
+- Bump Instabug Android SDK to v11.12.0 ([#985](https://github.com/Instabug/Instabug-React-Native/pull/985)). [See release notes](https://github.com/Instabug/Instabug-Android/releases/tag/v11.12.0).
+
 ### Deprecated
 
 - Deprecate `instabugUploadEnable` gradle property to disable Android sourcemaps auto upload in favor of `INSTABUG_SOURCEMAPS_UPLOAD_DISABLE` env variable ([#983](https://github.com/Instabug/Instabug-React-Native/pull/983)).

--- a/android/native.gradle
+++ b/android/native.gradle
@@ -1,5 +1,5 @@
 project.ext.instabug = [
-    version: '11.11.0'
+    version: '11.12.0'
 ]
 
 dependencies {


### PR DESCRIPTION
## Description of the change

- Bump Android SDK to `v11.12.0`

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request
