### PR TITLE
[MOB-12609] Unify Discard Alert Buttons Strings

### DIFF
--- a/android/src/main/java/com/instabug/reactlibrary/ArgsRegistry.java
+++ b/android/src/main/java/com/instabug/reactlibrary/ArgsRegistry.java
@@ -234,6 +234,9 @@ final class ArgsRegistry {
         put("discardAlertMessage", Key.REPORT_DISCARD_DIALOG_BODY);
         put("discardAlertCancel", Key.REPORT_DISCARD_DIALOG_NEGATIVE_ACTION);
         put("discardAlertAction", Key.REPORT_DISCARD_DIALOG_POSITIVE_ACTION);
+        put("discardAlertStay", Key.REPORT_DISCARD_DIALOG_NEGATIVE_ACTION);
+        put("discardAlertDiscard", Key.REPORT_DISCARD_DIALOG_POSITIVE_ACTION);
+
         put("addAttachmentButtonTitleStringName", Key.REPORT_ADD_ATTACHMENT_HEADER);
 
         put("reportReproStepsDisclaimerBody", Key.REPORT_REPRO_STEPS_DISCLAIMER_BODY);

--- a/ios/RNInstabug/ArgsRegistry.m
+++ b/ios/RNInstabug/ArgsRegistry.m
@@ -244,6 +244,8 @@
         @"discardAlertMessage": kIBGDiscardAlertMessage,
         @"discardAlertCancel": kIBGDiscardAlertCancel,
         @"discardAlertAction": kIBGDiscardAlertAction,
+        @"discardAlertDiscard": kIBGDiscardAlertCancel,
+        @"discardAlertStay": kIBGDiscardAlertAction,
         @"addAttachmentButtonTitleStringName": kIBGAddAttachmentButtonTitleStringName,
 
         @"reportReproStepsDisclaimerBody": kIBGReproStepsDisclaimerBody,

--- a/src/native/NativeConstants.ts
+++ b/src/native/NativeConstants.ts
@@ -144,6 +144,8 @@ interface NativeStringKey {
   conversationTextFieldHint: any;
   discardAlertAction: any;
   discardAlertCancel: any;
+  discardAlertStay: any;
+  discardAlertDiscard: any;
   discardAlertMessage: any;
   discardAlertTitle: any;
   edgeSwipeStartHint: any;

--- a/src/utils/ArgsRegistry.ts
+++ b/src/utils/ArgsRegistry.ts
@@ -254,8 +254,12 @@ export enum strings {
   requestFeatureDescription = constants.requestFeatureDescription,
   discardAlertTitle = constants.discardAlertTitle,
   discardAlertMessage = constants.discardAlertMessage,
+  /** @deprecated Use {@link discardAlertStay} and {@link discardAlertDiscard} instead */
   discardAlertCancel = constants.discardAlertCancel,
+  /** @deprecated Use {@link discardAlertStay} and {@link discardAlertDiscard} instead */
   discardAlertAction = constants.discardAlertAction,
+  discardAlertDiscard = constants.discardAlertDiscard,
+  discardAlertStay = constants.discardAlertStay,
   addAttachmentButtonTitleStringName = constants.addAttachmentButtonTitleStringName,
   reportReproStepsDisclaimerBody = constants.reportReproStepsDisclaimerBody,
   reportReproStepsDisclaimerLink = constants.reportReproStepsDisclaimerLink,

--- a/src/utils/Enums.ts
+++ b/src/utils/Enums.ts
@@ -160,8 +160,12 @@ export enum StringKey {
   commentFieldHintForQuestion = constants.commentFieldHintForQuestion,
   conversationsHeaderTitle = constants.conversationsHeaderTitle,
   conversationTextFieldHint = constants.conversationTextFieldHint,
+  /** @deprecated Use {@link discardAlertStay} and {@link discardAlertDiscard} instead */
   discardAlertAction = constants.discardAlertAction,
+  /** @deprecated Use {@link discardAlertStay} and {@link discardAlertDiscard} instead */
   discardAlertCancel = constants.discardAlertCancel,
+  discardAlertDiscard = constants.discardAlertDiscard,
+  discardAlertStay = constants.discardAlertStay,
   discardAlertMessage = constants.discardAlertMessage,
   discardAlertTitle = constants.discardAlertTitle,
   edgeSwipeStartHint = constants.edgeSwipeStartHint,


### PR DESCRIPTION
## Description of the change

- Deprecate the old `discardAlertCancel` and `discardAlertAction` string keys as they had inconsistent behavior between iOS and Android.
- Introduce unified replacements for the deprecated strings (`discardAlertStay` and `discardAlertDiscard`).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
