### PR TITLE
snapshot: resolve package not found and obfuscation issue at `instabug-apm-okhttp-interceptor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased](https://github.com/Instabug/Instabug-React-Native/compare/v12.1.0...dev)
+
+### Fixed
+
+- Fix an issue with Android Gradle Plugin namespace support required for React Native 0.73 and backward compatibility with previous versions ([#1044](https://github.com/Instabug/Instabug-React-Native/pull/1044)).
+
 ## [12.1.0](https://github.com/Instabug/Instabug-React-Native/compare/v12.1.0...v11.14.0)
 
 ### Added

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,15 +4,6 @@ apply from: './jacoco.gradle'
 apply from: './native.gradle'
 apply from: './sourcemaps.gradle'
 
-/* (Preparing to support RN 0.73) Checking APG version to be backward-compatible with RN versions < 0.71 */
-def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
-def shouldUseNameSpace = agpVersion >= 7
-def PACKAGE_PROP = "package=\"com.instabug.reactlibrary\""
-def manifestOutFile = file("${projectDir}/src/main/AndroidManifest.xml")
-def manifestContent = manifestOutFile.getText()
-def isManifestContentUpdated = manifestOutFile.getText() != manifestContent
-def isPackageNamespaceMissing = !manifestContent.contains("$PACKAGE_PROP")
-
 String getExtOrDefault(String name) {
     def defaultPropertyKey = 'InstabugReactNative_' + name
     if (rootProject.ext.has(name)) {
@@ -21,28 +12,44 @@ String getExtOrDefault(String name) {
     return project.properties[defaultPropertyKey]
 }
 
-if(shouldUseNameSpace){
-    manifestContent = manifestContent.replaceAll(
-        PACKAGE_PROP,
-        ''
-    )
-} else if(isPackageNamespaceMissing) {
-    manifestContent = manifestContent.replace(
-        '<manifest',
-        "<manifest $PACKAGE_PROP "
-    )
+static boolean supportsNamespace() {
+    def parsed = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')
+    def major = parsed[0].toInteger()
+    def minor = parsed[1].toInteger()
+
+    // Namespace support was added in 7.3.0
+    return (major == 7 && minor >= 3) || major >= 8
 }
 
-manifestContent.replaceAll("  ", " ")
+void updateManifestPackage() {
+    def packageProp = 'package="com.instabug.reactlibrary"'
+    def manifestFile = file("$projectDir/src/main/AndroidManifest.xml")
+    def currentContent = manifestFile.getText()
+    def content = currentContent
+    def hasPackage = currentContent.contains(packageProp)
 
-if(isManifestContentUpdated){
-    manifestOutFile.write(manifestContent)
+    if (supportsNamespace()) {
+        content = content.replaceAll(packageProp, '')
+    } else if (!hasPackage) {
+        content = content.replace(
+            '<manifest',
+            "<manifest $packageProp "
+        )
+    }
+
+    def shouldUpdateManifest = content != currentContent
+    if (shouldUpdateManifest) {
+        manifestFile.write(content)
+    }
 }
+
+updateManifestPackage()
 
 android {
-    if (shouldUseNameSpace){
-        namespace = "com.instabug.reactlibrary"
+    if (supportsNamespace()) {
+        namespace "com.instabug.reactlibrary"
     }
+
     compileSdkVersion getExtOrDefault('compileSdkVersion').toInteger()
     buildToolsVersion getExtOrDefault('buildToolsVersion')
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,12 +13,12 @@ String getExtOrDefault(String name) {
 }
 
 static boolean supportsNamespace() {
-    def parsed = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')
-    def major = parsed[0].toInteger()
-    def minor = parsed[1].toInteger()
+//    def parsed = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')
+//    def major = parsed[0].toInteger()
+//    def minor = parsed[1].toInteger()
 
-    // Namespace support was added in 7.3.0
-    return (major == 7 && minor >= 3) || major >= 8
+    // Namespace support was added in 7.3.0 (disabled for now)
+    return false
 }
 
 void updateManifestPackage() {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,6 +4,17 @@ apply from: './jacoco.gradle'
 apply from: './native.gradle'
 apply from: './sourcemaps.gradle'
 
+
+rootProject.allprojects {
+    repositories {
+        google()
+        jcenter()
+        maven {
+            url 'https://oss.sonatype.org/content/repositories/snapshots'
+        }
+    }
+}
+
 String getExtOrDefault(String name) {
     def defaultPropertyKey = 'InstabugReactNative_' + name
     if (rootProject.ext.has(name)) {

--- a/android/native.gradle
+++ b/android/native.gradle
@@ -1,5 +1,5 @@
 project.ext.instabug = [
-    version: '12.1.0'
+    version: '12.2.0.5390171-SNAPSHOT'
 ]
 
 dependencies {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest package="com.instabug.reactlibrary"
+  xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>
-  


### PR DESCRIPTION
## Description of the change

Integrate android snapshot which fixes the obfuscation issue error at `instabug-apm-okhttp-interceptor` which caused conflicts with other SDKs. [Android PR](https://github.com/Instabug/android/pull/5390)

Remove AGP `namespace` support (temporarily) only for this snapshot, till we further inquire why the client is facing issues. As their version of AGP `v7.3.0` shouldn't require package name and should be satisfied with the `namespace`.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues
- [INSD-10355](https://instabug.atlassian.net/browse/INSD-10355)
- [INSD-10354](https://instabug.atlassian.net/browse/INSD-10354)



## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request


[INSD-10355]: https://instabug.atlassian.net/browse/INSD-10355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INSD-10354]: https://instabug.atlassian.net/browse/INSD-10354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ