### PR TITLE
[MOB-12640] Unify Repro Steps List Item Title String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@
 ### Added
 
 - Add new strings (`StringKey.discardAlertStay` and `StringKey.discardAlertDiscard`) for overriding the discard alert buttons for consistency between iOS and Android ([#1001](https://github.com/Instabug/Instabug-React-Native/pull/1001)).
+- Add a new string (`StringKey.reproStepsListItemNumberingTitle`) for overriding the repro steps list item (screen) title for consistency between iOS and Android ([#1002](https://github.com/Instabug/Instabug-React-Native/pull/1002)).
 
 ### Deprecated
 
 - Deprecate the old `StringKey.discardAlertCancel` and `StringKey.discardAlertAction` string keys for overriding the discard alert buttons as they had incosistent behavior between iOS and Android ([#1001](https://github.com/Instabug/Instabug-React-Native/pull/1001)).
+- Deprecate the old `StringKey.reproStepsListItemNumberingTitle` string key for overriding the repro steps list item (screen) title as it had incosistent behavior between iOS and Android ([#1002](https://github.com/Instabug/Instabug-React-Native/pull/1002)).
 
 ## [11.13.0](https://github.com/Instabug/Instabug-React-Native/compare/v11.12.0...v11.13.0) (July 10, 2023)
 

--- a/android/src/main/java/com/instabug/reactlibrary/ArgsRegistry.java
+++ b/android/src/main/java/com/instabug/reactlibrary/ArgsRegistry.java
@@ -246,6 +246,7 @@ final class ArgsRegistry {
         put("reproStepsListDescription", Key.REPRO_STEPS_LIST_DESCRIPTION);
         put("reproStepsListEmptyStateDescription", Key.REPRO_STEPS_LIST_EMPTY_STATE_DESCRIPTION);
         put("reproStepsListItemTitle", Key.REPRO_STEPS_LIST_ITEM_NUMBERING_TITLE);
+        put("reproStepsListItemNumberingTitle", Key.REPRO_STEPS_LIST_ITEM_NUMBERING_TITLE);
         put("okButtonTitle", Key.BUG_ATTACHMENT_DIALOG_OK_BUTTON);
         put("audio", Key.CHATS_TYPE_AUDIO);
         put("image", Key.CHATS_TYPE_IMAGE);

--- a/android/src/test/java/com/instabug/reactlibrary/RNInstabugReactnativeModuleTest.java
+++ b/android/src/test/java/com/instabug/reactlibrary/RNInstabugReactnativeModuleTest.java
@@ -459,6 +459,7 @@ public class RNInstabugReactnativeModuleTest {
         // Ignore deprecated keys
         keys.remove("discardAlertCancel");
         keys.remove("discardAlertAction");
+        keys.remove("reproStepsListItemTitle");
 
         // when
         InstabugCustomTextPlaceHolder expectedPlaceHolders = new InstabugCustomTextPlaceHolder();

--- a/ios/RNInstabug/ArgsRegistry.m
+++ b/ios/RNInstabug/ArgsRegistry.m
@@ -255,6 +255,7 @@
         @"reproStepsListDescription": kIBGReproStepsListHeader,
         @"reproStepsListEmptyStateDescription": kIBGReproStepsListEmptyStateLabel,
         @"reproStepsListItemTitle": kIBGReproStepsListItemName,
+        @"reproStepsListItemNumberingTitle": kIBGReproStepsListItemName,
         @"conversationTextFieldHint": kIBGChatReplyFieldPlaceholderStringName,
         @"insufficientContentTitle" : kIBGInsufficientContentTitleStringName,
         @"insufficientContentMessage" : kIBGInsufficientContentMessageStringName,

--- a/src/modules/Instabug.ts
+++ b/src/modules/Instabug.ts
@@ -226,6 +226,12 @@ export const getTags = async (callback?: (tags: string[]) => void): Promise<stri
  * @param string String value to override the default one.
  */
 export const setString = (key: strings | StringKey, string: string) => {
+  // Suffix the repro steps list item numbering title with a # to unify the string key's
+  // behavior between Android and iOS
+  if (Platform.OS === 'android' && key === StringKey.reproStepsListItemNumberingTitle) {
+    string = `${string} #`;
+  }
+
   NativeInstabug.setString(string, key);
 };
 

--- a/src/native/NativeConstants.ts
+++ b/src/native/NativeConstants.ts
@@ -176,7 +176,7 @@ interface NativeStringKey {
   reproStepsListEmptyStateDescription: any;
   reproStepsListHeader: any;
   reproStepsListItemTitle: any;
-  reproStepsListItemNumberingTitle: string;
+  reproStepsListItemNumberingTitle: any;
   reproStepsProgressDialogBody: any;
   requestFeatureDescription: any;
   screenRecording: any;

--- a/src/native/NativeConstants.ts
+++ b/src/native/NativeConstants.ts
@@ -176,6 +176,7 @@ interface NativeStringKey {
   reproStepsListEmptyStateDescription: any;
   reproStepsListHeader: any;
   reproStepsListItemTitle: any;
+  reproStepsListItemNumberingTitle: any;
   reproStepsProgressDialogBody: any;
   requestFeatureDescription: any;
   screenRecording: any;

--- a/src/native/NativeConstants.ts
+++ b/src/native/NativeConstants.ts
@@ -176,7 +176,7 @@ interface NativeStringKey {
   reproStepsListEmptyStateDescription: any;
   reproStepsListHeader: any;
   reproStepsListItemTitle: any;
-  reproStepsListItemNumberingTitle: any;
+  reproStepsListItemNumberingTitle: string;
   reproStepsProgressDialogBody: any;
   requestFeatureDescription: any;
   screenRecording: any;

--- a/src/utils/Enums.ts
+++ b/src/utils/Enums.ts
@@ -195,7 +195,9 @@ export enum StringKey {
   reproStepsListDescription = constants.reproStepsListDescription,
   reproStepsListEmptyStateDescription = constants.reproStepsListEmptyStateDescription,
   reproStepsListHeader = constants.reproStepsListHeader,
+  /** @deprecated Use {@link reproStepsListItemNumberingTitle} instead */
   reproStepsListItemTitle = constants.reproStepsListItemTitle,
+  reproStepsListItemNumberingTitle = constants.reproStepsListItemNumberingTitle,
   reproStepsProgressDialogBody = constants.reproStepsProgressDialogBody,
   requestFeatureDescription = constants.requestFeatureDescription,
   screenRecording = constants.screenRecording,

--- a/test/mocks/mockInstabug.ts
+++ b/test/mocks/mockInstabug.ts
@@ -3,7 +3,9 @@ import type { InstabugNativeModule } from '../../src/native/NativeInstabug';
 const mockInstabug: InstabugNativeModule = {
   addListener: jest.fn(),
   removeListeners: jest.fn(),
-  getConstants: jest.fn().mockReturnValue({}),
+  getConstants: jest.fn().mockReturnValue({
+    reproStepsListItemNumberingTitle: 'reproStepsListItemNumberingTitle',
+  }),
   setEnabled: jest.fn(),
   init: jest.fn(),
   setUserData: jest.fn(),

--- a/test/modules/Instabug.spec.ts
+++ b/test/modules/Instabug.spec.ts
@@ -298,6 +298,19 @@ describe('Instabug Module', () => {
     expect(NativeInstabug.setString).toBeCalledWith(string, key);
   });
 
+  it('should suffix the repro steps list item numbering title string on Android', () => {
+    Platform.OS = 'android';
+
+    const key = StringKey.reproStepsListItemNumberingTitle;
+    const string = 'Page';
+    const expected = 'Page #';
+
+    Instabug.setString(key, string);
+
+    expect(NativeInstabug.setString).toBeCalledTimes(1);
+    expect(NativeInstabug.setString).toBeCalledWith(expected, key);
+  });
+
   it('should call the native method identifyUser', () => {
     const email = 'foo@instabug.com';
     const name = 'Instabug';


### PR DESCRIPTION
## Description of the change

- Deprecate `StringKey.reproStepsListItemTitle` as it has inconsistent behavior between Android and iOS (it puts an extra ` #` on iOS and doesn't put it on Android).
- Introduce a consistent `StringKey.reproStepsListItemNumberingTitle` which adds the ` #` on Android as well.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
