### PR TITLE
ci: restrict enterprise release jobs branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -466,6 +466,9 @@ workflows:
       - hold_release_d11:
           requires: *release_dependencies
           type: approval
+          filters:
+            branches:
+              only: dream11
       - publish:
           requires:
             - hold_publish
@@ -481,23 +484,38 @@ workflows:
       - hold_release_nn:
           requires: *release_dependencies
           type: approval
+          filters:
+            branches:
+              only: master
       - release_custom_package:
           name: release_nn
           requires:
             - hold_release_nn
+          filters:
+            branches:
+              only: master
           npm_package: '@instabug/react-native-nn'
           android_package: nn
           api_endpoint: st001009nn.instabug.com
       - hold_release_injazat:
           requires: *release_dependencies
           type: approval
+          filters:
+            branches:
+              only: master
       - release_custom_package:
           name: release_injazat
           requires:
             - hold_release_injazat
+          filters:
+            branches:
+              only: master
           npm_package: '@instabug/react-native-injazat'
           android_package: injazat
           api_endpoint: st001013mec1.instabug.com
       - release_d11:
           requires:
             - hold_release_d11
+          filters:
+            branches:
+              only: dream11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
   test_android:
     executor:
       name: android/android-machine
-      tag: default
+      tag: '2024.01.1'
     working_directory: ~/project/examples/default
     environment:
       INSTABUG_SOURCEMAPS_UPLOAD_DISABLE: true
@@ -231,7 +231,7 @@ jobs:
   e2e_android:
     executor:
       name: android/android-machine
-      tag: default
+      tag: '2024.01.1'
       resource-class: large
     environment:
       INSTABUG_SOURCEMAPS_UPLOAD_DISABLE: true


### PR DESCRIPTION
## Description of the change

Restrict running `release_nn` and `release_injazat` to `master`, and `release_d11` to `dream11`

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Jira ID: MOB-14565

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
