### PR TITLE
ci: fix and refactor enterprise release pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,7 +284,7 @@ jobs:
           search: instabug-reactnative
           replace: << parameters.npm_package >>
       - find_and_replace:
-          files: cli/UploadSourcemaps.ts
+          files: cli/UploadSourcemaps.ts cli/UploadSoFiles.ts
           search: api.instabug.com
           replace: << parameters.api_endpoint >>
       - find_and_replace:
@@ -317,7 +317,7 @@ jobs:
           search: instabug-reactnative
           replace: '@instabug/instabug-reactnative-dream11'
       - find_and_replace:
-          files: cli/UploadSourcemaps.ts
+          files: cli/UploadSourcemaps.ts cli/UploadSoFiles.ts
           search: api.instabug.com
           replace: st001012dream11.instabug.com
       - find_and_replace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,16 +50,20 @@ commands:
           key: v1-pods-{{ checksum "<< parameters.working_directory >>/Podfile.lock" }}
           paths:
             - << parameters.working_directory >>/Pods
-  search_and_replace:
+  find_and_replace:
     parameters:
-      file:
+      files:
+        description: A space-separated list of files to search and replace in.
         type: string
-      replace-pattern:
+      search:
+        type: string
+      replace:
         type: string
     steps:
       - run:
-          name: Search and Replace in << parameters.file >>
-          command: sed -i '<< parameters.replace-pattern >>' << parameters.file >>
+          name: Find and Replace in << parameters.files >>
+          command: node ~/project/scripts/replace.js << parameters.search >> << parameters.replace >> << parameters.files >>
+
   notify_github:
     parameters:
       data:
@@ -258,8 +262,14 @@ jobs:
           working_directory: examples/default
           command: detox test -c android.emu.release
 
-  # Automate the enterprise NN sdk changes
-  release_nn:
+  release_custom_package:
+    parameters:
+      npm_package:
+        type: string
+      android_package:
+        type: string
+      api_endpoint:
+        type: string
     working_directory: ~/project
     executor:
       name: node/default
@@ -269,53 +279,28 @@ jobs:
       - run:
           name: Remove README.md file
           command: rm README.md
-      - search_and_replace:
-          file: package.json
-          replace-pattern: 's/instabug-reactnative/@instabug\/react-native-nn/g'
-      - search_and_replace:
-          file: cli/UploadSourcemaps.ts
-          replace-pattern: 's/api.instabug.com\/api\/sdk/st001009nn.instabug.com\/api\/sdk/g'
-      - search_and_replace:
-          file: android/native.gradle
-          replace-pattern: 's/com\.instabug\.library:instabug:/com.instabug.library-nn:instabug:/g'
+      - find_and_replace:
+          files: package.json android/sourcemaps.gradle ios/sourcemaps.sh
+          search: instabug-reactnative
+          replace: << parameters.npm_package >>
+      - find_and_replace:
+          files: cli/UploadSourcemaps.ts
+          search: api.instabug.com
+          replace: << parameters.api_endpoint >>
+      - find_and_replace:
+          files: android/native.gradle
+          search: 'com.instabug.library:instabug:'
+          replace: 'com.instabug.library-<< parameters.android_package >>:instabug:'
       - run:
           name: Build the SDK
           command: yarn build
       - run:
-          name: Authorize with npm
+          name: Authorize with NPM
           command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
       - run:
           name: Publish new enterprise version
           command: npm publish
-  # Automate the enterprise injazat sdk changes
-  release_injazat:
-    working_directory: ~/project
-    executor:
-      name: node/default
-    steps:
-      - advanced-checkout/shallow-checkout
-      - install_node_modules
-      - run:
-          name: Remove README.md file
-          command: rm README.md
-      - search_and_replace:
-          file: package.json
-          replace-pattern: 's/instabug-reactnative/@instabug\/react-native-injazat/g'
-      - search_and_replace:
-          file: cli/UploadSourcemaps.ts
-          replace-pattern: 's/api.instabug.com\/api\/sdk/st001013mec1.instabug.com\/api\/sdk/g'
-      - search_and_replace:
-          file: android/native.gradle
-          replace-pattern: 's/com\.instabug\.library:instabug:/com.instabug.library-injazat:instabug:/g'
-      - run:
-          name: Build the SDK
-          command: yarn build
-      - run:
-          name: Authorize with npm
-          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-      - run:
-          name: Publish new enterprise version
-          command: npm publish
+
   # Automate the enterprise D11 sdk changes
   release_d11:
     working_directory: ~/project
@@ -327,15 +312,18 @@ jobs:
       - run:
           name: Remove README.md file
           command: rm README.md
-      - search_and_replace:
-          file: package.json
-          replace-pattern: 's/instabug-reactnative/@instabug\/instabug-reactnative-dream11/g'
-      - search_and_replace:
-          file: cli/UploadSourcemaps.ts
-          replace-pattern: 's/api.instabug.com\/api\/sdk/st001012dream11.instabug.com\/api\/sdk/g'
-      - search_and_replace:
-          file: android/native.gradle
-          replace-pattern: 's/com\.instabug\.library:instabug:/com.instabug.library-dream11:instabug:/g'
+      - find_and_replace:
+          files: package.json ios/sourcemaps.sh android/sourcemaps.gradle
+          search: instabug-reactnative
+          replace: '@instabug/instabug-reactnative-dream11'
+      - find_and_replace:
+          files: cli/UploadSourcemaps.ts
+          search: api.instabug.com
+          replace: st001012dream11.instabug.com
+      - find_and_replace:
+          files: android/native.gradle
+          search: com.instabug.library:instabug
+          replace: 'com.instabug.library-dream11:instabug:'
       - run:
           name: give exec permssion to d11 script
           command: chmod +x ./scripts/dream-11-delete-unused-features.sh
@@ -381,9 +369,10 @@ jobs:
     working_directory: '~'
     steps:
       - advanced-checkout/shallow-checkout
-      - search_and_replace:
-          file: package.json
-          replace-pattern: 's/instabug-reactnative/@instabug\/react-native/g'
+      - find_and_replace:
+          files: package.json
+          search: instabug-reactnative
+          replace: '@instabug/react-native'
       - run: git clone git@github.com:Instabug/Escape.git
       - run:
           working_directory: Escape
@@ -469,15 +458,6 @@ workflows:
           filters:
             branches:
               only: master
-      - hold_release_nn:
-          requires: *release_dependencies
-          type: approval
-          filters:
-            branches:
-              only: master
-      - hold_release_injazat:
-          requires: *release_dependencies
-          type: approval
       - hold_publish_new_namespace:
           requires: *release_dependencies
           type: approval
@@ -499,15 +479,26 @@ workflows:
           filters:
             branches:
               only: master
-      - release_nn:
+      - hold_release_nn:
+          requires: *release_dependencies
+          type: approval
+      - release_custom_package:
+          name: release_nn
           requires:
             - hold_release_nn
-          filters:
-            branches:
-              only: master
-      - release_injazat:
+          npm_package: '@instabug/react-native-nn'
+          android_package: nn
+          api_endpoint: st001009nn.instabug.com
+      - hold_release_injazat:
+          requires: *release_dependencies
+          type: approval
+      - release_custom_package:
+          name: release_injazat
           requires:
             - hold_release_injazat
+          npm_package: '@instabug/react-native-injazat'
+          android_package: injazat
+          api_endpoint: st001013mec1.instabug.com
       - release_d11:
           requires:
             - hold_release_d11

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,13 @@ module.exports = {
       },
     },
     {
+      // Node Scripts Overrides
+      files: ['scripts/**'],
+      env: {
+        node: true,
+      },
+    },
+    {
       // Detox Overrides
       files: ['examples/default/e2e/**.js'],
       env: {

--- a/scripts/replace.js
+++ b/scripts/replace.js
@@ -11,30 +11,32 @@
 const fs = require('fs');
 const path = require('path');
 
-const [search, replace, file] = process.argv.slice(2);
+const [search, replace, ...files] = process.argv.slice(2);
 
-if (!search || !replace || !file) {
+if (!search || !replace || !files.length) {
   // The path of the script relative to the directory where the user ran the
   // script to be used in the error message demonstrating the usage.
   const scriptPath = path.relative(process.cwd(), __filename);
 
   console.error('Missing arguments.');
-  console.table({ search, replace, file });
+  console.table({ search, replace, files });
 
-  console.error(`Usage: node ${scriptPath} <search> <replace> <file>`);
+  console.error(`Usage: node ${scriptPath} <search> <replace> <files...>`);
   process.exit(1);
 }
 
-try {
-  const filePath = path.resolve(process.cwd(), file);
+for (const file of files) {
+  try {
+    const filePath = path.resolve(process.cwd(), file);
 
-  const fileContent = fs.readFileSync(filePath, 'utf8');
+    const fileContent = fs.readFileSync(filePath, 'utf8');
 
-  const newContent = fileContent.replaceAll(search, replace);
+    const newContent = fileContent.replaceAll(search, replace);
 
-  fs.writeFileSync(filePath, newContent);
-} catch (error) {
-  console.error('An error occurred while replacing the content of the file.');
-  console.error(error);
-  process.exit(1);
+    fs.writeFileSync(filePath, newContent);
+  } catch (error) {
+    console.error(`An error occurred while replacing the content of the file: ${file}.`);
+    console.error(error);
+    process.exit(1);
+  }
 }

--- a/scripts/replace.js
+++ b/scripts/replace.js
@@ -1,0 +1,40 @@
+/**
+ * A script to replace all occurrences of a string in a file, this is built as a
+ * replacement for the `sed` command to make it easier to replace strings with
+ * special characters without the hassle of escaping them, this is important
+ * when we are replacing strings that aren't known in advance like parameters
+ * from files.
+ *
+ * Usage: node replace.js <search> <replace> <file>
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const [search, replace, file] = process.argv.slice(2);
+
+if (!search || !replace || !file) {
+  // The path of the script relative to the directory where the user ran the
+  // script to be used in the error message demonstrating the usage.
+  const scriptPath = path.relative(process.cwd(), __filename);
+
+  console.error('Missing arguments.');
+  console.table({ search, replace, file });
+
+  console.error(`Usage: node ${scriptPath} <search> <replace> <file>`);
+  process.exit(1);
+}
+
+try {
+  const filePath = path.resolve(process.cwd(), file);
+
+  const fileContent = fs.readFileSync(filePath, 'utf8');
+
+  const newContent = fileContent.replaceAll(search, replace);
+
+  fs.writeFileSync(filePath, newContent);
+} catch (error) {
+  console.error('An error occurred while replacing the content of the file.');
+  console.error(error);
+  process.exit(1);
+}


### PR DESCRIPTION
## Description of the change

1. Change the find and replace logic in CI code to use a JavaScript script instead of `sed` to avoid issues with escaping special characters.
2. Refactor NN and Injazat's release to use the same job but with different parameters instead of different jobs.
3. Fix NN, Injazat, and Dream11's packages sourcemaps upload script, the `ios/sourcemaps.sh` and `android/sourcemaps.gradle` scripts referred to `instabug-reactnative` to invoke the upload CLI in the past so we fixed the release pipelines to replace all occurrences of `instabug-reactnative` with the new package name in these files as well.
4. Replace the API URL used to upload SO files in the CLI to refer to the API URL of the customer instead of the default Instabug API.

I tested the new `release_custom_package` and `release_d11` CI jobs on the test-only `@instabug/react-native-private` to make sure things are working fine.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
