### PR TITLE
fix: dream11 package name in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,7 +298,7 @@ jobs:
           command: rm README.md
       - search_and_replace:
           file: package.json
-          replace-pattern: 's/instabug-reactnative/@instabug\/react-native-dream11/g'
+          replace-pattern: 's/instabug-reactnative/@instabug\/instabug-reactnative-dream11/g'
       - search_and_replace:
           file: android/native.gradle
           replace-pattern: 's/com\.instabug\.library:instabug:/com.instabug.library-dream11:instabug:/g'


### PR DESCRIPTION
## Description of the change

1. fix d11 package name in CI

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues


## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
