### PR TITLE
Snapshot/12.1.0 insd 10354

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,12 +13,12 @@ String getExtOrDefault(String name) {
 }
 
 static boolean supportsNamespace() {
-    def parsed = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')
-    def major = parsed[0].toInteger()
-    def minor = parsed[1].toInteger()
+//    def parsed = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')
+//    def major = parsed[0].toInteger()
+//    def minor = parsed[1].toInteger()
 
-    // Namespace support was added in 7.3.0
-    return (major == 7 && minor >= 3) || major >= 8
+    // Namespace support was added in 7.3.0 (disabled for now)
+    return false
 }
 
 void updateManifestPackage() {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,6 +4,17 @@ apply from: './jacoco.gradle'
 apply from: './native.gradle'
 apply from: './sourcemaps.gradle'
 
+
+rootProject.allprojects {
+    repositories {
+        google()
+        jcenter()
+        maven {
+            url 'https://oss.sonatype.org/content/repositories/snapshots'
+        }
+    }
+}
+
 String getExtOrDefault(String name) {
     def defaultPropertyKey = 'InstabugReactNative_' + name
     if (rootProject.ext.has(name)) {

--- a/android/native.gradle
+++ b/android/native.gradle
@@ -1,5 +1,5 @@
 project.ext.instabug = [
-    version: '12.1.0'
+    version: '12.2.0.5390171-SNAPSHOT'
 ]
 
 dependencies {

--- a/android/native.gradle
+++ b/android/native.gradle
@@ -1,5 +1,5 @@
 project.ext.instabug = [
-    version: '12.2.0.5390171-SNAPSHOT'
+    version: '12.2.0.5428088-SNAPSHOT'
 ]
 
 dependencies {


### PR DESCRIPTION
## Description of the change

Snapshot for dream11 integrating both obfuscation issue solution as well as early crashes support.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

- [[Bug][IBGCRASH-20553] Fixing crashes early capturing. #5412](https://github.com/Instabug/android/pull/5412)
- [[INSD-10355] Fix obfuscation issue at instabug-apm-okhttp-interceptor #5390](https://github.com/Instabug/android/pull/5390)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request


[IBGCRASH-20553]: https://instabug.atlassian.net/browse/IBGCRASH-20553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INSD-10355]: https://instabug.atlassian.net/browse/INSD-10355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ