### PR TITLE
fix: fix and enhance AGP namespace support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased](https://github.com/Instabug/Instabug-React-Native/compare/v12.1.0...dev)
+
+### Fixed
+
+- Fix an issue with Android Gradle Plugin namespace support required for React Native 0.73 and backward compatibility with previous versions ([#1044](https://github.com/Instabug/Instabug-React-Native/pull/1044)).
+
 ## [12.1.0](https://github.com/Instabug/Instabug-React-Native/compare/v12.1.0...v11.14.0)
 
 ### Added

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,7 +12,7 @@ String getExtOrDefault(String name) {
     return project.properties[defaultPropertyKey]
 }
 
-void supportsNamespace() {
+static boolean supportsNamespace() {
     def parsed = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')
     def major = parsed[0].toInteger()
     def minor = parsed[1].toInteger()
@@ -22,18 +22,18 @@ void supportsNamespace() {
 }
 
 void updateManifestPackage() {
-    def package = 'package="com.instabug.reactlibrary"'
-    def manifestFile = file("${projectDir}/src/main/AndroidManifest.xml")
+    def packageProp = 'package="com.instabug.reactlibrary"'
+    def manifestFile = file("$projectDir/src/main/AndroidManifest.xml")
     def currentContent = manifestFile.getText()
     def content = currentContent
-    def hasPackage = currentContent.contains(package)
+    def hasPackage = currentContent.contains(packageProp)
 
     if (supportsNamespace()) {
-        content = content.replaceAll(package, '')
-    } else (!hasPackage) {
+        content = content.replaceAll(packageProp, '')
+    } else if (!hasPackage) {
         content = content.replace(
             '<manifest',
-            "<manifest $package "
+            "<manifest $packageProp "
         )
     }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,7 +10,6 @@ def shouldUseNameSpace = agpVersion >= 7
 def PACKAGE_PROP = "package=\"com.instabug.reactlibrary\""
 def manifestOutFile = file("${projectDir}/src/main/AndroidManifest.xml")
 def manifestContent = manifestOutFile.getText()
-def isManifestContentUpdated = manifestOutFile.getText() != manifestContent
 def isPackageNamespaceMissing = !manifestContent.contains("$PACKAGE_PROP")
 
 String getExtOrDefault(String name) {
@@ -35,13 +34,14 @@ if(shouldUseNameSpace){
 
 manifestContent.replaceAll("  ", " ")
 
+def isManifestContentUpdated = manifestOutFile.getText() != manifestContent
 if(isManifestContentUpdated){
     manifestOutFile.write(manifestContent)
 }
 
 android {
     if (shouldUseNameSpace){
-        namespace = "com.instabug.reactlibrary"
+        namespace "com.instabug.reactlibrary"
     }
     compileSdkVersion getExtOrDefault('compileSdkVersion').toInteger()
     buildToolsVersion getExtOrDefault('buildToolsVersion')

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,14 +4,6 @@ apply from: './jacoco.gradle'
 apply from: './native.gradle'
 apply from: './sourcemaps.gradle'
 
-/* (Preparing to support RN 0.73) Checking APG version to be backward-compatible with RN versions < 0.71 */
-def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
-def shouldUseNameSpace = agpVersion >= 7
-def PACKAGE_PROP = "package=\"com.instabug.reactlibrary\""
-def manifestOutFile = file("${projectDir}/src/main/AndroidManifest.xml")
-def manifestContent = manifestOutFile.getText()
-def isPackageNamespaceMissing = !manifestContent.contains("$PACKAGE_PROP")
-
 String getExtOrDefault(String name) {
     def defaultPropertyKey = 'InstabugReactNative_' + name
     if (rootProject.ext.has(name)) {
@@ -20,29 +12,44 @@ String getExtOrDefault(String name) {
     return project.properties[defaultPropertyKey]
 }
 
-if(shouldUseNameSpace){
-    manifestContent = manifestContent.replaceAll(
-        PACKAGE_PROP,
-        ''
-    )
-} else if(isPackageNamespaceMissing) {
-    manifestContent = manifestContent.replace(
-        '<manifest',
-        "<manifest $PACKAGE_PROP "
-    )
+void supportsNamespace() {
+    def parsed = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')
+    def major = parsed[0].toInteger()
+    def minor = parsed[1].toInteger()
+
+    // Namespace support was added in 7.3.0
+    return (major == 7 && minor >= 3) || major >= 8
 }
 
-manifestContent.replaceAll("  ", " ")
+void updateManifestPackage() {
+    def package = 'package="com.instabug.reactlibrary"'
+    def manifestFile = file("${projectDir}/src/main/AndroidManifest.xml")
+    def currentContent = manifestFile.getText()
+    def content = currentContent
+    def hasPackage = currentContent.contains(package)
 
-def isManifestContentUpdated = manifestOutFile.getText() != manifestContent
-if(isManifestContentUpdated){
-    manifestOutFile.write(manifestContent)
+    if (supportsNamespace()) {
+        content = content.replaceAll(package, '')
+    } else (!hasPackage) {
+        content = content.replace(
+            '<manifest',
+            "<manifest $package "
+        )
+    }
+
+    def shouldUpdateManifest = content != currentContent
+    if (shouldUpdateManifest) {
+        manifestFile.write(content)
+    }
 }
+
+updateManifestPackage()
 
 android {
-    if (shouldUseNameSpace){
+    if (supportsNamespace()) {
         namespace "com.instabug.reactlibrary"
     }
+
     compileSdkVersion getExtOrDefault('compileSdkVersion').toInteger()
     buildToolsVersion getExtOrDefault('buildToolsVersion')
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest package="com.instabug.reactlibrary"
+  xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>
-  


### PR DESCRIPTION
## Description of the change

The current implementation of Android Gradle Plugin >= 7.3.0 namespace support calculates `isManifestContentUpdated` before applying any modifications to the file, so the manifest file was never updated since `isManifestContentUpdated` will always be `false`. The fix was to calculate it right before writing the updates to the file.

I've changed the namespace support condition to check for AGP version >= 7.3 not only >= 7 since `namespace` support was added in v7.3.0. I've also refactored the code into functions and renamed some variables for readability.

I've also kept the `package` property in the initial `AndroidManifest.xml` file since having it removed by default causes the first app build to fail sometimes with apps not using AGP >= 7.3.0, while having it there in the initial run when it's not needed (when using `namespace`) won't cause trouble.

I've tested these changes on React Native `0.66.0` and `0.73.0-rc.3` and its working fine.


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Jira ID: INSD-10287

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
