### PR TITLE
fix(android): get application through react context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased](https://github.com/Instabug/Instabug-React-Native/compare/v12.2.0...dev)
+
+### Fixed
+
+- Fix an issue with `Instabug.init` on Android causing the app to crash while trying to get the current `Application` instance through the current activity which can be `null` in some cases by utilizing the React context instead ([#1069](https://github.com/Instabug/Instabug-React-Native/pull/1069)).
+
 ## [12.2.0](https://github.com/Instabug/Instabug-React-Native/compare/v12.2.0...v12.1.0)
 
 ### Added

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
@@ -2,6 +2,7 @@ package com.instabug.reactlibrary;
 
 import static com.instabug.reactlibrary.utils.InstabugUtil.getMethod;
 
+import android.app.Application;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.view.View;
@@ -59,6 +60,7 @@ public class RNInstabugReactnativeModule extends EventEmitterModule {
 
     private InstabugCustomTextPlaceHolder placeHolders;
     private static Report currentReport;
+    private final ReactApplicationContext reactContext;
 
     /**
      * Instantiates a new Rn Instabug ReactNative module.
@@ -67,6 +69,9 @@ public class RNInstabugReactnativeModule extends EventEmitterModule {
      */
     public RNInstabugReactnativeModule(ReactApplicationContext reactContext) {
         super(reactContext);
+
+        this.reactContext = reactContext;
+
         //init placeHolders
         placeHolders = new InstabugCustomTextPlaceHolder();
     }
@@ -122,7 +127,10 @@ public class RNInstabugReactnativeModule extends EventEmitterModule {
                 final ArrayList<InstabugInvocationEvent> parsedInvocationEvents = ArgsRegistry.invocationEvents.getAll(keys);
                 final InstabugInvocationEvent[] invocationEvents = parsedInvocationEvents.toArray(new InstabugInvocationEvent[0]);
                 final int parsedLogLevel = ArgsRegistry.sdkLogLevels.getOrDefault(logLevel, LogLevel.ERROR);
-                RNInstabug.getInstance().init(getCurrentActivity().getApplication(), token, parsedLogLevel, invocationEvents);
+
+                final Application application = (Application) reactContext.getApplicationContext();
+
+                RNInstabug.getInstance().init(application, token, parsedLogLevel, invocationEvents);
             }
         });
     }


### PR DESCRIPTION
## Description of the change

Get the Android `Application` instance when initializing the SDK through the `reactContext` instead of `getCurrentActivity` since it can be `null` sometimes causing the SDK to crash.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Jira ID: [\[INSD-10472\] \[Dream11\] Feature flag crashing IBG library ](https://instabug.atlassian.net/browse/INSD-10472)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request
