### PR TITLE
chore(ios): sync JavaScript fatal crashes through promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fix an issue with Android Gradle Plugin namespace support required for React Native 0.73 and backward compatibility with previous versions ([#1044](https://github.com/Instabug/Instabug-React-Native/pull/1044)).
+- Fix an issue with unhandled JavaScript crashes being reported as native iOS crashes ([#1054](https://github.com/Instabug/Instabug-React-Native/pull/1054))
 
 ## [12.1.0](https://github.com/Instabug/Instabug-React-Native/compare/v12.1.0...v11.14.0)
 

--- a/ios/RNInstabug/InstabugCrashReportingBridge.m
+++ b/ios/RNInstabug/InstabugCrashReportingBridge.m
@@ -26,23 +26,29 @@ RCT_EXPORT_METHOD(setEnabled: (BOOL) isEnabled) {
     IBGCrashReporting.enabled = isEnabled;
 }
 
-RCT_EXPORT_METHOD(sendJSCrash:(NSDictionary *)stackTrace) {
+RCT_EXPORT_METHOD(sendJSCrash:(NSDictionary *)stackTrace
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
     dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0ul);
     dispatch_async(queue, ^{
         SEL reportCrashWithStackTraceSEL = NSSelectorFromString(@"reportCrashWithStackTrace:handled:");
         if ([[Instabug class] respondsToSelector:reportCrashWithStackTraceSEL]) {
             [[Instabug class] performSelector:reportCrashWithStackTraceSEL withObject:stackTrace withObject:@(NO)];
         }
+        resolve([NSNull null]);
     });
 }
 
-RCT_EXPORT_METHOD(sendHandledJSCrash:(NSDictionary *)stackTrace) {
+RCT_EXPORT_METHOD(sendHandledJSCrash:(NSDictionary *)stackTrace
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
     dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0ul);
     dispatch_async(queue, ^{
         SEL reportCrashWithStackTraceSEL = NSSelectorFromString(@"reportCrashWithStackTrace:handled:");
         if ([[Instabug class] respondsToSelector:reportCrashWithStackTraceSEL]) {
             [[Instabug class] performSelector:reportCrashWithStackTraceSEL withObject:stackTrace withObject:@(YES)];
         }
+        resolve([NSNull null]);
     });
 }
 

--- a/src/modules/CrashReporting.ts
+++ b/src/modules/CrashReporting.ts
@@ -17,5 +17,5 @@ export const setEnabled = (isEnabled: boolean) => {
  * @param error Error object to be sent to Instabug's servers
  */
 export const reportError = (error: ExtendedError) => {
-  InstabugUtils.sendCrashReport(error, NativeCrashReporting.sendHandledJSCrash);
+  return InstabugUtils.sendCrashReport(error, NativeCrashReporting.sendHandledJSCrash);
 };

--- a/src/native/NativeCrashReporting.ts
+++ b/src/native/NativeCrashReporting.ts
@@ -14,8 +14,8 @@ export interface CrashData {
 
 export interface CrashReportingNativeModule extends NativeModule {
   setEnabled(isEnabled: boolean): void;
-  sendJSCrash(data: CrashData | string): void;
-  sendHandledJSCrash(data: CrashData | string): void;
+  sendJSCrash(data: CrashData | string): Promise<void>;
+  sendHandledJSCrash(data: CrashData | string): Promise<void>;
 }
 
 export const NativeCrashReporting = NativeModules.IBGCrashReporting;


### PR DESCRIPTION
## Description of the change

Synchronize crash reporting fatal (unhandled) crashes with the iOS SDK through `Promise`s instead of assuming the JavaScript-native call is sync (and it's not).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Jira ID: MOB-13245

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
