### PR TITLE
feat: add runtime code push version API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Adds symbol files upload script ([#1137](https://github.com/Instabug/Instabug-React-Native/pull/1137))
 - Support enabling NDK crash capturing on Android ([#1132](https://github.com/Instabug/Instabug-React-Native/pull/1132)).
+- Support setting the Code Push version after SDK initialization ([#1143](https://github.com/Instabug/Instabug-React-Native/pull/1143)).
 
 ## [12.7.1](https://github.com/Instabug/Instabug-React-Native/compare/v12.7.0...v12.7.1) (February 15, 2024)
 

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
@@ -160,6 +160,20 @@ public class RNInstabugReactnativeModule extends EventEmitterModule {
         });
     }
 
+    @ReactMethod
+    public void setCodePushVersion(@Nullable String version) {
+        MainThreadHandler.runOnMainThread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    Instabug.setCodePushVersion(version);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        });
+    }
+
 
     /**
      * Adds tag(s) to issues before sending them

--- a/android/src/test/java/com/instabug/reactlibrary/RNInstabugReactnativeModuleTest.java
+++ b/android/src/test/java/com/instabug/reactlibrary/RNInstabugReactnativeModuleTest.java
@@ -200,6 +200,15 @@ public class RNInstabugReactnativeModuleTest {
     }
 
     @Test
+    public void testSetCodePushVersion() {
+        String codePushVersion = "123";
+
+        rnModule.setCodePushVersion(codePushVersion);
+
+        mockInstabug.verify(() -> Instabug.setCodePushVersion(codePushVersion));
+    }
+
+    @Test
     public void testIdentifyUserWithNoId() {
         // given
 

--- a/examples/default/ios/InstabugTests/InstabugSampleTests.m
+++ b/examples/default/ios/InstabugTests/InstabugSampleTests.m
@@ -81,6 +81,15 @@
   OCMVerify([self.mRNInstabug initWithToken:appToken invocationEvents:floatingButtonInvocationEvent debugLogsLevel:sdkDebugLogsLevel useNativeNetworkInterception:useNativeNetworkInterception]);
 }
 
+- (void)testSetCodePushVersion {
+  id mock = OCMClassMock([Instabug class]);
+  NSString *codePushVersion = @"123";
+  
+  [self.instabugBridge setCodePushVersion:codePushVersion];
+  
+  OCMVerify([mock setCodePushVersion:codePushVersion]);
+}
+
 - (void)testSetUserData {
   id mock = OCMClassMock([Instabug class]);
   NSString *userData = @"user_data";

--- a/ios/RNInstabug/InstabugReactBridge.h
+++ b/ios/RNInstabug/InstabugReactBridge.h
@@ -29,6 +29,8 @@
 
 - (void)init:(NSString *)token invocationEvents:(NSArray *)invocationEventsArray debugLogsLevel:(IBGSDKDebugLogsLevel)sdkDebugLogsLevel useNativeNetworkInterception:(BOOL)useNativeNetworkInterception codePushVersion:(NSString *)codePushVersion;
 
+- (void)setCodePushVersion:(NSString *)version;
+
 - (void)setUserData:(NSString *)userData;
 
 - (void)setTrackUserSteps:(BOOL)isEnabled;

--- a/ios/RNInstabug/InstabugReactBridge.m
+++ b/ios/RNInstabug/InstabugReactBridge.m
@@ -56,6 +56,10 @@ RCT_EXPORT_METHOD(init:(NSString *)token
  useNativeNetworkInterception:useNativeNetworkInterception];
 }
 
+RCT_EXPORT_METHOD(setCodePushVersion:(NSString *)version) {
+    [Instabug setCodePushVersion:version];
+}
+
 RCT_EXPORT_METHOD(setReproStepsConfig:(IBGUserStepsMode)bugMode :(IBGUserStepsMode)crashMode:(IBGUserStepsMode)sessionReplayMode) {
     [Instabug setReproStepsFor:IBGIssueTypeBug withMode:bugMode];
     [Instabug setReproStepsFor:IBGIssueTypeCrash withMode:crashMode];

--- a/src/modules/Instabug.ts
+++ b/src/modules/Instabug.ts
@@ -91,6 +91,14 @@ export const init = (config: InstabugConfig) => {
 };
 
 /**
+ * Sets the Code Push version to be sent with each report.
+ * @param version the Code Push version.
+ */
+export const setCodePushVersion = (version: string) => {
+  NativeInstabug.setCodePushVersion(version);
+};
+
+/**
  * Attaches user data to each report being sent.
  * Each call to this method overrides the user data to be attached.
  * Maximum size of the string is 1,000 characters.

--- a/src/native/NativeInstabug.ts
+++ b/src/native/NativeInstabug.ts
@@ -29,6 +29,7 @@ export interface InstabugNativeModule extends NativeModule {
   show(): void;
 
   // Misc APIs //
+  setCodePushVersion(version: string): void;
   setIBGLogPrintsToConsole(printsToConsole: boolean): void;
   setSessionProfilerEnabled(isEnabled: boolean): void;
 

--- a/test/mocks/mockInstabug.ts
+++ b/test/mocks/mockInstabug.ts
@@ -13,6 +13,7 @@ const mockInstabug: InstabugNativeModule = {
   removeListeners: jest.fn(),
   setEnabled: jest.fn(),
   init: jest.fn(),
+  setCodePushVersion: jest.fn(),
   setUserData: jest.fn(),
   setTrackUserSteps: jest.fn(),
   setIBGLogPrintsToConsole: jest.fn(),

--- a/test/modules/Instabug.spec.ts
+++ b/test/modules/Instabug.spec.ts
@@ -257,6 +257,15 @@ describe('Instabug Module', () => {
     );
   });
 
+  it('setCodePushVersion should call native method setCodePushVersion', () => {
+    const codePushVersion = '123';
+
+    Instabug.setCodePushVersion(codePushVersion);
+
+    expect(NativeInstabug.setCodePushVersion).toBeCalledTimes(1);
+    expect(NativeInstabug.setCodePushVersion).toBeCalledWith(codePushVersion);
+  });
+
   it('init should disable JavaScript interceptor when using native interception mode', () => {
     const instabugConfig = {
       token: 'some-token',


### PR DESCRIPTION
## Description of the change

Add `Instabug.setCodePushVersion` API to set the code push version at runtime rather than when calling `Instabug.init`.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Jira ID: MOB-14029

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request
