### PR TITLE
[MOB-12515] Support React Native 0.73

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add new strings (`StringKey.discardAlertStay` and `StringKey.discardAlertDiscard`) for overriding the discard alert buttons for consistency between iOS and Android ([#1001](https://github.com/Instabug/Instabug-React-Native/pull/1001)).
 - Add a new string (`StringKey.reproStepsListItemNumberingTitle`) for overriding the repro steps list item (screen) title for consistency between iOS and Android ([#1002](https://github.com/Instabug/Instabug-React-Native/pull/1002)).
+- Add support for RN version 0.73 by updating the `build.gradle` file with the `namespace` ([#1004])(https://github.com/Instabug/Instabug-React-Native/pull/1004)
 
 ### Deprecated
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,12 +10,15 @@ def shouldUseNameSpace = agpVersion >= 7
 def PACKAGE_PROP = "package=\"com.instabug.reactlibrary\""
 def manifestOutFile = file("${projectDir}/src/main/AndroidManifest.xml")
 def manifestContent = manifestOutFile.getText()
+def isManifestContentUpdated = manifestOutFile.getText() != manifestContent
+def isPackageNamespaceMissing = !manifestContent.contains("$PACKAGE_PROP")
 
 String getExtOrDefault(String name) {
+    def defaultPropertyKey = 'InstabugReactNative_' + name
     if (rootProject.ext.has(name)) {
         return rootProject.ext.get(name)
     }
-    return project.properties['InstabugReactNative_' + name]
+    return project.properties[defaultPropertyKey]
 }
 
 if(shouldUseNameSpace){
@@ -24,7 +27,7 @@ if(shouldUseNameSpace){
         ''
     )  
 } else {
-    if(!manifestContent.contains("$PACKAGE_PROP")){
+    if(isPackageNamespaceMissing){
         manifestContent = manifestContent.replace(
             '<manifest',
             "<manifest $PACKAGE_PROP "
@@ -33,7 +36,10 @@ if(shouldUseNameSpace){
 }
 
 manifestContent.replaceAll("  ", " ")
-manifestOutFile.write(manifestContent)
+
+if(isManifestContentUpdated){
+    manifestOutFile.write(manifestContent)
+}
 
 android {
     if (shouldUseNameSpace){

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,6 +4,13 @@ apply from: './jacoco.gradle'
 apply from: './native.gradle'
 apply from: './sourcemaps.gradle'
 
+/* Checking APG version to be backward-compatible with RN versions < 0.71 */
+def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+def shouldUseNameSpace = agpVersion >= 7
+def PACKAGE_PROP = "package=\"com.instabug.reactlibrary\""
+def manifestOutFile = file("${projectDir}/src/main/AndroidManifest.xml")
+def manifestContent = manifestOutFile.getText()
+
 String getExtOrDefault(String name) {
     if (rootProject.ext.has(name)) {
         return rootProject.ext.get(name)
@@ -11,7 +18,27 @@ String getExtOrDefault(String name) {
     return project.properties['InstabugReactNative_' + name]
 }
 
+if(shouldUseNameSpace){
+      manifestContent = manifestContent.replaceAll(
+        PACKAGE_PROP,
+        ''
+    )  
+} else {
+    if(!manifestContent.contains("$PACKAGE_PROP")){
+        manifestContent = manifestContent.replace(
+            '<manifest',
+            "<manifest $PACKAGE_PROP "
+        )
+    }
+}
+
+manifestContent.replaceAll("  ", " ")
+manifestOutFile.write(manifestContent)
+
 android {
+    if (shouldUseNameSpace){
+        namespace = "com.instabug.reactlibrary"
+    }
     compileSdkVersion getExtOrDefault('compileSdkVersion').toInteger()
     buildToolsVersion getExtOrDefault('buildToolsVersion')
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,17 +22,15 @@ String getExtOrDefault(String name) {
 }
 
 if(shouldUseNameSpace){
-      manifestContent = manifestContent.replaceAll(
+    manifestContent = manifestContent.replaceAll(
         PACKAGE_PROP,
         ''
     )  
-} else {
-    if(isPackageNamespaceMissing){
-        manifestContent = manifestContent.replace(
-            '<manifest',
-            "<manifest $PACKAGE_PROP "
-        )
-    }
+} else if(isPackageNamespaceMissing) {
+    manifestContent = manifestContent.replace(
+        '<manifest',
+        "<manifest $PACKAGE_PROP "
+    )
 }
 
 manifestContent.replaceAll("  ", " ")

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ apply from: './jacoco.gradle'
 apply from: './native.gradle'
 apply from: './sourcemaps.gradle'
 
-/* Checking APG version to be backward-compatible with RN versions < 0.71 */
+/* (Preparing to support RN 0.73) Checking APG version to be backward-compatible with RN versions < 0.71 */
 def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
 def shouldUseNameSpace = agpVersion >= 7
 def PACKAGE_PROP = "package=\"com.instabug.reactlibrary\""

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.instabug.reactlibrary">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>
   


### PR DESCRIPTION
## Description of the change

Add SDK project `namespace` in `build.gradle` file to support the upcoming version of React Native(0.73) as it will use Android Gradle Plugin (AGP) version 8.x which will need the `namespace` to be specified. [More here](https://github.com/react-native-community/discussions-and-proposals/issues/671)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
