### PR TITLE
ci: upgrade android orb, node orb and android image 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ jobs:
       INSTABUG_SOURCEMAPS_UPLOAD_DISABLE: true
     steps:
       - advanced-checkout/shallow-checkout
-      - node/install-yarn
+#      - node/install-yarn
       - install_node_modules
       - android/run-tests:
           working-directory: android
@@ -233,7 +233,7 @@ jobs:
       INSTABUG_SOURCEMAPS_UPLOAD_DISABLE: true
     steps:
       - advanced-checkout/shallow-checkout
-      - node/install-yarn
+#      - node/install-yarn
       - install_node_modules
       - node/install-packages:
           pkg-manager: yarn

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ commands:
     steps:
       - node/install:
           install-yarn: true
-          node-version: default
+          node-version: 'v20.11.1'
       - node/install-packages:
           pkg-manager: yarn
           # Network concurrency is set to 1 for installation from GitHub to work.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ commands:
     steps:
       - node/install:
           install-yarn: true
-          node-version: 'v18.17.0'
+          node-version: default
       - node/install-packages:
           pkg-manager: yarn
           # Network concurrency is set to 1 for installation from GitHub to work.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ jobs:
       INSTABUG_SOURCEMAPS_UPLOAD_DISABLE: true
     steps:
       - advanced-checkout/shallow-checkout
-#      - node/install-yarn
+      #      - node/install-yarn
       - install_node_modules
       - android/run-tests:
           working-directory: android
@@ -233,7 +233,7 @@ jobs:
       INSTABUG_SOURCEMAPS_UPLOAD_DISABLE: true
     steps:
       - advanced-checkout/shallow-checkout
-#      - node/install-yarn
+      #      - node/install-yarn
       - install_node_modules
       - node/install-packages:
           pkg-manager: yarn

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2.1
 
 orbs:
-  android: circleci/android@2.0
+  android: circleci/android@2.5.0
   advanced-checkout: vsco/advanced-checkout@1.1.0
-  node: circleci/node@5.1.0
+  node: circleci/node@5.2.0
 
 references:
   release_dependencies: &release_dependencies
@@ -113,7 +113,7 @@ jobs:
   test_android:
     executor:
       name: android/android-machine
-      tag: '2022.03.1'
+      tag: default
     working_directory: ~/project/examples/default
     environment:
       INSTABUG_SOURCEMAPS_UPLOAD_DISABLE: true
@@ -227,7 +227,7 @@ jobs:
   e2e_android:
     executor:
       name: android/android-machine
-      tag: 2022.03.1
+      tag: default
       resource-class: large
     environment:
       INSTABUG_SOURCEMAPS_UPLOAD_DISABLE: true


### PR DESCRIPTION
## Description of the change

> upgrade android orb from 2.0 to 2.5.0 (latest).
upgrade node orbe from 5.1.0 to 5.2.0 (latest).
upgrade the deprecated android image 2022.04.1 to default



## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> JiraID: MOB-14218

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
