### PR TITLE
fix(Android):  codepush version init in hybrid mode 

### DIFF
--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
@@ -144,7 +144,11 @@ public class RNInstabugReactnativeModule extends EventEmitterModule {
                         .setLogLevel(parsedLogLevel);
 
                 if(codePushVersion != null) {
-                    builder.setCodePushVersion(codePushVersion);
+                    if(Instabug.isBuilt()) {
+                        Instabug.setCodePushVersion(codePushVersion);
+                    } else {
+                        builder.setCodePushVersion(codePushVersion);
+                    }
                 }
                 builder.build();
             }


### PR DESCRIPTION
## Description of the change
    1. Fix set codepush version in hybrid apps by
       1. if SDK is initialized before then use setCodePushVersion
       2. if SDK hasn't  initialized yet then set Codepush version using Builderbuilder.setCodePushVersion
    
## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues
Jira ID:  [MOB-13727](https://instabug.atlassian.net/browse/MOB-13727)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request


[MOB-13727]: https://instabug.atlassian.net/browse/MOB-13727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ