### PR TITLE
chore: deprecate old bug content string keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Deprecate the old `StringKey.discardAlertCancel` and `StringKey.discardAlertAction` string keys for overriding the discard alert buttons as they had incosistent behavior between iOS and Android ([#1001](https://github.com/Instabug/Instabug-React-Native/pull/1001)).
 - Deprecate the old `StringKey.reproStepsListItemNumberingTitle` string key for overriding the repro steps list item (screen) title as it had incosistent behavior between iOS and Android ([#1002](https://github.com/Instabug/Instabug-React-Native/pull/1002)).
 - Deprecate `Instabug.setReproStepsMode` in favor of the new `Instabug.setReproStepsConfig` ([#1024](https://github.com/Instabug/Instabug-React-Native/pull/1024)).
+- Deprecate the old `StringKey.invalidCommentMessage` and `StringKey.invalidCommentTitle` in favor of `StringKey.insufficientContentMessage` and `StringKey.insufficientContentTitle` ([#1026](https://github.com/Instabug/Instabug-React-Native/pull/1026)).
 
 ## [11.13.0](https://github.com/Instabug/Instabug-React-Native/compare/v11.12.0...v11.13.0) (July 10, 2023)
 

--- a/android/src/main/java/com/instabug/reactlibrary/ArgsRegistry.java
+++ b/android/src/main/java/com/instabug/reactlibrary/ArgsRegistry.java
@@ -201,6 +201,7 @@ final class ArgsRegistry {
         put("shakeHint", Key.SHAKE_HINT);
         put("swipeHint", Key.SWIPE_HINT);
         put("invalidEmailMessage", Key.INVALID_EMAIL_MESSAGE);
+        // Deprecated
         put("invalidCommentMessage", Key.INVALID_COMMENT_MESSAGE);
         put("emailFieldHint", Key.EMAIL_FIELD_HINT);
         put("commentFieldHintForBugReport", Key.COMMENT_FIELD_HINT_FOR_BUG_REPORT);

--- a/ios/RNInstabug/ArgsRegistry.m
+++ b/ios/RNInstabug/ArgsRegistry.m
@@ -187,8 +187,12 @@
         @"startAlertText": kIBGStartAlertTextStringName,
         @"invalidEmailMessage": kIBGInvalidEmailMessageStringName,
         @"invalidEmailTitle": kIBGInvalidEmailTitleStringName,
+
+        // Deprecated
         @"invalidCommentMessage": kIBGInvalidCommentMessageStringName,
+        // Deprecated
         @"invalidCommentTitle": kIBGInvalidCommentTitleStringName,
+
         @"invocationHeader": kIBGInvocationTitleStringName,
         @"reportQuestion": kIBGAskAQuestionStringName,
         @"reportBug": kIBGReportBugStringName,

--- a/src/utils/Enums.ts
+++ b/src/utils/Enums.ts
@@ -171,10 +171,15 @@ export enum StringKey {
   edgeSwipeStartHint = constants.edgeSwipeStartHint,
   emailFieldHint = constants.emailFieldHint,
   image = constants.image,
+
   insufficientContentMessage = constants.insufficientContentMessage,
+  /** iOS only */
   insufficientContentTitle = constants.insufficientContentTitle,
+  /** @deprecated Use {@link insufficientContentMessage} instead. */
   invalidCommentMessage = constants.invalidCommentMessage,
+  /** @deprecated Use {@link insufficientContentTitle} instead. */
   invalidCommentTitle = constants.invalidCommentTitle,
+
   invalidEmailMessage = constants.invalidEmailMessage,
   invalidEmailTitle = constants.invalidEmailTitle,
   invocationHeader = constants.invocationHeader,


### PR DESCRIPTION
## Description of the change

Deprecate the old `StringKey.invalidCommentMessage` and `StringKey.invalidCommentTitle` in favor of `StringKey.insufficientContentMessage` and `StringKey.insufficientContentTitle`.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Jira ID: MOB-13020

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
