### PR TITLE
feat: support switching to native network interception

### DIFF
--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
@@ -127,6 +127,7 @@ public class RNInstabugReactnativeModule extends EventEmitterModule {
             final String token,
             final ReadableArray invocationEventValues,
             final String logLevel,
+            final boolean useNativeNetworkInterception,
             @Nullable final String codePushVersion
     ) {
         MainThreadHandler.runOnMainThread(new Runnable() {

--- a/examples/default/ios/InstabugTests/InstabugSampleTests.m
+++ b/examples/default/ios/InstabugTests/InstabugSampleTests.m
@@ -78,7 +78,7 @@
   [self.instabugBridge init:appToken invocationEvents:invocationEvents debugLogsLevel:sdkDebugLogsLevel useNativeNetworkInterception:useNativeNetworkInterception codePushVersion:codePushVersion];
   OCMVerify([mock setCodePushVersion:codePushVersion]);
 
-  OCMVerify([self.mRNInstabug initWithToken:appToken invocationEvents:floatingButtonInvocationEvent debugLogsLevel:sdkDebugLogsLevel]);
+  OCMVerify([self.mRNInstabug initWithToken:appToken invocationEvents:floatingButtonInvocationEvent debugLogsLevel:sdkDebugLogsLevel useNativeNetworkInterception:useNativeNetworkInterception]);
 }
 
 - (void)testSetUserData {

--- a/examples/default/ios/InstabugTests/InstabugSampleTests.m
+++ b/examples/default/ios/InstabugTests/InstabugSampleTests.m
@@ -70,11 +70,12 @@
   NSString *appToken = @"app_token";
   NSString *codePushVersion = @"1.0.0(1)";
   NSArray *invocationEvents = [NSArray arrayWithObjects:[NSNumber numberWithInteger:floatingButtonInvocationEvent], nil];
+  BOOL useNativeNetworkInterception = YES;
   IBGSDKDebugLogsLevel sdkDebugLogsLevel = IBGSDKDebugLogsLevelDebug;
   
   OCMStub([mock setCodePushVersion:codePushVersion]);
 
-  [self.instabugBridge init:appToken invocationEvents:invocationEvents debugLogsLevel:sdkDebugLogsLevel codePushVersion:codePushVersion];
+  [self.instabugBridge init:appToken invocationEvents:invocationEvents debugLogsLevel:sdkDebugLogsLevel useNativeNetworkInterception:useNativeNetworkInterception codePushVersion:codePushVersion];
   OCMVerify([mock setCodePushVersion:codePushVersion]);
 
   OCMVerify([self.mRNInstabug initWithToken:appToken invocationEvents:floatingButtonInvocationEvent debugLogsLevel:sdkDebugLogsLevel]);

--- a/examples/default/ios/InstabugTests/RNInstabugTests.m
+++ b/examples/default/ios/InstabugTests/RNInstabugTests.m
@@ -41,6 +41,19 @@
   OCMVerify([self.mIBGNetworkLogger setEnabled:YES]);
 }
 
+- (void)testInitWithNativeNetworkInterception {
+  NSString *token = @"app-token";
+  IBGInvocationEvent invocationEvents = IBGInvocationEventFloatingButton | IBGInvocationEventShake;
+  BOOL useNativeNetworkInterception = YES;
+
+  [RNInstabug initWithToken:token invocationEvents:invocationEvents useNativeNetworkInterception:useNativeNetworkInterception];
+
+  OCMVerify([self.mInstabug startWithToken:token invocationEvents:invocationEvents]);
+  OCMVerify([self.mInstabug setCurrentPlatform:IBGPlatformReactNative]);
+  OCMVerify(never(), [self.mIBGNetworkLogger disableAutomaticCapturingOfNetworkLogs]);
+  OCMVerify([self.mIBGNetworkLogger setEnabled:YES]);
+}
+
 - (void)testInitWithLogsLevel {
   NSString *token = @"app-token";
   IBGInvocationEvent invocationEvents = IBGInvocationEventFloatingButton | IBGInvocationEventShake;

--- a/ios/RNInstabug/InstabugReactBridge.h
+++ b/ios/RNInstabug/InstabugReactBridge.h
@@ -27,7 +27,7 @@
 
 - (void)setEnabled:(BOOL)isEnabled;
 
-- (void)init:(NSString *)token invocationEvents:(NSArray *)invocationEventsArray debugLogsLevel:(IBGSDKDebugLogsLevel)sdkDebugLogsLevel codePushVersion:(NSString *)codePushVersion;
+- (void)init:(NSString *)token invocationEvents:(NSArray *)invocationEventsArray debugLogsLevel:(IBGSDKDebugLogsLevel)sdkDebugLogsLevel useNativeNetworkInterception:(BOOL)useNativeNetworkInterception codePushVersion:(NSString *)codePushVersion;
 
 - (void)setUserData:(NSString *)userData;
 

--- a/ios/RNInstabug/InstabugReactBridge.m
+++ b/ios/RNInstabug/InstabugReactBridge.m
@@ -40,6 +40,7 @@ RCT_EXPORT_METHOD(setEnabled:(BOOL)isEnabled) {
 RCT_EXPORT_METHOD(init:(NSString *)token
           invocationEvents:(NSArray *)invocationEventsArray
           debugLogsLevel:(IBGSDKDebugLogsLevel)sdkDebugLogsLevel
+          useNativeNetworkInterception:(BOOL)useNativeNetworkInterception
           codePushVersion:(NSString *)codePushVersion) {
     IBGInvocationEvent invocationEvents = 0;
 
@@ -51,7 +52,8 @@ RCT_EXPORT_METHOD(init:(NSString *)token
 
     [RNInstabug initWithToken:token
              invocationEvents:invocationEvents
-               debugLogsLevel:sdkDebugLogsLevel];
+               debugLogsLevel:sdkDebugLogsLevel
+ useNativeNetworkInterception:useNativeNetworkInterception];
 }
 
 RCT_EXPORT_METHOD(setReproStepsConfig:(IBGUserStepsMode)bugMode :(IBGUserStepsMode)crashMode:(IBGUserStepsMode)sessionReplayMode) {

--- a/ios/RNInstabug/RNInstabug.h
+++ b/ios/RNInstabug/RNInstabug.h
@@ -6,6 +6,14 @@
 @interface RNInstabug : NSObject
 
 + (void)initWithToken:(NSString *)token invocationEvents:(IBGInvocationEvent)invocationEvents debugLogsLevel:(IBGSDKDebugLogsLevel)debugLogsLevel;
+
++ (void)initWithToken:(NSString *)token invocationEvents:(IBGInvocationEvent)invocationEvents debugLogsLevel:(IBGSDKDebugLogsLevel)debugLogsLevel
+useNativeNetworkInterception:(BOOL)useNativeNetworkInterception;
+
++ (void)initWithToken:(NSString *)token
+     invocationEvents:(IBGInvocationEvent)invocationEvents
+useNativeNetworkInterception:(BOOL)useNativeNetworkInterception;
+
 + (void)initWithToken:(NSString *)token invocationEvents:(IBGInvocationEvent)invocationEvents;
 
 /**

--- a/ios/RNInstabug/RNInstabug.m
+++ b/ios/RNInstabug/RNInstabug.m
@@ -13,15 +13,19 @@ static BOOL didInit = NO;
     didInit = NO;
 }
 
-+ (void)initWithToken:(NSString *)token invocationEvents:(IBGInvocationEvent)invocationEvents  {
++ (void)initWithToken:(NSString *)token
+     invocationEvents:(IBGInvocationEvent)invocationEvents
+useNativeNetworkInterception:(BOOL)useNativeNetworkInterception {
 
     didInit = YES;
 
     [Instabug setCurrentPlatform:IBGPlatformReactNative];
 
-    // Disable automatic network logging in the iOS SDK to avoid duplicate network logs coming
-    // from both the iOS and React Native SDKs
-    [IBGNetworkLogger disableAutomaticCapturingOfNetworkLogs];
+    if (!useNativeNetworkInterception) {
+        // Disable automatic network logging in the iOS SDK to avoid duplicate network logs coming
+        // from both the iOS and React Native SDKs
+        [IBGNetworkLogger disableAutomaticCapturingOfNetworkLogs];
+    }
 
     [Instabug startWithToken:token invocationEvents:invocationEvents];
 
@@ -35,6 +39,15 @@ static BOOL didInit = NO;
 
     // Temporarily disabling APM hot launches
     IBGAPM.hotAppLaunchEnabled = NO;
+}
+
++ (void)initWithToken:(NSString *)token invocationEvents:(IBGInvocationEvent)invocationEvents {
+    [self initWithToken:token invocationEvents:invocationEvents useNativeNetworkInterception:NO];
+}
+
++ (void)initWithToken:(NSString *)token invocationEvents:(IBGInvocationEvent)invocationEvents debugLogsLevel:(IBGSDKDebugLogsLevel)debugLogsLevel useNativeNetworkInterception:(BOOL)useNativeNetworkInterception {
+    [Instabug setSdkDebugLogsLevel:debugLogsLevel];
+    [self initWithToken:token invocationEvents:invocationEvents useNativeNetworkInterception:useNativeNetworkInterception];
 }
 
 + (void)initWithToken:(NSString *)token

--- a/src/models/InstabugConfig.ts
+++ b/src/models/InstabugConfig.ts
@@ -1,4 +1,4 @@
-import type { InvocationEvent, LogLevel } from '../utils/Enums';
+import type { InvocationEvent, LogLevel, NetworkInterceptionMode } from '../utils/Enums';
 
 export interface InstabugConfig {
   /**
@@ -18,4 +18,15 @@ export interface InstabugConfig {
    * An optional code push version to be used for all reports.
    */
   codePushVersion?: string;
+
+  /**
+   * An optional network interception mode, this determines whether network interception
+   * is done in the JavaScript side or in the native Android and iOS SDK side.
+   *
+   * When set to `NetworkInterceptionMode.native`, configuring network logging
+   * should be done through native code not JavaScript (e.g. network request obfuscation).
+   *
+   * @default NetworkInterceptionMode.javascript
+   */
+  networkInterceptionMode?: NetworkInterceptionMode;
 }

--- a/src/modules/Instabug.ts
+++ b/src/modules/Instabug.ts
@@ -12,6 +12,7 @@ import {
   ColorTheme,
   Locale,
   LogLevel,
+  NetworkInterceptionMode,
   ReproStepsMode,
   StringKey,
   WelcomeMessageMode,
@@ -61,12 +62,19 @@ function reportCurrentViewForAndroid(screenName: string | null) {
 export const init = (config: InstabugConfig) => {
   InstabugUtils.captureJsErrors();
   captureUnhandledRejections();
-  NetworkLogger.setEnabled(true);
+
+  // Default networkInterceptionMode to JavaScript
+  config.networkInterceptionMode ??= NetworkInterceptionMode.javascript;
+
+  if (config.networkInterceptionMode === NetworkInterceptionMode.javascript) {
+    NetworkLogger.setEnabled(true);
+  }
 
   NativeInstabug.init(
     config.token,
     config.invocationEvents,
     config.debugLogsLevel ?? LogLevel.error,
+    config.networkInterceptionMode === NetworkInterceptionMode.native,
     config.codePushVersion,
   );
 

--- a/src/native/NativeInstabug.ts
+++ b/src/native/NativeInstabug.ts
@@ -23,6 +23,7 @@ export interface InstabugNativeModule extends NativeModule {
     token: string,
     invocationEvents: InvocationEvent[],
     debugLogsLevel: LogLevel,
+    useNativeNetworkInterception: boolean,
     codePushVersion?: string,
   ): void;
   show(): void;

--- a/src/utils/Enums.ts
+++ b/src/utils/Enums.ts
@@ -25,6 +25,14 @@ export enum InvocationEvent {
 }
 
 /**
+ * The network interceptor to use.
+ */
+export enum NetworkInterceptionMode {
+  javascript,
+  native,
+}
+
+/**
  * Options added while invoking bug reporting.
  */
 export enum InvocationOption {

--- a/test/mocks/mockNetworkLogger.ts
+++ b/test/mocks/mockNetworkLogger.ts
@@ -1,0 +1,1 @@
+jest.mock('../../src/modules/NetworkLogger');


### PR DESCRIPTION
## Description of the change

Add a new `Instabug.init` config property (`networkInterceptionMode`) which allows switching between JavaScript and native network interception through JavaScript.

When the network interception mode is JavaScript, the SDK functions as it used to:
1. Network interception is done through JavaScript.
2. You can set an obfuscation handler and request filtering in the JavaScript code.
3. Network requests sent through native code don't get captured.

Native network interception provides the following:
1. Network interception is done through the native SDKs (the native iOS SDK works out of the box and the Android SDK requires configuring the [Instabug APM network plugin](https://docs.instabug.com/docs/android-apm-network#getting-started).
2. You can't set an obfuscation handler and request filtering in the JavaScript code, but you'd rather need to set it up in the native iOS and Android code through native APIs.
3. JavaScript network requests should get captured by the native network interceptors without extra effort, so this mode should have a wider coverage of network logs than the JavaScript network interception mode.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Jira ID: MOB-13771

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
