### PR TITLE
refactor: use anonymous class instead of lambda

### DIFF
--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
@@ -115,12 +115,15 @@ public class RNInstabugReactnativeModule extends EventEmitterModule {
      */
     @ReactMethod
     public void init(final String token, final ReadableArray invocationEventValues, final String logLevel) {
-        MainThreadHandler.runOnMainThread(() -> {
-            final ArrayList<String> keys = ArrayUtil.parseReadableArrayOfStrings(invocationEventValues);
-            final ArrayList<InstabugInvocationEvent> parsedInvocationEvents = ArgsRegistry.invocationEvents.getAll(keys);
-            final InstabugInvocationEvent[] invocationEvents = parsedInvocationEvents.toArray(new InstabugInvocationEvent[0]);
-            final int parsedLogLevel = ArgsRegistry.sdkLogLevels.getOrDefault(logLevel, LogLevel.ERROR);
-            RNInstabug.getInstance().init(getCurrentActivity().getApplication(), token, parsedLogLevel, invocationEvents);
+        MainThreadHandler.runOnMainThread(new Runnable() {
+            @Override
+            public void run() {
+                final ArrayList<String> keys = ArrayUtil.parseReadableArrayOfStrings(invocationEventValues);
+                final ArrayList<InstabugInvocationEvent> parsedInvocationEvents = ArgsRegistry.invocationEvents.getAll(keys);
+                final InstabugInvocationEvent[] invocationEvents = parsedInvocationEvents.toArray(new InstabugInvocationEvent[0]);
+                final int parsedLogLevel = ArgsRegistry.sdkLogLevels.getOrDefault(logLevel, LogLevel.ERROR);
+                RNInstabug.getInstance().init(getCurrentActivity().getApplication(), token, parsedLogLevel, invocationEvents);
+            }
         });
     }
 


### PR DESCRIPTION
## Description of the change

Removed the use of Java 8 lambda functions in Android that was added in #1012 and replaced it with `new Runnable` since it breaks apps running on older versions of Java and React Native.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Jira ID: MOB-12977

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
