### PR TITLE
fix(android): change parameters used in inner class to final

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased](https://github.com/Instabug/Instabug-React-Native/compare/v13.1.1...dev)
+
+### Fixed
+
+- Change parameters used inside inner classes to `final` in Android code to maintain compatibility with Java 7 and earlier ([#1239](https://github.com/Instabug/Instabug-React-Native/pull/1239)).
+
 ## [13.1.1](https://github.com/Instabug/Instabug-React-Native/compare/v13.0.4...dev) (JUN 6, 2024)
 
 ### Fixed

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugCrashReportingModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugCrashReportingModule.java
@@ -90,9 +90,9 @@ public class RNInstabugCrashReportingModule extends ReactContextBaseJavaModule {
      * @param level       different severity levels for errors
      */
     @ReactMethod
-    public void sendHandledJSCrash(final String exceptionObject, @Nullable ReadableMap userAttributes, @Nullable String fingerprint, @Nullable String level) {
+    public void sendHandledJSCrash(final String exceptionObject, @Nullable final ReadableMap userAttributes, @Nullable final String fingerprint, @Nullable final String level) {
         try {
-            JSONObject jsonObject = new JSONObject(exceptionObject);
+            final JSONObject jsonObject = new JSONObject(exceptionObject);
             MainThreadHandler.runOnMainThread(new Runnable() {
                 @Override
                 public void run() {

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
@@ -161,7 +161,7 @@ public class RNInstabugReactnativeModule extends EventEmitterModule {
     }
 
     @ReactMethod
-    public void setCodePushVersion(@Nullable String version) {
+    public void setCodePushVersion(@Nullable final String version) {
         MainThreadHandler.runOnMainThread(new Runnable() {
             @Override
             public void run() {

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugSessionReplayModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugSessionReplayModule.java
@@ -83,7 +83,7 @@ public class RNInstabugSessionReplayModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void getSessionReplayLink(Promise promise) {
+    public void getSessionReplayLink(final Promise promise) {
         MainThreadHandler.runOnMainThread(new Runnable() {
             @Override
             public void run() {


### PR DESCRIPTION
## Description of the change

Mark the parameters used inside inner classes in the Android code as `final` to fix errors like the one below in Java 7 and earlier.

> Error: local variable version is accessed from within inner class; needs to be declared final in RNInstabugReactnativeModule.java

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Jira ID: INSD-11725

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
