### PR TITLE
[MOB-12511] Replace JaCoCo’s `enabled` with `required`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fix an issue with the Android sourcemaps upload Gradle task getting recreated when both `bundleReleaseJsAndAssets` and `createBundleReleaseJsAndAssets` tasks exist in the same Android project ([#991](https://github.com/Instabug/Instabug-React-Native/pull/991)), closes [#989](https://github.com/Instabug/Instabug-React-Native/issues/989).
+- Fix an issue with JaCoCo gradle plugin replacing the `enabled` method with `required` prop to prevent gradle scripts breaking on version `0.72` ([#995](https://github.com/Instabug/Instabug-React-Native/pull/995)), closes [#994](https://github.com/Instabug/Instabug-React-Native/issues/994).
 
 ## [11.12.0](https://github.com/Instabug/Instabug-React-Native/compare/v11.10.0...11.12.0) (May 30, 2023)
 

--- a/android/jacoco.gradle
+++ b/android/jacoco.gradle
@@ -11,8 +11,8 @@ task jacocoTestReport(type: JacocoReport) {
   dependsOn 'testDebugUnitTest'
 
   reports {
-    html.enabled true
-    xml.enabled true
+    html.required=true
+    xml.required=true
   }
 
   def excludes = [

--- a/android/jacoco.gradle
+++ b/android/jacoco.gradle
@@ -11,8 +11,8 @@ task jacocoTestReport(type: JacocoReport) {
   dependsOn 'testDebugUnitTest'
 
   reports {
-    html.required=true
-    xml.required=true
+    html.required = true
+    xml.required = true
   }
 
   def excludes = [


### PR DESCRIPTION
## Description of the change

Replace the `enabled` method with `required` property in JaCoCo `gradle` plugin as it breaks the gradle scripts running on version `0.72`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues
Fixes #994 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
