### PR TITLE
chore: remove danger plugin for snapshot generation.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,7 +367,6 @@ workflows:
       - e2e_android
       - hold_generate_snapshot:
           type: approval
-          requires: *release_dependencies
       - generate_snapshot:
           requires:
             - hold_generate_snapshot

--- a/RNInstabug.podspec
+++ b/RNInstabug.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm}"
 
   s.dependency 'React-Core'
-  use_instabug!(s)
+  s.dependency 'Instabug'
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,12 +24,12 @@ String getExtOrDefault(String name) {
 }
 
 static boolean supportsNamespace() {
-    def parsed = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')
-    def major = parsed[0].toInteger()
-    def minor = parsed[1].toInteger()
+//    def parsed = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')
+//    def major = parsed[0].toInteger()
+//    def minor = parsed[1].toInteger()
 
-    // Namespace support was added in 7.3.0
-    return (major == 7 && minor >= 3) || major >= 8
+    // Namespace support was added in 7.3.0 (disabled for now)
+    return false
 }
 
 void updateManifestPackage() {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,6 +4,17 @@ apply from: './jacoco.gradle'
 apply from: './native.gradle'
 apply from: './sourcemaps.gradle'
 
+
+rootProject.allprojects {
+    repositories {
+        google()
+        jcenter()
+        maven {
+            url 'https://oss.sonatype.org/content/repositories/snapshots'
+        }
+    }
+}
+
 String getExtOrDefault(String name) {
     def defaultPropertyKey = 'InstabugReactNative_' + name
     if (rootProject.ext.has(name)) {

--- a/android/native.gradle
+++ b/android/native.gradle
@@ -1,5 +1,5 @@
 project.ext.instabug = [
-    version: '12.2.0.5448807-SNAPSHOT'
+    version: '12.3.1.5466421-SNAPSHOT'
 ]
 
 dependencies {

--- a/android/native.gradle
+++ b/android/native.gradle
@@ -1,5 +1,5 @@
 project.ext.instabug = [
-    version: '12.2.0.5428088-SNAPSHOT'
+    version: '12.2.0.5448807-SNAPSHOT'
 ]
 
 dependencies {

--- a/android/native.gradle
+++ b/android/native.gradle
@@ -1,5 +1,5 @@
 project.ext.instabug = [
-    version: '12.2.0'
+    version: '12.2.0.5390171-SNAPSHOT'
 ]
 
 dependencies {

--- a/android/native.gradle
+++ b/android/native.gradle
@@ -1,5 +1,5 @@
 project.ext.instabug = [
-    version: '12.2.0.5390171-SNAPSHOT'
+    version: '12.2.0.5428088-SNAPSHOT'
 ]
 
 dependencies {

--- a/examples/default/ios/Podfile
+++ b/examples/default/ios/Podfile
@@ -26,7 +26,7 @@ target 'InstabugExample' do
 
   # Flags change depending on the env values.
   flags = get_default_flags()
-
+  pod ‘Instabug’, :podspec => ’https://ios-releases.instabug.com/custom/fix_crashes_screenshot_attachments_pods/12.2.0/Instabug.podspec'
   use_react_native!(
     :path => config[:reactNativePath],
     # Hermes is now enabled by default. Disable by setting this flag to false.

--- a/examples/default/ios/Podfile.lock
+++ b/examples/default/ios/Podfile.lock
@@ -490,7 +490,7 @@ PODS:
     - React-logger (= 0.72.3)
     - React-perflogger (= 0.72.3)
   - RNInstabug (12.2.0):
-    - Instabug (= 12.2.0)
+    - Instabug
     - React-Core
   - RNScreens (3.24.0):
     - React-Core
@@ -531,6 +531,7 @@ DEPENDENCIES:
   - FlipperKit/SKIOSNetworkPlugin (= 0.182.0)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
+  - Instabug (from `https://ios-releases.instabug.com/custom/fix_crashes_screenshot_attachments_pods/12.2.0/Instabug.podspec`)
   - libevent (~> 2.1.12)
   - OCMock
   - OpenSSL-Universal (= 1.1.1100)
@@ -587,7 +588,6 @@ SPEC REPOS:
     - Flipper-PeerTalk
     - FlipperKit
     - fmt
-    - Instabug
     - libevent
     - OCMock
     - OpenSSL-Universal
@@ -608,6 +608,8 @@ EXTERNAL SOURCES:
   hermes-engine:
     :podspec: "../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec"
     :tag: hermes-2023-03-20-RNv0.72.0-49794cfc7c81fb8f69fd60c3bbf85a7480cc5a77
+  Instabug:
+    :podspec: https://ios-releases.instabug.com/custom/fix_crashes_screenshot_attachments_pods/12.2.0/Instabug.podspec
   RCT-Folly:
     :podspec: "../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTRequired:
@@ -702,7 +704,7 @@ SPEC CHECKSUMS:
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: 10fbd3f62405c41ea07e71973ea61e1878d07322
-  Instabug: 3eb90033224ef6b072ab9b2e739f62fe88a7edaa
+  Instabug: 9810332cc836f15363c6139d815dab3f99a7bf15
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OCMock: 9491e4bec59e0b267d52a9184ff5605995e74be8
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
@@ -739,7 +741,7 @@ SPEC CHECKSUMS:
   React-runtimescheduler: 837c1bebd2f84572db17698cd702ceaf585b0d9a
   React-utils: bcb57da67eec2711f8b353f6e3d33bd8e4b2efa3
   ReactCommon: 3ccb8fb14e6b3277e38c73b0ff5e4a1b8db017a9
-  RNInstabug: 6dc3a605bd4e9cf8fa8c170405cbceef8e2d457a
+  RNInstabug: 012b859e28e68ba275d2cd58b44ff997431d065f
   RNScreens: b21dc57dfa2b710c30ec600786a3fc223b1b92e7
   RNSVG: 80584470ff1ffc7994923ea135a3e5ad825546b9
   RNVectorIcons: 8b5bb0fa61d54cd2020af4f24a51841ce365c7e9
@@ -747,6 +749,6 @@ SPEC CHECKSUMS:
   Yoga: 8796b55dba14d7004f980b54bcc9833ee45b28ce
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: d169b4508f413ff5d69cdf38428960e0828e6282
+PODFILE CHECKSUM: f7940f1a1d813eda921bb2171b9e5376b9e829b5
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
## Description of the change

Dream 11 snapshot (all fixes)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

- [\[IBGCRASH-20553\] Early capture is not properly working](https://instabug.atlassian.net/browse/IBGCRASH-20553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ) 
	- [Android PR | Fixing crashes early capturing](https://github.com/Instabug/android/pull/5412)
- [\[Dream11\] Build failed when updating SDK version (AND)](https://instabug.atlassian.net/browse/INSD-10355) 
	- [Android PR | Fix obfuscation issue at instabug-apm-okhttp-interceptor](https://github.com/Instabug/android/pull/5390)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
