### PR TITLE
chore: update outdated jest config format

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,11 +12,6 @@ module.exports = {
   modulePathIgnorePatterns: ['examples'],
   transform: {
     '^.+\\.jsx$': 'babel-jest',
-    '^.+\\.tsx?$': 'ts-jest',
-  },
-  globals: {
-    'ts-jest': {
-      tsConfig: 'tsconfig.test.json',
-    },
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.test.json' }],
   },
 };


### PR DESCRIPTION
## Description of the change

Whenever we run yarn test to run our JavaScript tests, we get this warning from Jest to update our Jest configuration format.

> ts-jest[backports] (WARN) Your Jest configuration is outdated. Use the CLI to help migrating it: ts-jest config:migrate <config-file>.
> ts-jest[ts-jest-transformer] (WARN) Define `ts-jest` config under `globals` is deprecated. Please do
> transform: {
>     <transform_regex>: ['ts-jest', { /* ts-jest config goes here in Jest */ }],
> },
> ts-jest[backports] (WARN) "[jest-config].globals.ts-jest.tsConfig" is deprecated, use "[jest-config].globals.ts-jest.tsconfig" instead.

Updated the Jest config to follow the above logs instructions.

1. Putting `ts-jest`’s config in `transform` instead of `global`.
1. Using `tsconfig` instead of `tsConfig`.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Jira ID: MOB-13180

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
