### PR TITLE
feat: add new repro steps api

### DIFF
--- a/android/src/main/java/com/instabug/reactlibrary/ArgsRegistry.java
+++ b/android/src/main/java/com/instabug/reactlibrary/ArgsRegistry.java
@@ -11,6 +11,7 @@ import com.instabug.library.OnSdkDismissCallback;
 import com.instabug.library.InstabugColorTheme;
 import com.instabug.library.InstabugCustomTextPlaceHolder.Key;
 import com.instabug.library.OnSdkDismissCallback.DismissType;
+import com.instabug.library.ReproMode;
 import com.instabug.library.core.plugin.PluginPromptOption;
 import com.instabug.library.extendedbugreport.ExtendedBugReport;
 import com.instabug.library.internal.module.InstabugLocale;
@@ -43,6 +44,7 @@ final class ArgsRegistry {
         }
     }
 
+    @SuppressWarnings("deprecation")
     static Map<String, Object> getAll() {
         return new HashMap<String, Object>() {{
             putAll(logLevels);
@@ -57,6 +59,7 @@ final class ArgsRegistry {
             putAll(actionTypes);
             putAll(extendedBugReportStates);
             putAll(reproStates);
+            putAll(reproModes);
             putAll(sdkLogLevels);
             putAll(promptOptions);
             putAll(locales);
@@ -140,10 +143,17 @@ final class ArgsRegistry {
         put("disabled", ExtendedBugReport.State.DISABLED);
     }};
 
+    @Deprecated()
     static final ArgsMap<State> reproStates = new ArgsMap<State>() {{
         put("reproStepsEnabledWithNoScreenshots", State.ENABLED_WITH_NO_SCREENSHOTS);
         put("reproStepsEnabled", State.ENABLED);
         put("reproStepsDisabled", State.DISABLED);
+    }};
+
+    static final ArgsMap<Integer> reproModes = new ArgsMap<Integer>() {{
+        put("reproStepsEnabledWithNoScreenshots", ReproMode.EnableWithNoScreenshots);
+        put("reproStepsEnabled", ReproMode.EnableWithScreenshots);
+        put("reproStepsDisabled", ReproMode.Disable);
     }};
 
     static final ArgsMap<Integer> sdkLogLevels = new ArgsMap<Integer>() {{

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
@@ -24,7 +24,9 @@ import com.instabug.library.Feature;
 import com.instabug.library.Instabug;
 import com.instabug.library.InstabugColorTheme;
 import com.instabug.library.InstabugCustomTextPlaceHolder;
+import com.instabug.library.IssueType;
 import com.instabug.library.LogLevel;
+import com.instabug.library.ReproConfigurations;
 import com.instabug.library.internal.module.InstabugLocale;
 import com.instabug.library.invocation.InstabugInvocationEvent;
 import com.instabug.library.logging.InstabugLog;
@@ -48,6 +50,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+
+import javax.annotation.Nullable;
 
 
 /**
@@ -761,12 +765,14 @@ public class RNInstabugReactnativeModule extends EventEmitterModule {
         });
     }
 
- /**
+    /**
      * Sets whether user steps tracking is visual, non visual or disabled.
      *
      * @param reproStepsMode A string to set user steps tracking to be
      *                       enabled, non visual or disabled.
      */
+    @SuppressWarnings("deprecation")
+    @Deprecated()
     @ReactMethod
     public void setReproStepsMode(final String reproStepsMode) {
         MainThreadHandler.runOnMainThread(new Runnable() {
@@ -780,6 +786,29 @@ public class RNInstabugReactnativeModule extends EventEmitterModule {
                 }
             }
         });
+    }
+
+    @ReactMethod
+    public void setReproStepsConfig(@Nullable final String bugMode, @Nullable final String crashMode) {
+        try {
+            final ReproConfigurations.Builder builder = new ReproConfigurations.Builder();
+
+            if (bugMode != null) {
+                final Integer resolvedBugMode = ArgsRegistry.reproModes.get(bugMode);
+                builder.setIssueMode(IssueType.Bug, resolvedBugMode);
+            }
+
+            if (crashMode != null) {
+                final Integer resolvedCrashMode = ArgsRegistry.reproModes.get(crashMode);
+                builder.setIssueMode(IssueType.Crash, resolvedCrashMode);
+            }
+
+            final ReproConfigurations config = builder.build();
+
+            Instabug.setReproConfigurations(config);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     /**

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
@@ -789,21 +789,15 @@ public class RNInstabugReactnativeModule extends EventEmitterModule {
     }
 
     @ReactMethod
-    public void setReproStepsConfig(@Nullable final String bugMode, @Nullable final String crashMode) {
+    public void setReproStepsConfig(final String bugMode, final String crashMode) {
         try {
-            final ReproConfigurations.Builder builder = new ReproConfigurations.Builder();
+            final Integer resolvedBugMode = ArgsRegistry.reproModes.get(bugMode);
+            final Integer resolvedCrashMode = ArgsRegistry.reproModes.get(crashMode);
 
-            if (bugMode != null) {
-                final Integer resolvedBugMode = ArgsRegistry.reproModes.get(bugMode);
-                builder.setIssueMode(IssueType.Bug, resolvedBugMode);
-            }
-
-            if (crashMode != null) {
-                final Integer resolvedCrashMode = ArgsRegistry.reproModes.get(crashMode);
-                builder.setIssueMode(IssueType.Crash, resolvedCrashMode);
-            }
-
-            final ReproConfigurations config = builder.build();
+            final ReproConfigurations config = new ReproConfigurations.Builder()
+                    .setIssueMode(IssueType.Bug, resolvedBugMode)
+                    .setIssueMode(IssueType.Crash, resolvedCrashMode)
+                    .build();
 
             Instabug.setReproConfigurations(config);
         } catch (Exception e) {

--- a/examples/default/ios/InstabugTests/InstabugSampleTests.m
+++ b/examples/default/ios/InstabugTests/InstabugSampleTests.m
@@ -219,6 +219,17 @@
   OCMVerify([mock setReproStepsMode:reproStepsMode]);
 }
 
+- (void)testSetReproStepsConfig {
+  id mock = OCMClassMock([Instabug class]);
+  IBGUserStepsMode bugMode = IBGUserStepsModeDisable;
+  IBGUserStepsMode crashMode = IBGUserStepsModeEnable;
+
+  [self.instabugBridge setReproStepsConfig:bugMode :crashMode];
+
+  OCMVerify([mock setReproStepsFor:IBGIssueTypeBug withMode:bugMode]);
+  OCMVerify([mock setReproStepsFor:IBGIssueTypeCrash withMode:crashMode]);
+}
+
 - (void)testSetSdkDebugLogsLevel {
   id mock = OCMClassMock([Instabug class]);
   IBGSDKDebugLogsLevel sdkDebugLogsLevel = IBGSDKDebugLogsLevelVerbose;

--- a/ios/RNInstabug/InstabugReactBridge.h
+++ b/ios/RNInstabug/InstabugReactBridge.h
@@ -61,6 +61,8 @@
 
 - (void)setReproStepsMode:(IBGUserStepsMode)reproStepsMode;
 
+- (void)setReproStepsConfig:(IBGUserStepsMode)bugMode:(IBGUserStepsMode)crashMode;
+
 - (void)setUserAttribute:(NSString *)key withValue:(NSString *)value;
 
 - (void)getUserAttribute:(NSString *)key

--- a/ios/RNInstabug/InstabugReactBridge.m
+++ b/ios/RNInstabug/InstabugReactBridge.m
@@ -81,6 +81,11 @@ RCT_EXPORT_METHOD(setReproStepsMode:(IBGUserStepsMode)reproStepsMode) {
     [Instabug setReproStepsMode:reproStepsMode];
 }
 
+RCT_EXPORT_METHOD(setReproStepsConfig:(IBGUserStepsMode)bugMode :(IBGUserStepsMode)crashMode) {
+    [Instabug setReproStepsFor:IBGIssueTypeBug withMode:bugMode];
+    [Instabug setReproStepsFor:IBGIssueTypeCrash withMode:crashMode];
+}
+
 RCT_EXPORT_METHOD(setFileAttachment:(NSString *)fileLocation) {
     NSURL *url = [NSURL URLWithString:fileLocation];
     [Instabug addFileAttachmentWithURL:url];

--- a/src/models/ReproConfig.ts
+++ b/src/models/ReproConfig.ts
@@ -1,0 +1,24 @@
+import type { ReproStepsMode } from '../utils/Enums';
+
+export interface ReproConfig {
+  /**
+   * Repro steps mode for bug reporting.
+   *
+   * @default ReproStepsMode.enabled
+   */
+  bug?: ReproStepsMode;
+
+  /**
+   * Repro steps mode for crash reporting.
+   *
+   * @default ReproStepsMode.enabledWithNoScreenshots
+   */
+  crash?: ReproStepsMode;
+
+  /**
+   * Repro steps mode for both bug and crash reporting.
+   *
+   * When this is set, `bug` and `crash` will be ignored.
+   */
+  all?: ReproStepsMode;
+}

--- a/src/modules/Instabug.ts
+++ b/src/modules/Instabug.ts
@@ -378,6 +378,19 @@ export const setReproStepsMode = (mode: reproStepsMode | ReproStepsMode) => {
   NativeInstabug.setReproStepsMode(mode);
 };
 
+/**
+ * Sets the repro steps mode for bugs and crashes.
+ *
+ * @param config The repro steps config.
+ *
+ * @example
+ * ```js
+ * Instabug.setReproStepsConfig({
+ *   bug: ReproStepsMode.enabled,
+ *   crash: ReproStepsMode.disabled,
+ * });
+ * ```
+ */
 export const setReproStepsConfig = (config: ReproConfig) => {
   let bug = config.bug ?? ReproStepsMode.enabled;
   let crash = config.crash ?? ReproStepsMode.enabledWithNoScreenshots;

--- a/src/modules/Instabug.ts
+++ b/src/modules/Instabug.ts
@@ -37,6 +37,7 @@ import InstabugUtils, {
 } from '../utils/InstabugUtils';
 import * as NetworkLogger from './NetworkLogger';
 import { captureUnhandledRejections } from '../utils/UnhandledRejectionTracking';
+import type { ReproConfig } from '../models/ReproConfig';
 
 let _currentScreen: string | null = null;
 let _lastScreen: string | null = null;
@@ -365,6 +366,8 @@ export const clearLogs = () => {
 };
 
 /**
+ * @deprecated Use {@link setReproStepsConfig} instead.
+ *
  * Sets whether user steps tracking is visual, non visual or disabled.
  * User Steps tracking is enabled by default if it's available
  * in your current plan.
@@ -373,6 +376,18 @@ export const clearLogs = () => {
  */
 export const setReproStepsMode = (mode: reproStepsMode | ReproStepsMode) => {
   NativeInstabug.setReproStepsMode(mode);
+};
+
+export const setReproStepsConfig = (config: ReproConfig) => {
+  let bug = config.bug ?? ReproStepsMode.enabled;
+  let crash = config.crash ?? ReproStepsMode.enabledWithNoScreenshots;
+
+  if (config.all != null) {
+    bug = config.all;
+    crash = config.all;
+  }
+
+  NativeInstabug.setReproStepsConfig(bug, crash);
 };
 
 /**

--- a/src/modules/Instabug.ts
+++ b/src/modules/Instabug.ts
@@ -387,6 +387,15 @@ export const setReproStepsConfig = (config: ReproConfig) => {
     crash = config.all;
   }
 
+  // There's an issue with crashes repro steps with screenshots in the iOS SDK
+  // at the moment, so we'll map enabled with screenshots to enabled with no
+  // screenshots to avoid storing the images on disk if it's not needed until
+  // this issue is fixed in a future version.
+  if (Platform.OS === 'ios' && crash === ReproStepsMode.enabled) {
+    /* istanbul ignore next */
+    crash = ReproStepsMode.enabledWithNoScreenshots;
+  }
+
   NativeInstabug.setReproStepsConfig(bug, crash);
 };
 

--- a/src/native/NativeInstabug.ts
+++ b/src/native/NativeInstabug.ts
@@ -52,7 +52,7 @@ export interface InstabugNativeModule extends NativeModule {
   // Repro Steps APIs //
   /** @deprecated */
   setReproStepsMode(mode: ReproStepsMode | reproStepsMode): void;
-  setReproStepsConfig(bugMode?: ReproStepsMode | null, crashMode?: ReproStepsMode | null): void;
+  setReproStepsConfig(bugMode: ReproStepsMode, crashMode: ReproStepsMode): void;
   setTrackUserSteps(isEnabled: boolean): void;
   reportScreenChange(firstScreen: string): void;
   addPrivateView(nativeTag: number | null): void;

--- a/src/native/NativeInstabug.ts
+++ b/src/native/NativeInstabug.ts
@@ -50,7 +50,9 @@ export interface InstabugNativeModule extends NativeModule {
   setNetworkLoggingEnabled(isEnabled: boolean): void;
 
   // Repro Steps APIs //
+  /** @deprecated */
   setReproStepsMode(mode: ReproStepsMode | reproStepsMode): void;
+  setReproStepsConfig(bugMode?: ReproStepsMode | null, crashMode?: ReproStepsMode | null): void;
   setTrackUserSteps(isEnabled: boolean): void;
   reportScreenChange(firstScreen: string): void;
   addPrivateView(nativeTag: number | null): void;

--- a/test/mocks/mockInstabug.ts
+++ b/test/mocks/mockInstabug.ts
@@ -1,11 +1,16 @@
 import type { InstabugNativeModule } from '../../src/native/NativeInstabug';
 
+/**
+ * A fake implementation of the NativeConstants object using `Proxy` that
+ * returns the name of the property as its value instead of hardcoding all
+ * the constants.
+ */
+const fakeNativeConstants = new Proxy({}, { get: (_, prop) => prop });
+
 const mockInstabug: InstabugNativeModule = {
+  getConstants: jest.fn().mockReturnValue(fakeNativeConstants),
   addListener: jest.fn(),
   removeListeners: jest.fn(),
-  getConstants: jest.fn().mockReturnValue({
-    reproStepsListItemNumberingTitle: 'reproStepsListItemNumberingTitle',
-  }),
   setEnabled: jest.fn(),
   init: jest.fn(),
   setUserData: jest.fn(),
@@ -29,6 +34,7 @@ const mockInstabug: InstabugNativeModule = {
   logDebug: jest.fn(),
   clearLogs: jest.fn(),
   setReproStepsMode: jest.fn(),
+  setReproStepsConfig: jest.fn(),
   setSdkDebugLogsLevel: jest.fn(),
   setUserAttribute: jest.fn(),
   getUserAttribute: jest.fn(),

--- a/test/modules/Instabug.spec.ts
+++ b/test/modules/Instabug.spec.ts
@@ -419,6 +419,47 @@ describe('Instabug Module', () => {
     expect(NativeInstabug.setReproStepsMode).toBeCalledWith(mode);
   });
 
+  it('setReproStepsConfig should call the native setReproStepsConfig', () => {
+    Platform.OS = 'android';
+
+    const bug = ReproStepsMode.disabled;
+    const crash = ReproStepsMode.enabled;
+    const config = { bug, crash };
+
+    Instabug.setReproStepsConfig(config);
+
+    expect(NativeInstabug.setReproStepsConfig).toBeCalledTimes(1);
+    expect(NativeInstabug.setReproStepsConfig).toBeCalledWith(bug, crash);
+  });
+
+  it('setReproStepsConfig should prioritize `all` over `bug` and `crash`', () => {
+    Platform.OS = 'android';
+
+    const bug = ReproStepsMode.disabled;
+    const crash = ReproStepsMode.enabled;
+    const all = ReproStepsMode.enabledWithNoScreenshots;
+    const config = { all, bug, crash };
+
+    Instabug.setReproStepsConfig(config);
+
+    expect(NativeInstabug.setReproStepsConfig).toBeCalledTimes(1);
+    expect(NativeInstabug.setReproStepsConfig).toBeCalledWith(all, all);
+  });
+
+  it('setReproStepsConfig should use defaults for `bug` and `crash`', () => {
+    Platform.OS = 'android';
+
+    const config = {};
+
+    Instabug.setReproStepsConfig(config);
+
+    expect(NativeInstabug.setReproStepsConfig).toBeCalledTimes(1);
+    expect(NativeInstabug.setReproStepsConfig).toBeCalledWith(
+      ReproStepsMode.enabled,
+      ReproStepsMode.enabledWithNoScreenshots,
+    );
+  });
+
   it('should call the native method setSdkDebugLogsLevel on iOS', () => {
     const debugLevel = Instabug.sdkDebugLogsLevel.sdkDebugLogsLevelVerbose;
 


### PR DESCRIPTION
## Description of the change

Add support for the new `Instabug.setReproStepsConfig` API and deprecate the old `Instabug.setReproStepsMode`.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Jira ID: MOB-13006

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
