### PR TITLE
test: write unit tests for the refactored code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ android/keystores/debug.keystore
 
 # Bundle artifact
 *.jsbundle
+
+# Vscode local history
+.history/

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,1 @@
 source "https://rubygems.org"
-
-gem 'danger', '~> 8.6', '>= 8.6.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,84 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.1)
-      public_suffix (>= 2.0.2, < 6.0)
-    claide (1.1.0)
-    claide-plugins (0.9.2)
-      cork
-      nap
-      open4 (~> 1.3)
-    colored2 (3.1.2)
-    cork (0.3.0)
-      colored2 (~> 3.1)
-    danger (8.6.1)
-      claide (~> 1.0)
-      claide-plugins (>= 0.9.2)
-      colored2 (~> 3.1)
-      cork (~> 0.1)
-      faraday (>= 0.9.0, < 2.0)
-      faraday-http-cache (~> 2.0)
-      git (~> 1.7)
-      kramdown (~> 2.3)
-      kramdown-parser-gfm (~> 1.0)
-      no_proxy_fix
-      octokit (~> 4.7)
-      terminal-table (>= 1, < 4)
-    faraday (1.10.2)
-      faraday-em_http (~> 1.0)
-      faraday-em_synchrony (~> 1.0)
-      faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0)
-      faraday-multipart (~> 1.0)
-      faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.0)
-      faraday-patron (~> 1.0)
-      faraday-rack (~> 1.0)
-      faraday-retry (~> 1.0)
-      ruby2_keywords (>= 0.0.4)
-    faraday-em_http (1.0.0)
-    faraday-em_synchrony (1.0.0)
-    faraday-excon (1.1.0)
-    faraday-http-cache (2.4.1)
-      faraday (>= 0.8)
-    faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.4)
-      multipart-post (~> 2)
-    faraday-net_http (1.0.1)
-    faraday-net_http_persistent (1.2.0)
-    faraday-patron (1.0.0)
-    faraday-rack (1.0.0)
-    faraday-retry (1.0.3)
-    git (1.12.0)
-      addressable (~> 2.8)
-      rchardet (~> 1.8)
-    kramdown (2.4.0)
-      rexml
-    kramdown-parser-gfm (1.1.0)
-      kramdown (~> 2.0)
-    multipart-post (2.2.3)
-    nap (1.1.0)
-    no_proxy_fix (0.1.2)
-    octokit (4.25.1)
-      faraday (>= 1, < 3)
-      sawyer (~> 0.9)
-    open4 (1.3.4)
-    public_suffix (5.0.0)
-    rchardet (1.8.0)
-    rexml (3.2.5)
-    ruby2_keywords (0.0.5)
-    sawyer (0.9.2)
-      addressable (>= 2.3.5)
-      faraday (>= 0.17.3, < 3)
-    terminal-table (3.0.2)
-      unicode-display_width (>= 1.1.1, < 3)
-    unicode-display_width (2.3.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  danger (~> 8.6, >= 8.6.1)
 
 BUNDLED WITH
-   1.17.2
+   2.4.17

--- a/src/modules/CrashReporting.ts
+++ b/src/modules/CrashReporting.ts
@@ -1,7 +1,5 @@
-import { Platform } from 'react-native';
 import type { ExtendedError } from 'react-native/Libraries/Core/Devtools/parseErrorStack';
 
-import type { CrashData } from '../native/NativeCrashReporting';
 import { NativeCrashReporting } from '../native/NativeCrashReporting';
 import InstabugUtils from '../utils/InstabugUtils';
 

--- a/src/modules/CrashReporting.ts
+++ b/src/modules/CrashReporting.ts
@@ -30,20 +30,5 @@ export const reportJSException = (error: any) => {
  * @param error Error object to be sent to Instabug's servers
  */
 export const reportError = (error: ExtendedError) => {
-  const jsStackTrace = InstabugUtils.getStackTrace(error);
-
-  const jsonObject: CrashData = {
-    message: error.name + ' - ' + error.message,
-    e_message: error.message,
-    e_name: error.name,
-    os: Platform.OS,
-    platform: 'react_native',
-    exception: jsStackTrace,
-  };
-
-  if (Platform.OS === 'android') {
-    NativeCrashReporting.sendHandledJSCrash(JSON.stringify(jsonObject));
-  } else {
-    NativeCrashReporting.sendHandledJSCrash(jsonObject);
-  }
+  InstabugUtils.sendCrashReport(error, NativeCrashReporting.sendHandledJSCrash);
 };

--- a/test/mocks/mockInstabugUtils.ts
+++ b/test/mocks/mockInstabugUtils.ts
@@ -7,6 +7,7 @@ jest.mock('../../src/utils/InstabugUtils', () => {
     captureJsErrors: jest.fn(),
     getActiveRouteName: jest.fn(),
     stringifyIfNotString: jest.fn(),
+    sendCrashReport: jest.fn(),
     getStackTrace: jest.fn().mockReturnValue('javascriptStackTrace'),
     getFullRoute: jest.fn().mockImplementation(() => 'ScreenName'),
   };

--- a/test/modules/CrashReporting.spec.ts
+++ b/test/modules/CrashReporting.spec.ts
@@ -1,9 +1,8 @@
 import '../mocks/mockInstabugUtils';
 
-import { Platform } from 'react-native';
-
 import * as CrashReporting from '../../src/modules/CrashReporting';
 import { NativeCrashReporting } from '../../src/native/NativeCrashReporting';
+import InstabugUtils from '../../src/utils/InstabugUtils';
 
 describe('CrashReporting Module', () => {
   it('should call the native method setEnabled', () => {
@@ -13,39 +12,14 @@ describe('CrashReporting Module', () => {
     expect(NativeCrashReporting.setEnabled).toBeCalledWith(true);
   });
 
-  it('should call the native method sendHandledJSCrash with JSON object when platform is iOS', () => {
-    Platform.OS = 'ios';
+  it('should call the native method sendCrashReporting with JSON object and sendHandledJsCrash as a callback', () => {
     const error = { name: 'TypeError', message: 'Invalid type' };
     CrashReporting.reportError(error);
 
-    const expected = {
-      message: 'TypeError - Invalid type',
-      e_message: 'Invalid type',
-      e_name: 'TypeError',
-      os: 'ios',
-      platform: 'react_native',
-      exception: 'javascriptStackTrace',
-    };
-
-    expect(NativeCrashReporting.sendHandledJSCrash).toBeCalledTimes(1);
-    expect(NativeCrashReporting.sendHandledJSCrash).toBeCalledWith(expected);
-  });
-
-  it('should call the native method sendHandledJSCrash with stringified JSON object when platform is Android', () => {
-    Platform.OS = 'android';
-    const error = { name: 'TypeError', message: 'Invalid type' };
-    CrashReporting.reportError(error);
-
-    const expected = JSON.stringify({
-      message: 'TypeError - Invalid type',
-      e_message: 'Invalid type',
-      e_name: 'TypeError',
-      os: 'android',
-      platform: 'react_native',
-      exception: 'javascriptStackTrace',
-    });
-
-    expect(NativeCrashReporting.sendHandledJSCrash).toBeCalledTimes(1);
-    expect(NativeCrashReporting.sendHandledJSCrash).toBeCalledWith(expected);
+    expect(InstabugUtils.sendCrashReport).toBeCalledTimes(1);
+    expect(InstabugUtils.sendCrashReport).toBeCalledWith(
+      error,
+      NativeCrashReporting.sendHandledJSCrash,
+    );
   });
 });

--- a/test/utils/InstabugUtils.spec.ts
+++ b/test/utils/InstabugUtils.spec.ts
@@ -7,7 +7,7 @@ import parseErrorStackLib from 'react-native/Libraries/Core/Devtools/parseErrorS
 import * as Instabug from '../../src/modules/Instabug';
 import { NativeCrashReporting } from '../../src/native/NativeCrashReporting';
 import { InvocationEvent } from '../../src/utils/Enums';
-import InstabugUtils from '../../src/utils/InstabugUtils';
+import InstabugUtils, { sendCrashReport } from '../../src/utils/InstabugUtils';
 
 describe('Test global error handler', () => {
   beforeEach(() => {
@@ -219,5 +219,44 @@ describe('Instabug Utils', () => {
 
     mockDev.mockRestore();
     consoleWarnSpy.mockRestore();
+  });
+
+  it('should call remoteSenderCallback with the correct JSON object on Android', () => {
+    const remoteSenderCallback = NativeCrashReporting.sendHandledJSCrash;
+    Platform.OS = 'android';
+    const errorMock = { name: 'TypeError', message: 'Invalid type' };
+
+    sendCrashReport(errorMock, remoteSenderCallback);
+
+    const expectedMap = {
+      message: 'TypeError - Invalid type',
+      e_message: 'Invalid type',
+      e_name: 'TypeError',
+      os: 'android',
+      platform: 'react_native',
+      exception: [],
+    };
+    const expectedJsonObject = JSON.stringify(expectedMap);
+    expect(remoteSenderCallback).toHaveBeenCalledTimes(1);
+    expect(remoteSenderCallback).toHaveBeenCalledWith(expectedJsonObject);
+  });
+
+  it('should call remoteSenderCallback with the correct JSON object on iOS', () => {
+    const remoteSenderCallback = NativeCrashReporting.sendHandledJSCrash;
+    Platform.OS = 'ios';
+    const errorMock = { name: 'TypeError', message: 'Invalid type' };
+
+    sendCrashReport(errorMock, remoteSenderCallback);
+
+    const expectedMap = {
+      message: 'TypeError - Invalid type',
+      e_message: 'Invalid type',
+      e_name: 'TypeError',
+      os: 'ios',
+      platform: 'react_native',
+      exception: [],
+    };
+    expect(remoteSenderCallback).toHaveBeenCalledTimes(1);
+    expect(remoteSenderCallback).toHaveBeenCalledWith(expectedMap);
   });
 });


### PR DESCRIPTION
## Description of the change
- write test for sendCrashReport for both Android and iOS Platforms.
- re-write CrashReporting.spec.ts `reportError` method after refactoring duplicate code to `sendCrashReport`.
- exclude .history directory which includes vscode local history files.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
