### PR TITLE
chore(android): add Instabug API domains to network security config

### DIFF
--- a/examples/default/android/app/src/main/res/xml/network_security_config.xml
+++ b/examples/default/android/app/src/main/res/xml/network_security_config.xml
@@ -3,6 +3,8 @@
     <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="true">10.0.2.2</domain>
         <domain includeSubdomains="true">localhost</domain>
+        <domain includeSubdomains="true">api.instabug.com</domain>
+        <domain includeSubdomains="true">api-apm.instabug.com</domain>
     </domain-config>
     <base-config>
         <trust-anchors>


### PR DESCRIPTION
## Description of the change

Add Instabug API domains to network security config, in order to allow remote mapping for testing purposes.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Jira ID: MOB-13665

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
