### PR TITLE
[MOB-12473] Skip Recreating Sourcemaps Gradle Task If It Exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased](https://github.com/Instabug/Instabug-React-Native/compare/v11.12.0...dev)
+
+### Fixed
+
+- Fix an issue with the Android sourcemaps upload Gradle task getting recreated when both `bundleReleaseJsAndAssets` and `createBundleReleaseJsAndAssets` tasks exist in the same Android project ([#991](https://github.com/Instabug/Instabug-React-Native/pull/991)), closes [#989](https://github.com/Instabug/Instabug-React-Native/issues/989).
+
 ## [11.12.0](https://github.com/Instabug/Instabug-React-Native/compare/v11.10.0...11.12.0) (May 30, 2023)
 
 ### Changed

--- a/android/sourcemaps.gradle
+++ b/android/sourcemaps.gradle
@@ -21,9 +21,9 @@ gradle.projectsEvaluated {
 Task createUploadSourcemapsTask(String flavor) {
     def name = 'uploadSourcemaps' + flavor.capitalize()
 
-    // Don't recreate the task if it already exsts.
+    // Don't recreate the task if it already exists.
     // This prevents the build from failing in an edge case where the user has
-    // both `bundleReleaseJsAndAssets` and `createBundleJsAndAssets`
+    // both `bundleReleaseJsAndAssets` and `createBundleReleaseJsAndAssets`
     def taskExists = tasks.getNames().contains(name)
     if (taskExists) {
         return tasks.named(name).get()

--- a/android/sourcemaps.gradle
+++ b/android/sourcemaps.gradle
@@ -20,6 +20,15 @@ gradle.projectsEvaluated {
 
 Task createUploadSourcemapsTask(String flavor) {
     def name = 'uploadSourcemaps' + flavor.capitalize()
+
+    // Don't recreate the task if it already exsts.
+    // This prevents the build from failing in an edge case where the user has
+    // both `bundleReleaseJsAndAssets` and `createBundleJsAndAssets`
+    def taskExists = tasks.getNames().contains(name)
+    if (taskExists) {
+        return tasks.named(name).get()
+    }
+
     def provider = tasks.register(name) {
         group 'instabug'
         description 'Uploads sourcemaps file to Instabug server'


### PR DESCRIPTION
## Description of the change

Fix an issue with the Android sourcemaps upload Gradle task getting recreated when both `bundleReleaseJsAndAssets` and `createBundleReleaseJsAndAssets` tasks exist in the same Android project by defaulting to the existent task when it exists.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes #989 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
