### PR TITLE
[MOB-12654] Add auto device selection detection 🔧

### DIFF
--- a/examples/default/.detoxrc.js
+++ b/examples/default/.detoxrc.js
@@ -2,6 +2,28 @@
 
 const { execSync } = require('child_process');
 
+
+// Currently we only test on `Pixel_4_API_31`
+const specificAvdName = null;
+
+// Returns the AVD name from available installed AVDs
+function getAVDName() {
+  try {
+
+    // Execute 'emulator -list-avds' command to get the list of AVDs
+    const avdListOutput = execSync('emulator -list-avds').toString();
+
+    // Split the output to get individual AVD names
+    const avdList = avdListOutput.trim().split('\n');
+
+    // Assuming you want to use the first AVD from the list, you can modify this logic as needed
+    return (specificAvdName !== null) ? specificAvdName : avdList.length > 0 ? avdList[0] : null;
+  } catch (error) {
+    console.error('Error while fetching AVD list:', error);
+    return null;
+  }
+}
+
 // Function to get the iOS simulator device type
 function getSimulatorDeviceType() {
   try {

--- a/examples/default/.detoxrc.js
+++ b/examples/default/.detoxrc.js
@@ -1,4 +1,35 @@
 /** @type {Detox.DetoxConfig} */
+
+const { execSync } = require('child_process');
+
+// Function to get the iOS simulator device type
+function getSimulatorDeviceType() {
+  try {
+
+     /// Execute 'xcrun simctl list devices' command to get the list of iOS simulator devices
+     const allSimulatorDevices = execSync('xcrun simctl list devices').toString();
+
+     /// Filter the output to get the list of iPhone devices
+     const filteredDevices = allSimulatorDevices.match(/iPhone[^)]*/g);
+
+     /// Clean the device names to get the final device type
+     const cleanedDevices = filteredDevices.map(device => device.replace(/\(.*$/, '').trim());
+
+     /// Assuming you want to use the last device from the list, you can modify this logic as needed
+     const lastDeviceType = cleanedDevices[cleanedDevices.length - 1];
+
+     /// Remove the trailing newline character from the device type
+     const trimmedDeviceType = lastDeviceType.replace('\n', '');
+
+     /// Return the final device type
+     return trimmedDeviceType;
+  } catch (error) {
+    console.error('Error while fetching iOS simulator device list:', error);
+    return null;
+  }
+}
+
+
 module.exports = {
   testRunner: {
     $0: 'jest',
@@ -37,13 +68,13 @@ module.exports = {
     simulator: {
       type: 'ios.simulator',
       device: {
-        type: 'iPhone 13 Pro Max',
+        type: getSimulatorDeviceType(),
       },
     },
     emulator: {
       type: 'android.emulator',
       device: {
-        avdName: 'Nexus_6P_API_27',
+        avdName: getAVDName(),
       },
     },
   },


### PR DESCRIPTION

Add detection for available simulators and pick the last one available to run the E2E detox tests.## Description of the change

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

[MOB-12654](https://instabug.atlassian.net/browse/MOB-12654)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
