### PR TITLE
fix(android): resolve private views through UI manager directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased](https://github.com/Instabug/Instabug-React-Native/compare/v12.6.0...dev)
+
+### Fixed
+
+- Fix an Android `NullPointerException` crash in private views APIs ([#1121](https://github.com/Instabug/Instabug-React-Native/pull/1121)), closes [#514](https://github.com/Instabug/Instabug-React-Native/issues/514).
+
 ## [12.6.0](https://github.com/Instabug/Instabug-React-Native/compare/v12.5.0...v12.6.0) (January 14, 2024)
 
 ### Changed

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
@@ -7,6 +7,8 @@ import android.graphics.Bitmap;
 import android.net.Uri;
 import android.view.View;
 
+import androidx.annotation.UiThread;
+
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.Promise;
@@ -17,8 +19,6 @@ import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeArray;
 import com.facebook.react.bridge.WritableNativeMap;
-import com.facebook.react.uimanager.NativeViewHierarchyManager;
-import com.facebook.react.uimanager.UIBlock;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.instabug.library.Feature;
 import com.instabug.library.Instabug;
@@ -893,24 +893,32 @@ public class RNInstabugReactnativeModule extends EventEmitterModule {
         networkLog.insert();
     }
 
+    @UiThread
+    @Nullable
+    private View resolveReactView(final int reactTag) {
+        final ReactApplicationContext reactContext = getReactApplicationContext();
+        final UIManagerModule uiManagerModule = reactContext.getNativeModule(UIManagerModule.class);
+
+        if (uiManagerModule == null) {
+            return null;
+        }
+
+        return uiManagerModule.resolveView(reactTag);
+    }
+
 
     @ReactMethod
     public void addPrivateView(final int reactTag) {
         MainThreadHandler.runOnMainThread(new Runnable() {
             @Override
             public void run() {
-                UIManagerModule uiManagerModule = getReactApplicationContext().getNativeModule(UIManagerModule.class);
-                uiManagerModule.prependUIBlock(new UIBlock() {
-                    @Override
-                    public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
-                        try {
-                            final View view = nativeViewHierarchyManager.resolveView(reactTag);
-                            Instabug.addPrivateViews(view);
-                        } catch(Exception e) {
-                            e.printStackTrace();
-                        }
-                    }
-                });
+                try {
+                    final View view = resolveReactView(reactTag);
+
+                    Instabug.addPrivateViews(view);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
             }
         });
     }
@@ -920,18 +928,13 @@ public class RNInstabugReactnativeModule extends EventEmitterModule {
         MainThreadHandler.runOnMainThread(new Runnable() {
             @Override
             public void run() {
-                UIManagerModule uiManagerModule = getReactApplicationContext().getNativeModule(UIManagerModule.class);
-                uiManagerModule.prependUIBlock(new UIBlock() {
-                    @Override
-                    public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
-                        try {
-                            final View view = nativeViewHierarchyManager.resolveView(reactTag);
-                            Instabug.removePrivateViews(view);
-                        } catch(Exception e) {
-                            e.printStackTrace();
-                        }
-                    }
-                });
+                try {
+                    final View view = resolveReactView(reactTag);
+
+                    Instabug.removePrivateViews(view);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
             }
         });
     }


### PR DESCRIPTION
## Description of the change

Eliminate the use of `UIManagerModule.prependUIBlock` which causes crashes due to `UIOperation` objects being `null` while React Native's `UIViewOperationQueue` is trying to execute it which causes a `NullPointerException`, and instead resolve the view directly using `UIManagerModule.resolveView`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Jira ID: INSD-10851

Fixes #514

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request
