### PR TITLE
chore(android): bump sdk to v12.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - Bump Instabug iOS SDK to v12.7.0 ([#1125](https://github.com/Instabug/Instabug-React-Native/pull/1125)). [See release notes](https://github.com/instabug/instabug-ios/releases/tag/12.7.0).
+- Bump Instabug Android SDK to v12.7.0 ([#1126](https://github.com/Instabug/Instabug-React-Native/pull/1126)). [See release notes](https://github.com/Instabug/android/releases/tag/v12.7.0).
 
 ### Fixed
 

--- a/android/native.gradle
+++ b/android/native.gradle
@@ -1,5 +1,5 @@
 project.ext.instabug = [
-    version: '12.6.0'
+    version: '12.7.0'
 ]
 
 dependencies {


### PR DESCRIPTION
## Description of the change

Bump Android SDK to `v12.7.0`

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Jira ID: MOB-13964

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
