### PR TITLE
fix(android): UIManagerModule Fix for Bridgeless

### DIFF
--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
@@ -15,11 +15,12 @@ import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.UIManager;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeArray;
 import com.facebook.react.bridge.WritableNativeMap;
-import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.UIManagerHelper;
 import com.instabug.library.Feature;
 import com.instabug.library.Instabug;
 import com.instabug.library.InstabugColorTheme;
@@ -922,13 +923,13 @@ public class RNInstabugReactnativeModule extends EventEmitterModule {
     @Nullable
     private View resolveReactView(final int reactTag) {
         final ReactApplicationContext reactContext = getReactApplicationContext();
-        final UIManagerModule uiManagerModule = reactContext.getNativeModule(UIManagerModule.class);
+        final UIManager uiManager = UIManagerHelper.getUIManagerForReactTag(reactContext, reactTag);
 
-        if (uiManagerModule == null) {
+        if (uiManager == null) {
             return null;
         }
 
-        return uiManagerModule.resolveView(reactTag);
+        return uiManager.resolveView(reactTag);
     }
 
 


### PR DESCRIPTION
## Description of the change

https://github.com/expo/expo/blob/0cc4a2d84a0960dd938260e94b4c5b7e6f7d4c1e/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/viewshot/RNViewShotModule.java#L105

will fail in Bridgeless mode React Native 0.74 on Android since which returns null in Bridgeless

https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java#L600-L606

# How

Implemented fallback in Bridgeless to UIManagerHelper

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Issue links go here

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
