### PR TITLE
fix: sync android fatal crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Fix an issue with Android Gradle Plugin namespace support required for React Native 0.73 and backward compatibility with previous versions ([#1044](https://github.com/Instabug/Instabug-React-Native/pull/1044)).
 - Fix an issue with unhandled JavaScript crashes being reported as native iOS crashes ([#1054](https://github.com/Instabug/Instabug-React-Native/pull/1054))
 - Re-enable screenshot capturing for Crash Reporting and Session Replay by removing redundant mapping ([#1055](https://github.com/Instabug/Instabug-React-Native/pull/1055)).
+- Fix an issue with unhandled JavaScript crashes being reported as native Android crashes ([#1059](https://github.com/Instabug/Instabug-React-Native/pull/1059))
+
 
 ## [12.1.0](https://github.com/Instabug/Instabug-React-Native/compare/v12.1.0...v11.14.0)
 

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugCrashReportingModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugCrashReportingModule.java
@@ -2,6 +2,7 @@ package com.instabug.reactlibrary;
 
 import static com.instabug.reactlibrary.utils.InstabugUtil.getMethod;
 
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -52,32 +53,38 @@ public class RNInstabugCrashReportingModule extends ReactContextBaseJavaModule {
     }
 
     /**
-     * Send unhandled JS error object
+     * Send unhandled JS error object using reflection
      *
      * @param exceptionObject Exception object to be sent to Instabug's servers
+     * @param promise A Promise object for handling the asynchronous result of the operation.
      */
     @ReactMethod
-    public void sendJSCrash(final String exceptionObject) {
+    public void sendJSCrash(final String exceptionObject, final Promise promise) {
         try {
             JSONObject jsonObject = new JSONObject(exceptionObject);
             sendJSCrashByReflection(jsonObject, false);
+            promise.resolve(null);
         } catch (Exception e) {
             e.printStackTrace();
+            promise.reject("IBG_CRASH", "sendJSCrash: Error sending JS crash", e);
         }
     }
 
     /**
-     * Send handled JS error object
+     * Send handled JS error object using reflection
      *
      * @param exceptionObject Exception object to be sent to Instabug's servers
+     * @param promise A Promise object for handling the asynchronous result of the operation.
      */
     @ReactMethod
-    public void sendHandledJSCrash(final String exceptionObject) {
+    public void sendHandledJSCrash(final String exceptionObject, final Promise promise) {
         try {
             JSONObject jsonObject = new JSONObject(exceptionObject);
             sendJSCrashByReflection(jsonObject, true);
+            promise.resolve(null);
         } catch (Exception e) {
             e.printStackTrace();
+            promise.reject("IBG_CRASH", "sendHandledJSCrash: Error sending Handled JS crash", e);
         }
     }
 

--- a/src/utils/InstabugUtils.ts
+++ b/src/utils/InstabugUtils.ts
@@ -78,13 +78,7 @@ export const captureJsErrors = () => {
       return;
     }
 
-    if (Platform.OS === 'android') {
-      setTimeout(() => {
-        originalErrorHandler(err, isFatal);
-      }, 500);
-    } else {
-      originalErrorHandler(err, isFatal);
-    }
+    originalErrorHandler(err, isFatal);
   });
 };
 


### PR DESCRIPTION
## Description of the change

Synchronize crash reporting fatal (unhandled) crashes with the Android SDK through Promises instead of assuming the JavaScript-native call is sync (and it's not).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Jira ID: [MOB-13248](https://instabug.atlassian.net/browse/MOB-13248)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request


[MOB-13248]: https://instabug.atlassian.net/browse/MOB-13248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ