### PR TITLE
fix: use correct string type in network diagnostics handler

### DIFF
--- a/src/modules/Instabug.ts
+++ b/src/modules/Instabug.ts
@@ -550,7 +550,7 @@ export const clearAllExperiments = () => {
 };
 
 export type NetworkDiagnosticsHandler = (
-  date: String,
+  date: string,
   totalRequestCount: number,
   failureCount: number,
 ) => void;


### PR DESCRIPTION
## Description of the change

The type of the `data` parameter in `NetworkDiagnosticsHandler` was set to `String` which is the object wrapper around the `string` type, this causes TypeScript errors when trying to assign `data` to a variable of type `string`. So we changed it to `string`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Jira ID: INSD-11050

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
