### PR TITLE
feat: read INSTABUG_APP_TOKEN from env in sourcemap uploading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased](https://github.com/Instabug/Instabug-React-Native/compare/v13.0.5...dev)
+
+### Added
+
+- support reading `INSTABUG_APP_TOKEN` variable from env files in automatic sourcemap files uploading ([#1222](https://github.com/Instabug/Instabug-React-Native/pull/1222))
+
 ## [13.0.5](https://github.com/Instabug/Instabug-React-Native/compare/v13.0.4...v13.0.5) (May 18, 2024)
 
 ### Changed

--- a/scripts/find-token.sh
+++ b/scripts/find-token.sh
@@ -8,7 +8,7 @@ INIT_APP_TOKEN=$(
     grep -o "[\"\'][0-9a-zA-Z]*[\"\']" |
     cut -d "\"" -f 2 |
     cut -d "'" -f 2
-) 
+)
 
 if [ ! -z "${INIT_APP_TOKEN}" ]; then
     echo $INIT_APP_TOKEN
@@ -20,10 +20,26 @@ START_APP_TOKEN=$(
     grep -o "[\"\'][0-9a-zA-Z]*[\"\']" |
     cut -d "\"" -f 2 |
     cut -d "'" -f 2
-) 
+)
 
 if [ ! -z "${START_APP_TOKEN}" ]; then
     echo $START_APP_TOKEN
+    exit 0
+fi
+
+
+
+
+ENV_APP_TOKEN=$(
+    grep "INSTABUG_APP_TOKEN" -r -A 1 -m 1 --exclude-dir={node_modules,ios,android} --include=\*.env ./ |
+    sed 's/ //g' |
+    grep -o "=[0-9a-zA-Z]*" |
+    cut -d "=" -f 2
+
+     )
+
+if [ ! -z "${ENV_APP_TOKEN}" ]; then
+    echo $ENV_APP_TOKEN
     exit 0
 fi
 


### PR DESCRIPTION
## Description of the change

1) support reading `INSTABUG_APP_TOKEN` variable from env files in automatic sourcemap files uploading

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

JIRA ID:  INSD-10736

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
