### PR TITLE
[MOB-12702] Remove danger ruby package

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,1 @@
 source "https://rubygems.org"
-
-gem 'danger', '~> 8.6', '>= 8.6.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,84 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.1)
-      public_suffix (>= 2.0.2, < 6.0)
-    claide (1.1.0)
-    claide-plugins (0.9.2)
-      cork
-      nap
-      open4 (~> 1.3)
-    colored2 (3.1.2)
-    cork (0.3.0)
-      colored2 (~> 3.1)
-    danger (8.6.1)
-      claide (~> 1.0)
-      claide-plugins (>= 0.9.2)
-      colored2 (~> 3.1)
-      cork (~> 0.1)
-      faraday (>= 0.9.0, < 2.0)
-      faraday-http-cache (~> 2.0)
-      git (~> 1.7)
-      kramdown (~> 2.3)
-      kramdown-parser-gfm (~> 1.0)
-      no_proxy_fix
-      octokit (~> 4.7)
-      terminal-table (>= 1, < 4)
-    faraday (1.10.2)
-      faraday-em_http (~> 1.0)
-      faraday-em_synchrony (~> 1.0)
-      faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0)
-      faraday-multipart (~> 1.0)
-      faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.0)
-      faraday-patron (~> 1.0)
-      faraday-rack (~> 1.0)
-      faraday-retry (~> 1.0)
-      ruby2_keywords (>= 0.0.4)
-    faraday-em_http (1.0.0)
-    faraday-em_synchrony (1.0.0)
-    faraday-excon (1.1.0)
-    faraday-http-cache (2.4.1)
-      faraday (>= 0.8)
-    faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.4)
-      multipart-post (~> 2)
-    faraday-net_http (1.0.1)
-    faraday-net_http_persistent (1.2.0)
-    faraday-patron (1.0.0)
-    faraday-rack (1.0.0)
-    faraday-retry (1.0.3)
-    git (1.12.0)
-      addressable (~> 2.8)
-      rchardet (~> 1.8)
-    kramdown (2.4.0)
-      rexml
-    kramdown-parser-gfm (1.1.0)
-      kramdown (~> 2.0)
-    multipart-post (2.2.3)
-    nap (1.1.0)
-    no_proxy_fix (0.1.2)
-    octokit (4.25.1)
-      faraday (>= 1, < 3)
-      sawyer (~> 0.9)
-    open4 (1.3.4)
-    public_suffix (5.0.0)
-    rchardet (1.8.0)
-    rexml (3.2.5)
-    ruby2_keywords (0.0.5)
-    sawyer (0.9.2)
-      addressable (>= 2.3.5)
-      faraday (>= 0.17.3, < 3)
-    terminal-table (3.0.2)
-      unicode-display_width (>= 1.1.1, < 3)
-    unicode-display_width (2.3.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  danger (~> 8.6, >= 8.6.1)
 
 BUNDLED WITH
-   1.17.2
+   2.4.17


### PR DESCRIPTION

- Remove danger ruby package to resolve depenndabot git security vulnerability issue.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

[MOB-12702](https://instabug.atlassian.net/browse/MOB-12702)

## Checklists
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] E2E Succeeds for iOS
- [x] E2E succeeds for Android
- [x] unit tests succeeds

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request


[MOB-12702]: https://instabug.atlassian.net/browse/MOB-12702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ