### PR TITLE
chore(android): bump sdk to v13.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/Instabug/Instabug-React-Native/compare/v13.1.1...dev)
 
+### Changed
+
+- Bump Instabug Android SDK to v13.2.0 ([#1245](https://github.com/Instabug/Instabug-React-Native/pull/1245)). [See release notes](https://github.com/Instabug/Instabug-Android/releases/tag/v13.2.0).
+
 ### Fixed
 
 - Change parameters used inside inner classes to `final` in Android code to maintain compatibility with Java 7 and earlier ([#1239](https://github.com/Instabug/Instabug-React-Native/pull/1239)).

--- a/android/native.gradle
+++ b/android/native.gradle
@@ -1,5 +1,5 @@
 project.ext.instabug = [
-    version: '13.1.1'
+    version: '13.2.0'
 ]
 
 dependencies {


### PR DESCRIPTION
## Description of the change

Bump Instabug Android SDK to v13.2.0

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Jira ID: MOB-14896

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
