### PR TITLE
fix(ios): report fatal crashes with the updated api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,10 @@
 
 ### Fixed
 
+- Fix an issue with JavaScript fatal crashes on iOS causing them to be reported as native iOS crashes instead. ([#1290](https://github.com/Instabug/Instabug-React-Native/pull/1290)).
+- Correctly resolve the flavor path when uploading sourcemaps on Android. ([#1225](https://github.com/Instabug/Instabug-React-Native/pull/1225)).
 - Drop non-error objects reported as crashes since they don't have a stack trace ([#1279](https://github.com/Instabug/Instabug-React-Native/pull/1279)).
 - Fix APM network logging on iOS when the response body is missing or empty. ([#1273](https://github.com/Instabug/Instabug-React-Native/pull/1273)).
-
-### Fixed
-
-- Correctly resolve the flavor path when uploading sourcemaps on Android. ([#1225](https://github.com/Instabug/Instabug-React-Native/pull/1225)).
 
 ## [13.3.0](https://github.com/Instabug/Instabug-React-Native/compare/v13.2.0...v13.3.0) (August 4, 2024)
 

--- a/examples/default/ios/InstabugTests/InstabugCrashReportingTests.m
+++ b/examples/default/ios/InstabugTests/InstabugCrashReportingTests.m
@@ -26,6 +26,22 @@
   XCTAssertFalse(IBGCrashReporting.enabled);
 }
 
+- (void)testSendJSCrash {
+  NSDictionary *stackTrace = @{};
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Expected resolve to be called."];
+
+  RCTPromiseResolveBlock resolve = ^(id result) {
+    [expectation fulfill];
+  };
+  RCTPromiseRejectBlock reject = ^(NSString *code, NSString *message, NSError *error) {};
+  
+  [self.bridge sendJSCrash:stackTrace resolver:resolve rejecter:reject];
+
+  [self waitForExpectations:@[expectation] timeout:1];
+  OCMVerify([self.mCrashReporting cp_reportFatalCrashWithStackTrace:stackTrace]);
+}
+
 - (void)testSendNonFatalErrorJsonCrash {
   NSDictionary<NSString *,NSString * > *jsonCrash = @{};
   NSString *fingerPrint = @"fingerprint";

--- a/ios/RNInstabug/InstabugCrashReportingBridge.m
+++ b/ios/RNInstabug/InstabugCrashReportingBridge.m
@@ -29,12 +29,9 @@ RCT_EXPORT_METHOD(setEnabled: (BOOL) isEnabled) {
 RCT_EXPORT_METHOD(sendJSCrash:(NSDictionary *)stackTrace
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0ul);
+    dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0ul);
     dispatch_async(queue, ^{
-        SEL reportCrashWithStackTraceSEL = NSSelectorFromString(@"reportCrashWithStackTrace:handled:");
-        if ([[Instabug class] respondsToSelector:reportCrashWithStackTraceSEL]) {
-            [[Instabug class] performSelector:reportCrashWithStackTraceSEL withObject:stackTrace withObject:@(NO)];
-        }
+        [IBGCrashReporting cp_reportFatalCrashWithStackTrace:stackTrace];
         resolve([NSNull null]);
     });
 }
@@ -45,8 +42,6 @@ RCT_EXPORT_METHOD(sendHandledJSCrash: (NSDictionary *)stackTrace
                   rejecter:(RCTPromiseRejectBlock)reject) {
     dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0ul);
     dispatch_async(queue, ^{
-        
-     
         [IBGCrashReporting cp_reportNonFatalCrashWithStackTrace:stackTrace level:nonFatalExceptionLevel groupingString:fingerprint userAttributes:userAttributes];
         
         resolve([NSNull null]);


### PR DESCRIPTION
## Description of the change

The API for reporting JavaScript crashes on iOS has been changed from `Instabug.reportCrashWithStackTrace` to `CrashReporting.cp_reportFatalCrashWithStackTrace` in the native iOS SDK as part of v13.1.0 but the React Native SDK wasn't updated to use the new API. This led to fatal JavaScript crashes being reported by the iOS SDK as native crashes rather than JavaScript crashes breaking symbolication for these crashes.

This PR updates the API to be the new one to fix this bug.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Jira ID: MOB-16163

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request
