### PR TITLE
fix(android): resolve `JsonException` handling error

### DIFF
--- a/android/src/main/java/com/instabug/reactlibrary/utils/ReportUtil.java
+++ b/android/src/main/java/com/instabug/reactlibrary/utils/ReportUtil.java
@@ -70,7 +70,7 @@ public class ReportUtil {
         for(int i = 0; i < consoleLogs.size(); i++) {
             try {
                 writableArray.pushString(consoleLogs.get(i).toJson());
-            } catch (JSONException e) {
+            } catch (Exception e) {
                 e.printStackTrace();
             }
 


### PR DESCRIPTION
## Description of the change

Update exception handling in parseConsoleLogs method to resolve the error related to JSON serialization exceptions. Modify the try-catch block to handle potential JSON exceptions effectively using a wider exceptions type.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Jira ID: MOB-13598

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
