### PR TITLE
fix(ios): enable screenshots for crashes & sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Fix an issue with Android Gradle Plugin namespace support required for React Native 0.73 and backward compatibility with previous versions ([#1044](https://github.com/Instabug/Instabug-React-Native/pull/1044)).
 - Fix an issue with unhandled JavaScript crashes being reported as native iOS crashes ([#1054](https://github.com/Instabug/Instabug-React-Native/pull/1054))
+- Re-enable screenshot capturing for Crash Reporting and Session Replay by removing redundant mapping ([#1055](https://github.com/Instabug/Instabug-React-Native/pull/1055)).
 
 ## [12.1.0](https://github.com/Instabug/Instabug-React-Native/compare/v12.1.0...v11.14.0)
 

--- a/src/modules/Instabug.ts
+++ b/src/modules/Instabug.ts
@@ -328,15 +328,6 @@ export const setReproStepsConfig = (config: ReproConfig) => {
     sessionReplay = config.all;
   }
 
-  // There's an issue with crashes repro steps with screenshots in the iOS SDK
-  // at the moment, so we'll map enabled with screenshots to enabled with no
-  // screenshots to avoid storing the images on disk if it's not needed until
-  // this issue is fixed in a future version.
-  if (Platform.OS === 'ios' && crash === ReproStepsMode.enabled) {
-    /* istanbul ignore next */
-    crash = ReproStepsMode.enabledWithNoScreenshots;
-  }
-
   NativeInstabug.setReproStepsConfig(bug, crash, sessionReplay);
 };
 


### PR DESCRIPTION
## Description of the change

Remove unnecessary mapping that mapped ReproStepsMode.enabled to ReproStepsMode.enabledWithNoScreenshots for iOS platform. This workaround was added due to an [issue](https://instabug.atlassian.net/browse/IBGCRASH-19924) with crashes repro steps with screenshots in the iOS SDK, and now it's no longer needed as the issue has been resolved. This re-enabled it for Crash Reporting and Session Replay.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Jira ID: [IBGCRASH-20555](https://instabug.atlassian.net/browse/IBGCRASH-20555)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request


[IBGCRASH-20555]: https://instabug.atlassian.net/browse/IBGCRASH-20555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ