### PR TITLE
chore(android): sync JS fatal crashes via promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fix an issue with `Instabug.init` on Android causing the app to crash while trying to get the current `Application` instance through the current activity which can be `null` in some cases by utilizing the React context instead ([#1069](https://github.com/Instabug/Instabug-React-Native/pull/1069)).
+- Fix an issue with unhandled JavaScript crashes not getting linked with the current session causing inaccurate session metrics ([#1071](https://github.com/Instabug/Instabug-React-Native/pull/1071)).
 
 ## [12.2.0](https://github.com/Instabug/Instabug-React-Native/compare/v12.2.0...v12.1.0)
 

--- a/src/utils/InstabugUtils.ts
+++ b/src/utils/InstabugUtils.ts
@@ -77,14 +77,7 @@ export const captureJsErrors = () => {
     if (process.env.JEST_WORKER_ID) {
       return;
     }
-
-    if (Platform.OS === 'android') {
-      setTimeout(() => {
-        originalErrorHandler(err, isFatal);
-      }, 500);
-    } else {
-      originalErrorHandler(err, isFatal);
-    }
+    originalErrorHandler(err, isFatal);
   });
 };
 


### PR DESCRIPTION
## Description of the change

Wait for Android SDK to process the crash by waiting for `sendJSCrashByReflection` to finish before we crash the app.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Jira ID: MOB-13312

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request

### Testing scenarios
- Test that an unhandled fatal crash is sent normally after relaunch