### PR TITLE
feat(android): add session sync callback

### DIFF
--- a/android/native.gradle
+++ b/android/native.gradle
@@ -1,5 +1,5 @@
 project.ext.instabug = [
-    version: '13.3.0'
+    version: '13.3.0.6212131-SNAPSHOT',
 ]
 
 dependencies {

--- a/android/src/main/java/com/instabug/reactlibrary/ArgsRegistry.java
+++ b/android/src/main/java/com/instabug/reactlibrary/ArgsRegistry.java
@@ -15,6 +15,7 @@ import com.instabug.library.internal.module.InstabugLocale;
 import com.instabug.library.invocation.InstabugInvocationEvent;
 import com.instabug.library.invocation.util.InstabugFloatingButtonEdge;
 import com.instabug.library.invocation.util.InstabugVideoRecordingButtonPosition;
+import com.instabug.library.sessionreplay.model.SessionMetadata;
 import com.instabug.library.ui.onboarding.WelcomeMessage;
 
 import java.util.ArrayList;
@@ -58,6 +59,7 @@ final class ArgsRegistry {
             putAll(nonFatalExceptionLevel);
             putAll(locales);
             putAll(placeholders);
+            putAll(launchType);
         }};
     }
 
@@ -238,4 +240,18 @@ final class ArgsRegistry {
         put("team", Key.CHATS_TEAM_STRING_NAME);
         put("insufficientContentMessage", Key.COMMENT_FIELD_INSUFFICIENT_CONTENT);
     }};
+
+    public static ArgsMap<String> launchType = new ArgsMap<String>() {{
+        put("cold", SessionMetadata.LaunchType.COLD);
+        put("hot",SessionMetadata.LaunchType.HOT );
+        put("warm",SessionMetadata.LaunchType.WARM );
+    }};
+    
+// Temporary workaround to be removed in future release
+    public static HashMap<String,String> launchTypeReversed = new HashMap<String,String>() {{
+        put(SessionMetadata.LaunchType.COLD,"cold");
+        put(SessionMetadata.LaunchType.HOT,"hot" );
+        put(SessionMetadata.LaunchType.WARM,"warm" );
+    }};
+
 }

--- a/android/src/main/java/com/instabug/reactlibrary/ArgsRegistry.java
+++ b/android/src/main/java/com/instabug/reactlibrary/ArgsRegistry.java
@@ -248,6 +248,7 @@ final class ArgsRegistry {
     }};
     
 // Temporary workaround to be removed in future release
+// This is used for mapping native `LaunchType` values into React Native enum values.
     public static HashMap<String,String> launchTypeReversed = new HashMap<String,String>() {{
         put(SessionMetadata.LaunchType.COLD,"cold");
         put(SessionMetadata.LaunchType.HOT,"hot" );

--- a/android/src/main/java/com/instabug/reactlibrary/Constants.java
+++ b/android/src/main/java/com/instabug/reactlibrary/Constants.java
@@ -9,4 +9,6 @@ final class Constants {
 
     final static String IBG_ON_NEW_MESSAGE_HANDLER = "IBGonNewMessageHandler";
     final static String IBG_ON_NEW_REPLY_RECEIVED_CALLBACK = "IBGOnNewReplyReceivedCallback";
+    final static String IBG_SESSION_REPLAY_ON_SYNC_CALLBACK_INVOCATION = "IBGSessionReplayOnSyncCallback";
+
 }

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugSessionReplayModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugSessionReplayModule.java
@@ -116,7 +116,7 @@ public class RNInstabugSessionReplayModule extends EventEmitterModule {
 
     }
 
-    volatile boolean shouldSync = false;
+     boolean shouldSync = false;
      CountDownLatch latch;
     @ReactMethod
     public void setSyncCallback() {

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugSessionReplayModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugSessionReplayModule.java
@@ -172,6 +172,7 @@ public class RNInstabugSessionReplayModule extends EventEmitterModule {
                                 latch.await();
                             } catch (InterruptedException e) {
                                 e.printStackTrace();
+                                return true;
                             }
 
                             return shouldSync;

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugSessionReplayModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugSessionReplayModule.java
@@ -152,10 +152,10 @@ public class RNInstabugSessionReplayModule extends EventEmitterModule {
                             params.putString("device",sessionMetadata.getDevice());
                             params.putDouble("sessionDurationInSeconds",(double)sessionMetadata.getSessionDurationInSeconds());
                             params.putBoolean("hasLinkToAppReview",sessionMetadata.getLinkedToReview());
-                            params.putDouble("launchType", sessionMetadata.getLaunchType());
+                            params.putString("launchType",ArgsRegistry.launchTypeReversed.get(sessionMetadata.getLaunchType()) );
                             params.putDouble("launchDuration", sessionMetadata.getLaunchDuration());
                             params.putArray("networkLogs",getNetworkLogsArray(sessionMetadata.getNetworkLogs()));
-
+                            
 //                              TODO:Add rest of sessionMetadata
 //                            params.putDouble("bugsCount", ??);
 //                            params.putDouble("fatalCrashCount",??);

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugSessionReplayModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugSessionReplayModule.java
@@ -151,7 +151,7 @@ public class RNInstabugSessionReplayModule extends EventEmitterModule {
         return networkLogs;
     }
 
-    private boolean shouldSync = false;
+    private boolean shouldSync = true;
     private CountDownLatch latch;
     @ReactMethod
     public void setSyncCallback() {

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugSessionReplayModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugSessionReplayModule.java
@@ -115,9 +115,8 @@ public class RNInstabugSessionReplayModule extends EventEmitterModule {
 
 
     }
-
-     boolean shouldSync = false;
-     CountDownLatch latch;
+    private boolean shouldSync = false;
+    private CountDownLatch latch;
     @ReactMethod
     public void setSyncCallback() {
         MainThreadHandler.runOnMainThread(new Runnable() {

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugSessionReplayModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugSessionReplayModule.java
@@ -8,6 +8,7 @@ import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.instabug.library.OnSessionReplayLinkReady;
@@ -136,7 +137,7 @@ public class RNInstabugSessionReplayModule extends EventEmitterModule {
         return params;
     }
 
-    public WritableArray getNetworkLogsArray(List<SessionMetadata.NetworkLog> networkLogList ){
+    public ReadableArray getNetworkLogsArray(List<SessionMetadata.NetworkLog> networkLogList ){
         WritableArray networkLogs = Arguments.createArray();
 
         for (SessionMetadata.NetworkLog log : networkLogList) {

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugSessionReplayModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugSessionReplayModule.java
@@ -118,12 +118,28 @@ public class RNInstabugSessionReplayModule extends EventEmitterModule {
 
     }
 
+    public WritableMap getSessionMetadataMap(SessionMetadata sessionMetadata){
+        WritableMap params = Arguments.createMap();
+        params.putString("appVersion",sessionMetadata.getAppVersion());
+        params.putString("OS",sessionMetadata.getOs());
+        params.putString("device",sessionMetadata.getDevice());
+        params.putDouble("sessionDurationInSeconds",(double)sessionMetadata.getSessionDurationInSeconds());
+        params.putBoolean("hasLinkToAppReview",sessionMetadata.getLinkedToReview());
+        params.putString("launchType",ArgsRegistry.launchTypeReversed.get(sessionMetadata.getLaunchType()) );
+        params.putDouble("launchDuration", sessionMetadata.getLaunchDuration());
+        params.putArray("networkLogs",getNetworkLogsArray(sessionMetadata.getNetworkLogs()));
+
+//                              TODO:Add rest of sessionMetadata
+//                            params.putDouble("bugsCount", ??);
+//                            params.putDouble("fatalCrashCount",??);
+//                            params.putDouble("oomCrashCount",??);
+        return params;
+    }
+
     public WritableArray getNetworkLogsArray(List<SessionMetadata.NetworkLog> networkLogList ){
-        List<SessionMetadata.NetworkLog> networkLogArrayList = networkLogList;
-        
         WritableArray networkLogs = Arguments.createArray();
 
-        for (SessionMetadata.NetworkLog log : networkLogArrayList) {
+        for (SessionMetadata.NetworkLog log : networkLogList) {
             WritableMap networkLog = Arguments.createMap();
             networkLog.putString("url", log.getUrl());
             networkLog.putDouble("duration", log.getDuration());
@@ -146,22 +162,8 @@ public class RNInstabugSessionReplayModule extends EventEmitterModule {
                     SessionReplay.setSyncCallback(new SessionSyncListener() {
                         @Override
                         public boolean onSessionReadyToSync(@NonNull SessionMetadata sessionMetadata) {
-                            WritableMap params = Arguments.createMap();
-                            params.putString("appVersion",sessionMetadata.getAppVersion());
-                            params.putString("OS",sessionMetadata.getOs());
-                            params.putString("device",sessionMetadata.getDevice());
-                            params.putDouble("sessionDurationInSeconds",(double)sessionMetadata.getSessionDurationInSeconds());
-                            params.putBoolean("hasLinkToAppReview",sessionMetadata.getLinkedToReview());
-                            params.putString("launchType",ArgsRegistry.launchTypeReversed.get(sessionMetadata.getLaunchType()) );
-                            params.putDouble("launchDuration", sessionMetadata.getLaunchDuration());
-                            params.putArray("networkLogs",getNetworkLogsArray(sessionMetadata.getNetworkLogs()));
-                            
-//                              TODO:Add rest of sessionMetadata
-//                            params.putDouble("bugsCount", ??);
-//                            params.putDouble("fatalCrashCount",??);
-//                            params.putDouble("oomCrashCount",??);
 
-                            sendEvent(Constants.IBG_SESSION_REPLAY_ON_SYNC_CALLBACK_INVOCATION,params);
+                            sendEvent(Constants.IBG_SESSION_REPLAY_ON_SYNC_CALLBACK_INVOCATION,getSessionMetadataMap(sessionMetadata));
 
                             latch = new CountDownLatch(1);
 

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugSessionReplayModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugSessionReplayModule.java
@@ -8,6 +8,7 @@ import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.instabug.library.OnSessionReplayLinkReady;
 import com.instabug.library.SessionSyncListener;
@@ -15,6 +16,8 @@ import com.instabug.library.sessionreplay.SessionReplay;
 import com.instabug.library.sessionreplay.model.SessionMetadata;
 import com.instabug.reactlibrary.utils.EventEmitterModule;
 import com.instabug.reactlibrary.utils.MainThreadHandler;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
 import javax.annotation.Nonnull;
@@ -95,7 +98,7 @@ public class RNInstabugSessionReplayModule extends EventEmitterModule {
                     e.printStackTrace();
                 }
             }
-        });
+        });  
     }
 
     @ReactMethod
@@ -113,8 +116,25 @@ public class RNInstabugSessionReplayModule extends EventEmitterModule {
             }
         });
 
-
     }
+
+    public WritableArray getNetworkLogsArray(List<SessionMetadata.NetworkLog> networkLogList ){
+        List<SessionMetadata.NetworkLog> networkLogArrayList = networkLogList;
+        
+        WritableArray networkLogs = Arguments.createArray();
+
+        for (SessionMetadata.NetworkLog log : networkLogArrayList) {
+            WritableMap networkLog = Arguments.createMap();
+            networkLog.putString("url", log.getUrl());
+            networkLog.putDouble("duration", log.getDuration());
+            networkLog.putInt("statusCode", log.getStatusCode());
+
+            networkLogs.pushMap(networkLog);
+        }
+
+        return networkLogs;
+    }
+
     private boolean shouldSync = false;
     private CountDownLatch latch;
     @ReactMethod
@@ -131,6 +151,15 @@ public class RNInstabugSessionReplayModule extends EventEmitterModule {
                             params.putString("OS",sessionMetadata.getOs());
                             params.putString("device",sessionMetadata.getDevice());
                             params.putDouble("sessionDurationInSeconds",(double)sessionMetadata.getSessionDurationInSeconds());
+                            params.putBoolean("hasLinkToAppReview",sessionMetadata.getLinkedToReview());
+                            params.putDouble("launchType", sessionMetadata.getLaunchType());
+                            params.putDouble("launchDuration", sessionMetadata.getLaunchDuration());
+                            params.putArray("networkLogs",getNetworkLogsArray(sessionMetadata.getNetworkLogs()));
+
+//                              TODO:Add rest of sessionMetadata
+//                            params.putDouble("bugsCount", ??);
+//                            params.putDouble("fatalCrashCount",??);
+//                            params.putDouble("oomCrashCount",??);
 
                             sendEvent(Constants.IBG_SESSION_REPLAY_ON_SYNC_CALLBACK_INVOCATION,params);
 

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugSessionReplayModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugSessionReplayModule.java
@@ -119,7 +119,7 @@ public class RNInstabugSessionReplayModule extends EventEmitterModule {
 
     }
 
-    public WritableMap getSessionMetadataMap(SessionMetadata sessionMetadata){
+    public ReadableMap getSessionMetadataMap(SessionMetadata sessionMetadata){
         WritableMap params = Arguments.createMap();
         params.putString("appVersion",sessionMetadata.getAppVersion());
         params.putString("OS",sessionMetadata.getOs());

--- a/android/src/test/java/com/instabug/reactlibrary/RNInstabugSessionReplayModuleTest.java
+++ b/android/src/test/java/com/instabug/reactlibrary/RNInstabugSessionReplayModuleTest.java
@@ -154,7 +154,7 @@ public class RNInstabugSessionReplayModuleTest {
             mockSessionReplay.when(() -> SessionReplay.setSyncCallback(any(SessionSyncListener.class)))
                     .thenAnswer((invocation) -> {
                         SessionSyncListener listener = (SessionSyncListener) invocation.getArguments()[0];
-                        SessionMetadata metadata = new SessionMetadata("device", "android", "1.0", 20);
+                        SessionMetadata metadata = mock(SessionMetadata.class);
                         actual.set(listener.onSessionReadyToSync(metadata));
                         return null;
                     });
@@ -165,10 +165,6 @@ public class RNInstabugSessionReplayModuleTest {
             }).when(SRModule).sendEvent(eq(Constants.IBG_SESSION_REPLAY_ON_SYNC_CALLBACK_INVOCATION), any());
 
             WritableMap params = Arguments.createMap();
-            params.putString("appVersion","1.0");
-            params.putString("OS","android");
-            params.putString("device","device");
-            params.putDouble("sessionDurationInSeconds",20);
 
             SRModule.setSyncCallback();
 

--- a/examples/default/e2e/reportBug.e2e.ts
+++ b/examples/default/e2e/reportBug.e2e.ts
@@ -14,7 +14,9 @@ it('reports a bug', async () => {
   await waitFor(floatingButton).toBeVisible().withTimeout(30000);
   await floatingButton.tap();
 
-  await getElement('reportBugMenuItem').tap();
+  const reportBugMenuItemButton = getElement('reportBugMenuItem');
+  await waitFor(reportBugMenuItemButton).toBeVisible().withTimeout(30000);
+  await reportBugMenuItemButton.tap();
 
   await getElement('emailField').typeText(mockData.email);
   await getElement('commentField').typeText(mockData.bugComment);

--- a/examples/default/src/App.tsx
+++ b/examples/default/src/App.tsx
@@ -10,6 +10,7 @@ import Instabug, {
   ReproStepsMode,
   SessionReplay,
 } from 'instabug-reactnative';
+import type { sessionData } from 'instabug-reactnative';
 import { NativeBaseProvider } from 'native-base';
 
 import { RootTabNavigator } from './navigation/RootTab';
@@ -21,12 +22,7 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 const queryClient = new QueryClient();
 
 export const App: React.FC = () => {
-  const shouldSyncSession = (data: {
-    appVersion: string;
-    OS: string;
-    device: string;
-    sessionDurationInSeconds: number;
-  }) => {
+  const shouldSyncSession = (data: sessionData) => {
     if (data.sessionDurationInSeconds > 20) {
       return true;
     }

--- a/examples/default/src/App.tsx
+++ b/examples/default/src/App.tsx
@@ -30,7 +30,7 @@ export const App: React.FC = () => {
     if (data.sessionDurationInSeconds > 20) {
       return true;
     }
-    if (data.OS == 'OS Level 34') {
+    if (data.OS === 'OS Level 34') {
       return true;
     }
     return false;

--- a/examples/default/src/App.tsx
+++ b/examples/default/src/App.tsx
@@ -8,6 +8,7 @@ import Instabug, {
   InvocationEvent,
   LogLevel,
   ReproStepsMode,
+  SessionReplay,
 } from 'instabug-reactnative';
 import { NativeBaseProvider } from 'native-base';
 
@@ -20,8 +21,26 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 const queryClient = new QueryClient();
 
 export const App: React.FC = () => {
+  const shouldSyncSession = (data: {
+    appVersion: string;
+    OS: string;
+    device: string;
+    sessionDurationInSeconds: number;
+  }) => {
+    if (data.sessionDurationInSeconds > 20) {
+      return true;
+    }
+    if (data.OS == 'OS Level 34') {
+      return true;
+    }
+    return false;
+  };
+
   const navigationRef = useNavigationContainerRef();
+
   useEffect(() => {
+    SessionReplay.setSyncCallback((data) => shouldSyncSession(data));
+
     Instabug.init({
       token: 'deb1910a7342814af4e4c9210c786f35',
       invocationEvents: [InvocationEvent.floatingButton],

--- a/examples/default/src/App.tsx
+++ b/examples/default/src/App.tsx
@@ -9,6 +9,7 @@ import Instabug, {
   LogLevel,
   ReproStepsMode,
   SessionReplay,
+  LaunchType,
 } from 'instabug-reactnative';
 import type { sessionData } from 'instabug-reactnative';
 import { NativeBaseProvider } from 'native-base';
@@ -23,6 +24,9 @@ const queryClient = new QueryClient();
 
 export const App: React.FC = () => {
   const shouldSyncSession = (data: sessionData) => {
+    if (data.launchType === LaunchType.cold) {
+      return true;
+    }
     if (data.sessionDurationInSeconds > 20) {
       return true;
     }

--- a/examples/default/src/App.tsx
+++ b/examples/default/src/App.tsx
@@ -11,7 +11,7 @@ import Instabug, {
   SessionReplay,
   LaunchType,
 } from 'instabug-reactnative';
-import type { sessionData } from 'instabug-reactnative';
+import type { SessionMetadata } from 'instabug-reactnative';
 import { NativeBaseProvider } from 'native-base';
 
 import { RootTabNavigator } from './navigation/RootTab';
@@ -23,7 +23,7 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 const queryClient = new QueryClient();
 
 export const App: React.FC = () => {
-  const shouldSyncSession = (data: sessionData) => {
+  const shouldSyncSession = (data: SessionMetadata) => {
     if (data.launchType === LaunchType.cold) {
       return true;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import * as Replies from './modules/Replies';
 import type { Survey } from './modules/Surveys';
 import * as Surveys from './modules/Surveys';
 import * as SessionReplay from './modules/SessionReplay';
-import type { sessionData } from './modules/SessionReplay';
+import type { SessionMetadata } from './modules/SessionReplay';
 
 export * from './utils/Enums';
 export {
@@ -29,6 +29,6 @@ export {
   Replies,
   Surveys,
 };
-export type { InstabugConfig, Survey, NetworkData, NetworkDataObfuscationHandler, sessionData };
+export type { InstabugConfig, Survey, NetworkData, NetworkDataObfuscationHandler, SessionMetadata };
 
 export default Instabug;

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import * as Replies from './modules/Replies';
 import type { Survey } from './modules/Surveys';
 import * as Surveys from './modules/Surveys';
 import * as SessionReplay from './modules/SessionReplay';
+import type { sessionData } from './modules/SessionReplay';
 
 export * from './utils/Enums';
 export {
@@ -28,6 +29,6 @@ export {
   Replies,
   Surveys,
 };
-export type { InstabugConfig, Survey, NetworkData, NetworkDataObfuscationHandler };
+export type { InstabugConfig, Survey, NetworkData, NetworkDataObfuscationHandler, sessionData };
 
 export default Instabug;

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import * as Replies from './modules/Replies';
 import type { Survey } from './modules/Surveys';
 import * as Surveys from './modules/Surveys';
 import * as SessionReplay from './modules/SessionReplay';
-import type { SessionMetadata } from './modules/SessionReplay';
+import type { SessionMetadata } from './models/SessionMetadata';
 
 export * from './utils/Enums';
 export {

--- a/src/models/SessionMetadata.ts
+++ b/src/models/SessionMetadata.ts
@@ -1,0 +1,57 @@
+import type { LaunchType } from '../utils/Enums';
+
+/**
+ * network log item
+ */
+export interface NetworkLog {
+  url: string;
+  duration: number;
+  statusCode: number;
+}
+
+export interface SessionMetadata {
+  /**
+   * app version of the session
+   */
+  appVersion: string;
+  /**
+   * operating system of the session
+   */
+  OS: string;
+  /**
+   * mobile device model of the session
+   */
+  device: string;
+  /**
+   * session duration in seconds
+   */
+  sessionDurationInSeconds: number;
+  /**
+   * list of netwrok requests occurred during the session
+   */
+  networkLogs: NetworkLog[];
+  /**
+   * launch type of the session
+   */
+  launchType: LaunchType;
+  /**
+   * is an in-app review occurred in the previous session.
+   */
+  hasLinkToAppReview: boolean;
+  /**
+   * app launch duration
+   */
+  launchDuration: number;
+  /**
+   * number of bugs in the session
+   */
+  bugsCount?: number;
+  /**
+   * number of fetal crashes in the session
+   */
+  fatalCrashCount?: number;
+  /**
+   * number of out of memory crashes in the session
+   */
+  oomCrashCount?: number;
+}

--- a/src/modules/SessionReplay.ts
+++ b/src/modules/SessionReplay.ts
@@ -96,7 +96,7 @@ export const getSessionReplayLink = async (): Promise<string> => {
 };
 
 /**
- * Set a callback for weather this session should sync
+ * Set a callback for whether this session should sync
  *
  * @param handler
 

--- a/src/modules/SessionReplay.ts
+++ b/src/modules/SessionReplay.ts
@@ -124,7 +124,7 @@ export const setSyncCallback = async (
       );
     }
 
-    NativeSessionReplay.evaluateSync(Boolean(handler(payload)));
+    NativeSessionReplay.evaluateSync(shouldSync);
   });
 
   return NativeSessionReplay.setSyncCallback();

--- a/src/modules/SessionReplay.ts
+++ b/src/modules/SessionReplay.ts
@@ -102,12 +102,11 @@ export const getSessionReplayLink = async (): Promise<string> => {
 
  * @example
  * ```ts
- * SessionReplay.setSyncCallback((payload)=>{
- *    if(payload.device == "Xiaomi M2007J3SY" &&
- *         payload.os == "OS Level 33" &&
- *         payload.appVersion == "3.1.4 (4)" ||
- *         payload.sessionDurationInSeconds > 20 )
- *    {return true}
+ * SessionReplay.setSyncCallback((metadata) => {
+ *    return metadata.device == "Xiaomi M2007J3SY" &&
+ *         metadata.os == "OS Level 33" &&
+ *         metadata.appVersion == "3.1.4 (4)" ||
+ *         metadata.sessionDurationInSeconds > 20;
  * });
  * ```
  */

--- a/src/modules/SessionReplay.ts
+++ b/src/modules/SessionReplay.ts
@@ -1,10 +1,19 @@
 import { NativeSessionReplay, NativeEvents, emitter } from '../native/NativeSessionReplay';
 
+import type { NetworkData } from '../modules/NetworkLogger';
+
 export interface sessionData {
   appVersion: string;
   OS: string;
   device: string;
   sessionDurationInSeconds: number;
+  bugsCount: number;
+  fatalCrashCount: number;
+  oomCrashCount: number;
+  networkLogs: Array<NetworkData>;
+  launchType: string;
+  hasLinkToAppReview: boolean;
+  launchDuration: number;
 }
 /**
  * Enables or disables Session Replay for your Instabug integration.

--- a/src/modules/SessionReplay.ts
+++ b/src/modules/SessionReplay.ts
@@ -11,7 +11,7 @@ export interface SessionMetadata {
   OS: string;
   device: string;
   sessionDurationInSeconds: number;
-  networkLogs: Array<NetworkLog>;
+  networkLogs: NetworkLog[];
   launchType: LaunchType;
   hasLinkToAppReview: boolean;
   launchDuration: number;

--- a/src/modules/SessionReplay.ts
+++ b/src/modules/SessionReplay.ts
@@ -1,5 +1,5 @@
 import { NativeSessionReplay, NativeEvents, emitter } from '../native/NativeSessionReplay';
-import { LaunchType } from '../utils/Enums';
+import type { LaunchType } from '../utils/Enums';
 export interface networkLog {
   url: string;
   duration: number;

--- a/src/modules/SessionReplay.ts
+++ b/src/modules/SessionReplay.ts
@@ -1,24 +1,5 @@
 import { NativeSessionReplay, NativeEvents, emitter } from '../native/NativeSessionReplay';
-import type { LaunchType } from '../utils/Enums';
-export interface NetworkLog {
-  url: string;
-  duration: number;
-  statusCode: number;
-}
-
-export interface SessionMetadata {
-  appVersion: string;
-  OS: string;
-  device: string;
-  sessionDurationInSeconds: number;
-  networkLogs: NetworkLog[];
-  launchType: LaunchType;
-  hasLinkToAppReview: boolean;
-  launchDuration: number;
-  bugsCount?: number;
-  fatalCrashCount?: number;
-  oomCrashCount?: number;
-}
+import type { SessionMetadata } from '../models/SessionMetadata';
 /**
  * Enables or disables Session Replay for your Instabug integration.
  *

--- a/src/modules/SessionReplay.ts
+++ b/src/modules/SessionReplay.ts
@@ -78,7 +78,7 @@ export const getSessionReplayLink = async (): Promise<string> => {
 
 /**
  * Set a callback for weather this session should sync
- * 
+ *
  * @param handler
 
  * @example
@@ -101,7 +101,7 @@ export const setSyncCallback = async (
   }) => boolean,
 ): Promise<void> => {
   emitter.addListener(NativeEvents.SESSION_REPLAY_ON_SYNC_CALLBACK_INVOCATION, (payload) => {
-    if (typeof handler(payload) != 'boolean') {
+    if (typeof handler(payload) !== 'boolean') {
       console.warn('setSyncCallback expects boolean value');
     }
 

--- a/src/modules/SessionReplay.ts
+++ b/src/modules/SessionReplay.ts
@@ -1,19 +1,23 @@
 import { NativeSessionReplay, NativeEvents, emitter } from '../native/NativeSessionReplay';
-
-import type { NetworkData } from '../modules/NetworkLogger';
+import { LaunchType } from '../utils/Enums';
+export interface networkLog {
+  url: string;
+  duration: number;
+  statusCode: number;
+}
 
 export interface sessionData {
   appVersion: string;
   OS: string;
   device: string;
   sessionDurationInSeconds: number;
-  bugsCount: number;
-  fatalCrashCount: number;
-  oomCrashCount: number;
-  networkLogs: Array<NetworkData>;
-  launchType: string;
+  networkLogs: Array<networkLog>;
+  launchType: LaunchType;
   hasLinkToAppReview: boolean;
   launchDuration: number;
+  bugsCount?: number;
+  fatalCrashCount?: number;
+  oomCrashCount?: number;
 }
 /**
  * Enables or disables Session Replay for your Instabug integration.

--- a/src/modules/SessionReplay.ts
+++ b/src/modules/SessionReplay.ts
@@ -1,5 +1,11 @@
 import { NativeSessionReplay, NativeEvents, emitter } from '../native/NativeSessionReplay';
 
+export interface sessionData {
+  appVersion: string;
+  OS: string;
+  device: string;
+  sessionDurationInSeconds: number;
+}
 /**
  * Enables or disables Session Replay for your Instabug integration.
  *
@@ -93,16 +99,16 @@ export const getSessionReplayLink = async (): Promise<string> => {
  * ```
  */
 export const setSyncCallback = async (
-  handler: (payload: {
-    appVersion: string;
-    OS: string;
-    device: string;
-    sessionDurationInSeconds: number;
-  }) => boolean,
+  handler: (payload: sessionData) => boolean,
 ): Promise<void> => {
   emitter.addListener(NativeEvents.SESSION_REPLAY_ON_SYNC_CALLBACK_INVOCATION, (payload) => {
-    if (typeof handler(payload) !== 'boolean') {
-      console.warn('setSyncCallback expects boolean value');
+    const result = handler(payload);
+    const shouldSync = Boolean(result);
+
+    if (typeof result !== 'boolean') {
+      console.warn(
+        `IBG-RN: The callback passed to SessionReplay.setSyncCallback was expected to return a boolean but returned "${result}". The value has been cast to boolean, proceeding with ${shouldSync}.`,
+      );
     }
 
     NativeSessionReplay.evaluateSync(Boolean(handler(payload)));

--- a/src/modules/SessionReplay.ts
+++ b/src/modules/SessionReplay.ts
@@ -1,17 +1,17 @@
 import { NativeSessionReplay, NativeEvents, emitter } from '../native/NativeSessionReplay';
 import type { LaunchType } from '../utils/Enums';
-export interface networkLog {
+export interface NetworkLog {
   url: string;
   duration: number;
   statusCode: number;
 }
 
-export interface sessionData {
+export interface SessionMetadata {
   appVersion: string;
   OS: string;
   device: string;
   sessionDurationInSeconds: number;
-  networkLogs: Array<networkLog>;
+  networkLogs: Array<NetworkLog>;
   launchType: LaunchType;
   hasLinkToAppReview: boolean;
   launchDuration: number;
@@ -111,7 +111,7 @@ export const getSessionReplayLink = async (): Promise<string> => {
  * ```
  */
 export const setSyncCallback = async (
-  handler: (payload: sessionData) => boolean,
+  handler: (payload: SessionMetadata) => boolean,
 ): Promise<void> => {
   emitter.addListener(NativeEvents.SESSION_REPLAY_ON_SYNC_CALLBACK_INVOCATION, (payload) => {
     const result = handler(payload);

--- a/src/modules/SessionReplay.ts
+++ b/src/modules/SessionReplay.ts
@@ -1,4 +1,4 @@
-import { NativeSessionReplay } from '../native/NativeSessionReplay';
+import { NativeSessionReplay, NativeEvents, emitter } from '../native/NativeSessionReplay';
 
 /**
  * Enables or disables Session Replay for your Instabug integration.
@@ -74,4 +74,39 @@ export const setUserStepsEnabled = (isEnabled: boolean) => {
  */
 export const getSessionReplayLink = async (): Promise<string> => {
   return NativeSessionReplay.getSessionReplayLink();
+};
+
+/**
+ * Set a callback for weather this session should sync
+ * 
+ * @param handler
+
+ * @example
+ * ```ts
+ * SessionReplay.setSyncCallback((payload)=>{
+ *    if(payload.device == "Xiaomi M2007J3SY" &&
+ *         payload.os == "OS Level 33" &&
+ *         payload.appVersion == "3.1.4 (4)" ||
+ *         payload.sessionDurationInSeconds > 20 )
+ *    {return true}
+ * });
+ * ```
+ */
+export const setSyncCallback = async (
+  handler: (payload: {
+    appVersion: string;
+    OS: string;
+    device: string;
+    sessionDurationInSeconds: number;
+  }) => boolean,
+): Promise<void> => {
+  emitter.addListener(NativeEvents.SESSION_REPLAY_ON_SYNC_CALLBACK_INVOCATION, (payload) => {
+    if (typeof handler(payload) != 'boolean') {
+      console.warn('setSyncCallback expects boolean value');
+    }
+
+    NativeSessionReplay.evaluateSync(Boolean(handler(payload)));
+  });
+
+  return NativeSessionReplay.setSyncCallback();
 };

--- a/src/native/NativeConstants.ts
+++ b/src/native/NativeConstants.ts
@@ -12,7 +12,8 @@ export type NativeConstants = NativeSdkDebugLogsLevel &
   NativeReproStepsMode &
   NativeLocale &
   NativeNonFatalErrorLevel &
-  NativeStringKey;
+  NativeStringKey &
+  NativeLaunchType;
 
 interface NativeSdkDebugLogsLevel {
   sdkDebugLogsLevelVerbose: any;
@@ -187,4 +188,10 @@ interface NativeStringKey {
   welcomeMessageBetaWelcomeStepTitle: any;
   welcomeMessageLiveWelcomeStepContent: any;
   welcomeMessageLiveWelcomeStepTitle: any;
+}
+
+interface NativeLaunchType {
+  hot: any;
+  cold: any;
+  warm: any;
 }

--- a/src/native/NativeSessionReplay.ts
+++ b/src/native/NativeSessionReplay.ts
@@ -1,4 +1,5 @@
-import { NativeEventEmitter, type NativeModule } from 'react-native';
+import { NativeEventEmitter } from 'react-native';
+import type { NativeModule } from 'react-native';
 
 import { NativeModules } from './NativePackage';
 

--- a/src/native/NativeSessionReplay.ts
+++ b/src/native/NativeSessionReplay.ts
@@ -1,4 +1,4 @@
-import type { NativeModule } from 'react-native';
+import { NativeEventEmitter, type NativeModule } from 'react-native';
 
 import { NativeModules } from './NativePackage';
 
@@ -8,6 +8,13 @@ export interface SessionReplayNativeModule extends NativeModule {
   setInstabugLogsEnabled(isEnabled: boolean): void;
   setUserStepsEnabled(isEnabled: boolean): void;
   getSessionReplayLink(): Promise<string>;
+  setSyncCallback(): Promise<void>;
+  evaluateSync(shouldSync: boolean): void;
 }
 
 export const NativeSessionReplay = NativeModules.IBGSessionReplay;
+export enum NativeEvents {
+  SESSION_REPLAY_ON_SYNC_CALLBACK_INVOCATION = 'IBGSessionReplayOnSyncCallback',
+}
+
+export const emitter = new NativeEventEmitter(NativeSessionReplay);

--- a/src/utils/Enums.ts
+++ b/src/utils/Enums.ts
@@ -232,3 +232,12 @@ export enum StringKey {
   welcomeMessageLiveWelcomeStepContent = constants.welcomeMessageLiveWelcomeStepContent,
   welcomeMessageLiveWelcomeStepTitle = constants.welcomeMessageLiveWelcomeStepTitle,
 }
+
+export enum LaunchType {
+  hot = constants.hot,
+  cold = constants.cold,
+  /**
+   *  android only
+   */
+  warm = constants.warm,
+}

--- a/test/mocks/mockSessionReplay.ts
+++ b/test/mocks/mockSessionReplay.ts
@@ -8,6 +8,8 @@ const mockSessionReplay: SessionReplayNativeModule = {
   setInstabugLogsEnabled: jest.fn(),
   setUserStepsEnabled: jest.fn(),
   getSessionReplayLink: jest.fn().mockReturnValue('link'),
+  setSyncCallback: jest.fn(),
+  evaluateSync: jest.fn(),
 };
 
 export default mockSessionReplay;

--- a/test/modules/SessionReplay.spec.ts
+++ b/test/modules/SessionReplay.spec.ts
@@ -1,5 +1,5 @@
 import * as SessionReplay from '../../src/modules/SessionReplay';
-import { NativeSessionReplay } from '../../src/native/NativeSessionReplay';
+import { NativeSessionReplay, emitter, NativeEvents } from '../../src/native/NativeSessionReplay';
 
 describe('Session Replay Module', () => {
   it('should call the native method setEnabled', () => {
@@ -35,5 +35,16 @@ describe('Session Replay Module', () => {
 
     expect(NativeSessionReplay.getSessionReplayLink).toBeCalledTimes(1);
     expect(NativeSessionReplay.getSessionReplayLink).toReturnWith('link');
+  });
+
+  it('should call the native method setSyncCallback', () => {
+    const callback = jest.fn().mockReturnValue(true);
+
+    SessionReplay.setSyncCallback(callback);
+    emitter.emit(NativeEvents.SESSION_REPLAY_ON_SYNC_CALLBACK_INVOCATION);
+
+    expect(NativeSessionReplay.setSyncCallback).toBeCalledTimes(1);
+    expect(emitter.listenerCount(NativeEvents.SESSION_REPLAY_ON_SYNC_CALLBACK_INVOCATION)).toBe(1);
+    expect(NativeSessionReplay.evaluateSync).toBeCalledTimes(1);
   });
 });

--- a/test/modules/SessionReplay.spec.ts
+++ b/test/modules/SessionReplay.spec.ts
@@ -38,7 +38,8 @@ describe('Session Replay Module', () => {
   });
 
   it('should call the native method setSyncCallback', () => {
-    const callback = jest.fn().mockReturnValue(true);
+    const shouldSync = true;
+    const callback = jest.fn().mockReturnValue(shouldSync);
 
     SessionReplay.setSyncCallback(callback);
     emitter.emit(NativeEvents.SESSION_REPLAY_ON_SYNC_CALLBACK_INVOCATION);
@@ -46,5 +47,6 @@ describe('Session Replay Module', () => {
     expect(NativeSessionReplay.setSyncCallback).toBeCalledTimes(1);
     expect(emitter.listenerCount(NativeEvents.SESSION_REPLAY_ON_SYNC_CALLBACK_INVOCATION)).toBe(1);
     expect(NativeSessionReplay.evaluateSync).toBeCalledTimes(1);
+    expect(NativeSessionReplay.evaluateSync).toBeCalledWith(shouldSync);
   });
 });


### PR DESCRIPTION
## Description of the change

Add a callback for session replay to determine weather to sync the session

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

[jiraID:MOB-15002](https://instabug.atlassian.net/browse/MOB-15002)
## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
