### PR TITLE
ci: replace  d11 cluster url in UploadSourcemaps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,6 +300,9 @@ jobs:
           file: package.json
           replace-pattern: 's/instabug-reactnative/@instabug\/instabug-reactnative-dream11/g'
       - search_and_replace:
+          file: cli/UploadSourcemaps.ts
+          replace-pattern: 's/api.instabug.com\/api\/sdk/st001012dream11.instabug.com\/api\/sdk/g'
+      - search_and_replace:
           file: android/native.gradle
           replace-pattern: 's/com\.instabug\.library:instabug:/com.instabug.library-dream11:instabug:/g'
       - run:
@@ -436,6 +439,3 @@ workflows:
       - release_d11:
           requires:
             - hold_release_d11
-          filters:
-            branches:
-              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -421,9 +421,6 @@ workflows:
       - hold_release_d11:
           requires: *release_dependencies
           type: approval
-          filters:
-            branches:
-              only: master
       - publish:
           requires:
             - hold_publish


### PR DESCRIPTION
## Description of the change

> Description goes here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
