### PR TITLE
ci: lock android machine to tag 2024.01.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
   test_android:
     executor:
       name: android/android-machine
-      tag: default
+      tag: '2024.01.1'
     working_directory: ~/project/examples/default
     environment:
       INSTABUG_SOURCEMAPS_UPLOAD_DISABLE: true
@@ -231,7 +231,7 @@ jobs:
   e2e_android:
     executor:
       name: android/android-machine
-      tag: default
+      tag: '2024.01.1'
       resource-class: large
     environment:
       INSTABUG_SOURCEMAPS_UPLOAD_DISABLE: true


### PR DESCRIPTION
## Description of the change

Lock the Android machine to tag `2024.01.1` to resolve CI failures in `test_android` and `e2e_android`.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Jira ID: MOB-14564

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
