### PR TITLE
fix(android): pass network start time in microseconds

### DIFF
--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugAPMModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugAPMModule.java
@@ -343,7 +343,7 @@ public class RNInstabugAPMModule extends ReactContextBaseJavaModule {
                 if (method != null) {
                         method.invoke(
                                 networkLogger,
-                                (long) requestStartTime,
+                                (long) requestStartTime*1000,
                                 (long) requestDuration,
                                 requestHeaders,
                                 requestBody,

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugAPMModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugAPMModule.java
@@ -343,7 +343,7 @@ public class RNInstabugAPMModule extends ReactContextBaseJavaModule {
                 if (method != null) {
                         method.invoke(
                                 networkLogger,
-                                (long) requestStartTime*1000,
+                                (long) requestStartTime * 1000,
                                 (long) requestDuration,
                                 requestHeaders,
                                 requestBody,


### PR DESCRIPTION
## Description of the change

change network timestamp in android side from milliSeconds into microSeconds

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

JIRA ID : MOB-15317
## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
